### PR TITLE
Use better colors for the infinite grid

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -63,8 +63,8 @@ pub const NAVMESH_AREA_3: Color = Color::srgba(0.4, 0.0, 0.8, 0.25);
 pub const NAVMESH_AREA_DEFAULT: Color = Color::srgba(0.5, 0.5, 0.5, 0.25);
 
 // ── Grid ──
-pub const GRID_MAJOR_LINE: Color = Color::srgb(0.25, 0.25, 0.25);
-pub const GRID_MINOR_LINE: Color = Color::srgb(0.1, 0.1, 0.1);
+pub const GRID_MAJOR_LINE: Color = Color::srgb(0.3, 0.3, 0.3);
+pub const GRID_MINOR_LINE: Color = Color::srgb(0.25, 0.25, 0.25);
 
 // ── Terrain ──
 pub const TERRAIN_SCULPT_GIZMO: Color = Color::srgb(1.0, 0.8, 0.2);

--- a/src/snapping.rs
+++ b/src/snapping.rs
@@ -32,6 +32,8 @@ pub struct GridSettings {
     pub scale: f32,
     pub major_line_color: Color,
     pub minor_line_color: Color,
+    pub x_axis_color: Color,
+    pub z_axis_color: Color,
     pub fadeout_distance: f32,
 }
 
@@ -42,6 +44,8 @@ impl Default for GridSettings {
             scale: 4.0,
             major_line_color: colors::GRID_MAJOR_LINE,
             minor_line_color: colors::GRID_MINOR_LINE,
+            x_axis_color: colors::AXIS_X,
+            z_axis_color: colors::AXIS_Z,
             fadeout_distance: 100.0,
         }
     }
@@ -64,6 +68,8 @@ fn sync_grid_settings(
         settings.scale = grid.scale;
         settings.major_line_color = grid.major_line_color;
         settings.minor_line_color = grid.minor_line_color;
+        settings.x_axis_color = grid.x_axis_color;
+        settings.z_axis_color = grid.z_axis_color;
         settings.fadeout_distance = grid.fadeout_distance;
         *visibility = if grid.visible {
             Visibility::Inherited

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -5,7 +5,7 @@ use bevy::{
     render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
     ui::{UiGlobalTransform, widget::ViewportNode},
 };
-use bevy_infinite_grid::InfiniteGridPlugin;
+use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin};
 use jackdaw_camera::{JackdawCameraPlugin, JackdawCameraSettings};
 
 use crate::selection::{Selected, Selection};
@@ -91,10 +91,7 @@ pub(crate) fn setup_viewport(
         .id();
 
     // Spawn infinite grid (marked EditorEntity so it's hidden from hierarchy and undeletable)
-    commands.spawn((
-        crate::EditorEntity,
-        bevy_infinite_grid::InfiniteGridBundle::default(),
-    ));
+    commands.spawn((crate::EditorEntity, InfiniteGridBundle::default()));
 
     // Attach ViewportNode to the SceneViewport UI entity
     commands


### PR DESCRIPTION
## Changes

- Make both minor and major grid lines lighter than the background color, matching Blender, Godot, Unity, and most other editors
- Make X and Z axis colors match the colors used elsewhere

## Comparison

Before:

<img width="3840" height="2120" alt="Screenshot from 2026-04-07 20-15-28" src="https://github.com/user-attachments/assets/13fbffa6-2d5e-40a9-a865-ffc75db84407" />

After:

<img width="3840" height="2119" alt="Screenshot from 2026-04-07 20-13-35" src="https://github.com/user-attachments/assets/15055226-2a57-4d9f-9d02-d0420fef4818" />
