### PR TITLE
Fix Menu Bar not closing on clicking outside of panel

### DIFF
--- a/crates/jackdaw_widgets/src/menu_bar.rs
+++ b/crates/jackdaw_widgets/src/menu_bar.rs
@@ -60,6 +60,7 @@ fn close_menu_on_action(
 
 fn close_menu_on_click_outside(
     keyboard: Res<ButtonInput<KeyCode>>,
+    mouse: Res<ButtonInput<MouseButton>>,
     mut commands: Commands,
     mut state: ResMut<MenuBarState>,
 ) {
@@ -67,8 +68,8 @@ fn close_menu_on_click_outside(
         return;
     }
 
-    // Close on Escape
-    if keyboard.just_pressed(KeyCode::Escape) {
+    // Close on Escape or left-click outside
+    if mouse.just_pressed(MouseButton::Left) || keyboard.just_pressed(KeyCode::Escape) {
         if let Some(dropdown) = state.dropdown_entity.take() {
             commands.entity(dropdown).despawn();
         }

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -327,8 +327,8 @@ fn detect_and_create_materials(
                         occlusion_texture = Some(img);
                     }
                 }
-                "metallic" | "metalness" | "metal" | "mtl" | "roughness" | "rough" | "rgh" => {
-                    if metallic_roughness_texture.is_none() {
+                "metallic" | "metalness" | "metal" | "mtl" | "roughness" | "rough" | "rgh"
+                    if metallic_roughness_texture.is_none() => {
                         metallic_roughness_texture = Some(
                             asset_server.load_with_settings::<Image, ImageLoaderSettings>(
                                 asset_path.clone(),
@@ -336,7 +336,6 @@ fn detect_and_create_materials(
                             ),
                         );
                     }
-                }
                 "emission" | "emissive" | "emit" => {
                     emissive_texture = Some(asset_server.load::<Image>(asset_path.clone()));
                 }
@@ -348,10 +347,10 @@ fn detect_and_create_materials(
                         ),
                     );
                 }
-                "displacement" | "displace" | "disp" | "dsp" | "height" | "heightmap" => {
+                "displacement" | "displace" | "disp" | "dsp" | "height" | "heightmap"
                     // Skip 16-bit integer PNGs. Bevy decodes them as R16Uint which
                     // is incompatible with StandardMaterial's float-filterable depth_map slot.
-                    if !is_16bit_png(Path::new(asset_path)) {
+                    if !is_16bit_png(Path::new(asset_path)) => {
                         depth_map = Some(
                             asset_server.load_with_settings::<Image, ImageLoaderSettings>(
                                 asset_path.clone(),
@@ -359,7 +358,6 @@ fn detect_and_create_materials(
                             ),
                         );
                     }
-                }
                 _ => {}
             }
         }

--- a/src/prefab_picker.rs
+++ b/src/prefab_picker.rs
@@ -57,7 +57,7 @@ pub fn open_prefab_picker(world: &mut World) {
 
     let mut prefabs: Vec<(String, String)> = Vec::new(); // (path, display_name)
     scan_jsn_files(&assets_dir, &assets_dir, &mut prefabs);
-    prefabs.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+    prefabs.sort_by_key(|a| a.1.to_lowercase());
 
     // Find the viewport entity to parent the picker to
     let viewport_entity = world


### PR DESCRIPTION
On clicking the menu bar, it opens but you can only close it by pressing Escape or actually selecting something.  
This change makes it so that clicking outside closes the Menu Bar. 

Also it has small clippy fixes.