### PR TITLE
fix runtime loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4336,7 +4336,9 @@ dependencies = [
  "jackdaw_geometry",
  "jackdaw_jsn",
  "jackdaw_node_graph",
+ "jackdaw_panels",
  "jackdaw_remote",
+ "jackdaw_runtime",
  "jackdaw_terrain",
  "jackdaw_widgets",
  "notify",
@@ -4426,12 +4428,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "jackdaw_panels"
+version = "0.3.0"
+dependencies = [
+ "bevy",
+ "serde",
+]
+
+[[package]]
 name = "jackdaw_remote"
 version = "0.3.0"
 dependencies = [
  "bevy",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jackdaw_runtime"
+version = "0.3.0"
+dependencies = [
+ "bevy",
+ "jackdaw_geometry",
+ "jackdaw_jsn",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,7 +4314,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jackdaw"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4336,7 +4336,6 @@ dependencies = [
  "jackdaw_geometry",
  "jackdaw_jsn",
  "jackdaw_node_graph",
- "jackdaw_panels",
  "jackdaw_remote",
  "jackdaw_runtime",
  "jackdaw_terrain",
@@ -4351,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_animation"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "jackdaw_commands",
@@ -4363,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_avian_integration"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "avian3d",
  "bevy",
@@ -4371,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_camera"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "jackdaw_commands",
@@ -4379,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_commands"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "serde",
@@ -4387,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_feathers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "bevy_easings",
@@ -4399,14 +4398,14 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_geometry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
 ]
 
 [[package]]
 name = "jackdaw_jsn"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "jackdaw_geometry",
@@ -4417,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_node_graph"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "bevy_monitors",
@@ -4429,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_panels"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "serde",
@@ -4437,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_remote"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "serde",
@@ -4446,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "jackdaw_geometry",
@@ -4458,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_terrain"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy_math 0.18.0",
  "noise",
@@ -4467,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "jackdaw_widgets"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bevy",
  "bevy_monitors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ jackdaw_commands.workspace = true
 jackdaw_terrain.workspace = true
 jackdaw_remote.workspace = true
 jackdaw_node_graph.workspace = true
+jackdaw_panels.workspace = true
 jackdaw_animation.workspace = true
 jackdaw_avian_integration.workspace = true
 serde.workspace = true
@@ -71,6 +72,8 @@ bevy_ui_text_input = "0.7"
 bevy_easings = "0.18.0"
 avian3d = { version = "0.5", default-features = false, features = ["3d", "parry-f32", "collider-from-mesh"] }
 jackdaw_avian_integration = { version = "0.3.0", path = "crates/jackdaw_avian_integration" }
+jackdaw_runtime = { version = "0.3.0", path = "crates/jackdaw_runtime" }
+jackdaw_panels = { version = "0.3.0", path = "crates/jackdaw_panels" }
 rfd = "0.15"
 bevy_rerecast = { version = "0.4", default-features = true }
 ehttp = { version = "0.5", default-features = false, features = ["native-async", "json"] }
@@ -87,6 +90,9 @@ too_many_arguments = "allow"
 type_complexity = "allow"
 collapsible_if = "allow"
 redundant_closure = "allow"
+
+[dev-dependencies]
+jackdaw_runtime.workspace = true
 
 [lints]
 workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "A 3D level editor built with Bevy"
 license = "MIT OR Apache-2.0"
@@ -30,7 +30,6 @@ jackdaw_commands.workspace = true
 jackdaw_terrain.workspace = true
 jackdaw_remote.workspace = true
 jackdaw_node_graph.workspace = true
-jackdaw_panels.workspace = true
 jackdaw_animation.workspace = true
 jackdaw_avian_integration.workspace = true
 serde.workspace = true
@@ -51,18 +50,18 @@ bevy_simple_subsecond_system = { version = "0.2", optional = true }
 
 [workspace.dependencies]
 bevy = { version = "0.18", features = ["experimental_bevy_feathers", "serialize", "debug", "bevy_remote", "file_watcher"] }
-jackdaw_jsn = { version = "0.3.0", path = "crates/jackdaw_jsn" }
-jackdaw_geometry = { version = "0.3.0", path = "crates/jackdaw_geometry" }
+jackdaw_jsn = { version = "0.3.1", path = "crates/jackdaw_jsn" }
+jackdaw_geometry = { version = "0.3.1", path = "crates/jackdaw_geometry" }
 bevy_monitors = "0.2"
 bevy_infinite_grid = "0.18"
-jackdaw_camera = { version = "0.3.0", path = "crates/jackdaw_camera" }
-jackdaw_feathers = { version = "0.3.0", path = "crates/jackdaw_feathers" }
-jackdaw_widgets = { version = "0.3.0", path = "crates/jackdaw_widgets" }
-jackdaw_commands = { version = "0.3.0", path = "crates/jackdaw_commands" }
-jackdaw_terrain = { version = "0.3.0", path = "crates/jackdaw_terrain" }
-jackdaw_remote = { version = "0.3.0", path = "crates/jackdaw_remote" }
-jackdaw_node_graph = { version = "0.3.0", path = "crates/jackdaw_node_graph" }
-jackdaw_animation = { version = "0.3.0", path = "crates/jackdaw_animation" }
+jackdaw_camera = { version = "0.3.1", path = "crates/jackdaw_camera" }
+jackdaw_feathers = { version = "0.3.1", path = "crates/jackdaw_feathers" }
+jackdaw_widgets = { version = "0.3.1", path = "crates/jackdaw_widgets" }
+jackdaw_commands = { version = "0.3.1", path = "crates/jackdaw_commands" }
+jackdaw_terrain = { version = "0.3.1", path = "crates/jackdaw_terrain" }
+jackdaw_remote = { version = "0.3.1", path = "crates/jackdaw_remote" }
+jackdaw_node_graph = { version = "0.3.1", path = "crates/jackdaw_node_graph" }
+jackdaw_animation = { version = "0.3.1", path = "crates/jackdaw_animation" }
 noise = "0.9"
 rand = "0.9"
 serde = "1"
@@ -71,9 +70,9 @@ serde_json = "1"
 bevy_ui_text_input = "0.7"
 bevy_easings = "0.18.0"
 avian3d = { version = "0.5", default-features = false, features = ["3d", "parry-f32", "collider-from-mesh"] }
-jackdaw_avian_integration = { version = "0.3.0", path = "crates/jackdaw_avian_integration" }
-jackdaw_runtime = { version = "0.3.0", path = "crates/jackdaw_runtime" }
-jackdaw_panels = { version = "0.3.0", path = "crates/jackdaw_panels" }
+jackdaw_avian_integration = { version = "0.3.1", path = "crates/jackdaw_avian_integration" }
+jackdaw_runtime = { version = "0.3.1", path = "crates/jackdaw_runtime" }
+jackdaw_panels = { version = "0.3.1", path = "crates/jackdaw_panels" }
 rfd = "0.15"
 bevy_rerecast = { version = "0.4", default-features = true }
 ehttp = { version = "0.5", default-features = false, features = ["native-async", "json"] }

--- a/assets/examples/scenes/scene.jsn
+++ b/assets/examples/scenes/scene.jsn
@@ -1,59 +1,30 @@
 {
   "jsn": {
-    "format_version": [
-      1,
-      0,
-      0
-    ],
-    "editor_version": "0.1.0",
+    "format_version": [3, 0, 0],
+    "editor_version": "0.3.0",
     "bevy_version": "0.18"
   },
   "metadata": {
-    "name": "Untitled",
-    "description": "",
+    "name": "Example Scene",
+    "description": "A minimal scene with a light and a brush",
     "author": "",
-    "created": "2026-02-25T16:01:20Z",
-    "modified": "2026-02-25T16:01:20Z"
+    "created": "2026-04-12T00:00:00Z",
+    "modified": "2026-04-12T00:00:00Z"
   },
-  "assets": {
-    "textures": [],
-    "models": []
-  },
+  "assets": {},
   "editor": null,
   "scene": [
     {
-      "name": "Sun",
-      "transform": {
-        "translation": [
-          10.0,
-          20.0,
-          10.0
-        ],
-        "rotation": [
-          -0.3816559,
-          0.18298657,
-          -0.07736548,
-          0.9027011
-        ],
-        "scale": [
-          1.0,
-          1.0,
-          1.0
-        ]
-      },
       "components": {
-        "bevy_light::cascade::CascadeShadowConfig": {
-          "bounds": [
-            10.0,
-            24.662120819091797,
-            60.822021484375,
-            149.99998474121094
-          ],
-          "minimum_distance": 0.10000000149011612,
-          "overlap_proportion": 0.20000000298023224
+        "bevy_ecs::name::Name": "Sun",
+        "bevy_transform::components::transform::Transform": {
+          "translation": [10.0, 20.0, 10.0],
+          "rotation": [-0.3816559, 0.18298657, -0.07736548, 0.9027011],
+          "scale": [1.0, 1.0, 1.0]
         },
         "bevy_light::directional_light::DirectionalLight": {
-          "affects_lightmapped_mesh_diffuse": true,
+          "shadows_enabled": true,
+          "illuminance": 10000.0,
           "color": {
             "LinearRgba": {
               "alpha": 1.0,
@@ -61,162 +32,73 @@
               "green": 1.0,
               "red": 1.0
             }
-          },
-          "illuminance": 10000.0,
-          "shadow_depth_bias": 0.019999999552965164,
-          "shadow_normal_bias": 1.7999999523162842,
-          "shadows_enabled": true
+          }
         }
       }
     },
     {
-      "name": "Brush",
-      "transform": {
-        "translation": [
-          1.0,
-          1.125,
-          1.25
-        ],
-        "rotation": [
-          0.0,
-          0.0,
-          0.0,
-          1.0
-        ],
-        "scale": [
-          1.0,
-          1.0,
-          1.0
-        ]
-      },
       "components": {
+        "bevy_ecs::name::Name": "Brush",
+        "bevy_transform::components::transform::Transform": {
+          "translation": [0.0, 0.0, 0.0],
+          "rotation": [0.0, 0.0, 0.0, 1.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
         "jackdaw_jsn::types::Brush": {
           "faces": [
             {
-              "material_index": 0,
-              "plane": {
-                "distance": 1.0,
-                "normal": [
-                  1.0,
-                  0.0,
-                  0.0
-                ]
-              },
-              "texture_path": null,
-              "uv_offset": [
-                0.0,
-                0.0
-              ],
+              "plane": { "normal": [1.0, 0.0, 0.0], "distance": 1.0 },
+              "material": null,
+              "uv_offset": [0.0, 0.0],
+              "uv_scale": [1.0, 1.0],
               "uv_rotation": 0.0,
-              "uv_scale": [
-                1.0,
-                1.0
-              ]
+              "uv_u_axis": [0.0, 1.0, 0.0],
+              "uv_v_axis": [0.0, 0.0, 1.0]
             },
             {
-              "material_index": 0,
-              "plane": {
-                "distance": 1.0,
-                "normal": [
-                  -1.0,
-                  0.0,
-                  0.0
-                ]
-              },
-              "texture_path": null,
-              "uv_offset": [
-                0.0,
-                0.0
-              ],
+              "plane": { "normal": [-1.0, 0.0, 0.0], "distance": 1.0 },
+              "material": null,
+              "uv_offset": [0.0, 0.0],
+              "uv_scale": [1.0, 1.0],
               "uv_rotation": 0.0,
-              "uv_scale": [
-                1.0,
-                1.0
-              ]
+              "uv_u_axis": [0.0, 1.0, 0.0],
+              "uv_v_axis": [0.0, 0.0, -1.0]
             },
             {
-              "material_index": 0,
-              "plane": {
-                "distance": 1.125,
-                "normal": [
-                  0.0,
-                  1.0,
-                  0.0
-                ]
-              },
-              "texture_path": null,
-              "uv_offset": [
-                0.0,
-                0.0
-              ],
+              "plane": { "normal": [0.0, 1.0, 0.0], "distance": 1.0 },
+              "material": null,
+              "uv_offset": [0.0, 0.0],
+              "uv_scale": [1.0, 1.0],
               "uv_rotation": 0.0,
-              "uv_scale": [
-                1.0,
-                1.0
-              ]
+              "uv_u_axis": [1.0, 0.0, 0.0],
+              "uv_v_axis": [0.0, 0.0, 1.0]
             },
             {
-              "material_index": 0,
-              "plane": {
-                "distance": 1.125,
-                "normal": [
-                  0.0,
-                  -1.0,
-                  0.0
-                ]
-              },
-              "texture_path": null,
-              "uv_offset": [
-                0.0,
-                0.0
-              ],
+              "plane": { "normal": [0.0, -1.0, 0.0], "distance": 1.0 },
+              "material": null,
+              "uv_offset": [0.0, 0.0],
+              "uv_scale": [1.0, 1.0],
               "uv_rotation": 0.0,
-              "uv_scale": [
-                1.0,
-                1.0
-              ]
+              "uv_u_axis": [1.0, 0.0, 0.0],
+              "uv_v_axis": [0.0, 0.0, -1.0]
             },
             {
-              "material_index": 0,
-              "plane": {
-                "distance": 1.25,
-                "normal": [
-                  0.0,
-                  0.0,
-                  1.0
-                ]
-              },
-              "texture_path": null,
-              "uv_offset": [
-                0.0,
-                0.0
-              ],
+              "plane": { "normal": [0.0, 0.0, 1.0], "distance": 1.0 },
+              "material": null,
+              "uv_offset": [0.0, 0.0],
+              "uv_scale": [1.0, 1.0],
               "uv_rotation": 0.0,
-              "uv_scale": [
-                1.0,
-                1.0
-              ]
+              "uv_u_axis": [1.0, 0.0, 0.0],
+              "uv_v_axis": [0.0, 1.0, 0.0]
             },
             {
-              "material_index": 0,
-              "plane": {
-                "distance": 1.25,
-                "normal": [
-                  0.0,
-                  0.0,
-                  -1.0
-                ]
-              },
-              "texture_path": null,
-              "uv_offset": [
-                0.0,
-                0.0
-              ],
+              "plane": { "normal": [0.0, 0.0, -1.0], "distance": 1.0 },
+              "material": null,
+              "uv_offset": [0.0, 0.0],
+              "uv_scale": [1.0, 1.0],
               "uv_rotation": 0.0,
-              "uv_scale": [
-                1.0,
-                1.0
-              ]
+              "uv_u_axis": [-1.0, 0.0, 0.0],
+              "uv_v_axis": [0.0, 1.0, 0.0]
             }
           ]
         }

--- a/assets/examples/scenes/scene.jsn
+++ b/assets/examples/scenes/scene.jsn
@@ -1,30 +1,37 @@
 {
   "jsn": {
-    "format_version": [3, 0, 0],
+    "format_version": [
+      3,
+      0,
+      0
+    ],
     "editor_version": "0.3.0",
     "bevy_version": "0.18"
   },
   "metadata": {
-    "name": "Example Scene",
-    "description": "A minimal scene with a light and a brush",
+    "name": "Untitled",
+    "description": "",
     "author": "",
-    "created": "2026-04-12T00:00:00Z",
-    "modified": "2026-04-12T00:00:00Z"
+    "created": "2026-04-12T16:00:13Z",
+    "modified": "2026-04-12T16:00:13Z"
   },
   "assets": {},
   "editor": null,
   "scene": [
     {
       "components": {
-        "bevy_ecs::name::Name": "Sun",
-        "bevy_transform::components::transform::Transform": {
-          "translation": [10.0, 20.0, 10.0],
-          "rotation": [-0.3816559, 0.18298657, -0.07736548, 0.9027011],
-          "scale": [1.0, 1.0, 1.0]
+        "bevy_light::cascade::CascadeShadowConfig": {
+          "bounds": [
+            10.0,
+            24.662120819091797,
+            60.822021484375,
+            149.99998474121094
+          ],
+          "minimum_distance": 0.10000000149011612,
+          "overlap_proportion": 0.20000000298023224
         },
         "bevy_light::directional_light::DirectionalLight": {
-          "shadows_enabled": true,
-          "illuminance": 10000.0,
+          "affects_lightmapped_mesh_diffuse": true,
           "color": {
             "LinearRgba": {
               "alpha": 1.0,
@@ -32,76 +39,240 @@
               "green": 1.0,
               "red": 1.0
             }
-          }
-        }
+          },
+          "illuminance": 10000.0,
+          "shadow_depth_bias": 0.019999999552965164,
+          "shadow_normal_bias": 1.7999999523162842,
+          "shadows_enabled": true
+        },
+        "bevy_transform::components::transform::Transform": {
+          "rotation": [
+            -0.38165590167045593,
+            0.1829865723848343,
+            -0.07736548036336899,
+            0.9027010798454285
+          ],
+          "scale": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "translation": [
+            10.0,
+            20.0,
+            10.0
+          ]
+        },
+        "bevy_ecs::name::Name": "Sun",
+        "bevy_camera::visibility::Visibility": "Inherited"
       }
     },
     {
       "components": {
-        "bevy_ecs::name::Name": "Brush",
+        "bevy_camera::visibility::Visibility": "Inherited",
         "bevy_transform::components::transform::Transform": {
-          "translation": [0.0, 0.0, 0.0],
-          "rotation": [0.0, 0.0, 0.0, 1.0],
-          "scale": [1.0, 1.0, 1.0]
+          "rotation": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ],
+          "scale": [
+            1.0,
+            1.0,
+            1.0
+          ],
+          "translation": [
+            -0.125,
+            0.75,
+            0.25
+          ]
         },
         "jackdaw_jsn::types::Brush": {
           "faces": [
             {
-              "plane": { "normal": [1.0, 0.0, 0.0], "distance": 1.0 },
               "material": null,
-              "uv_offset": [0.0, 0.0],
-              "uv_scale": [1.0, 1.0],
+              "plane": {
+                "distance": 1.375,
+                "normal": [
+                  1.0,
+                  0.0,
+                  0.0
+                ]
+              },
+              "uv_offset": [
+                0.0,
+                0.0
+              ],
               "uv_rotation": 0.0,
-              "uv_u_axis": [0.0, 1.0, 0.0],
-              "uv_v_axis": [0.0, 0.0, 1.0]
+              "uv_scale": [
+                1.0,
+                1.0
+              ],
+              "uv_u_axis": [
+                0.0,
+                0.0,
+                1.0
+              ],
+              "uv_v_axis": [
+                0.0,
+                -1.0,
+                0.0
+              ]
             },
             {
-              "plane": { "normal": [-1.0, 0.0, 0.0], "distance": 1.0 },
               "material": null,
-              "uv_offset": [0.0, 0.0],
-              "uv_scale": [1.0, 1.0],
+              "plane": {
+                "distance": 1.375,
+                "normal": [
+                  -1.0,
+                  0.0,
+                  0.0
+                ]
+              },
+              "uv_offset": [
+                0.0,
+                0.0
+              ],
               "uv_rotation": 0.0,
-              "uv_u_axis": [0.0, 1.0, 0.0],
-              "uv_v_axis": [0.0, 0.0, -1.0]
+              "uv_scale": [
+                1.0,
+                1.0
+              ],
+              "uv_u_axis": [
+                0.0,
+                0.0,
+                -1.0
+              ],
+              "uv_v_axis": [
+                -0.0,
+                -1.0,
+                -0.0
+              ]
             },
             {
-              "plane": { "normal": [0.0, 1.0, 0.0], "distance": 1.0 },
               "material": null,
-              "uv_offset": [0.0, 0.0],
-              "uv_scale": [1.0, 1.0],
+              "plane": {
+                "distance": 0.75,
+                "normal": [
+                  0.0,
+                  1.0,
+                  0.0
+                ]
+              },
+              "uv_offset": [
+                0.0,
+                0.0
+              ],
               "uv_rotation": 0.0,
-              "uv_u_axis": [1.0, 0.0, 0.0],
-              "uv_v_axis": [0.0, 0.0, 1.0]
+              "uv_scale": [
+                1.0,
+                1.0
+              ],
+              "uv_u_axis": [
+                1.0,
+                0.0,
+                0.0
+              ],
+              "uv_v_axis": [
+                0.0,
+                0.0,
+                -1.0
+              ]
             },
             {
-              "plane": { "normal": [0.0, -1.0, 0.0], "distance": 1.0 },
               "material": null,
-              "uv_offset": [0.0, 0.0],
-              "uv_scale": [1.0, 1.0],
+              "plane": {
+                "distance": 0.75,
+                "normal": [
+                  0.0,
+                  -1.0,
+                  0.0
+                ]
+              },
+              "uv_offset": [
+                0.0,
+                0.0
+              ],
               "uv_rotation": 0.0,
-              "uv_u_axis": [1.0, 0.0, 0.0],
-              "uv_v_axis": [0.0, 0.0, -1.0]
+              "uv_scale": [
+                1.0,
+                1.0
+              ],
+              "uv_u_axis": [
+                -1.0,
+                0.0,
+                0.0
+              ],
+              "uv_v_axis": [
+                -0.0,
+                -0.0,
+                -1.0
+              ]
             },
             {
-              "plane": { "normal": [0.0, 0.0, 1.0], "distance": 1.0 },
               "material": null,
-              "uv_offset": [0.0, 0.0],
-              "uv_scale": [1.0, 1.0],
+              "plane": {
+                "distance": 3.5,
+                "normal": [
+                  0.0,
+                  0.0,
+                  1.0
+                ]
+              },
+              "uv_offset": [
+                0.0,
+                0.0
+              ],
               "uv_rotation": 0.0,
-              "uv_u_axis": [1.0, 0.0, 0.0],
-              "uv_v_axis": [0.0, 1.0, 0.0]
+              "uv_scale": [
+                1.0,
+                1.0
+              ],
+              "uv_u_axis": [
+                -1.0,
+                0.0,
+                0.0
+              ],
+              "uv_v_axis": [
+                0.0,
+                -1.0,
+                0.0
+              ]
             },
             {
-              "plane": { "normal": [0.0, 0.0, -1.0], "distance": 1.0 },
               "material": null,
-              "uv_offset": [0.0, 0.0],
-              "uv_scale": [1.0, 1.0],
+              "plane": {
+                "distance": 3.5,
+                "normal": [
+                  0.0,
+                  0.0,
+                  -1.0
+                ]
+              },
+              "uv_offset": [
+                0.0,
+                0.0
+              ],
               "uv_rotation": 0.0,
-              "uv_u_axis": [-1.0, 0.0, 0.0],
-              "uv_v_axis": [0.0, 1.0, 0.0]
+              "uv_scale": [
+                1.0,
+                1.0
+              ],
+              "uv_u_axis": [
+                1.0,
+                -0.0,
+                0.0
+              ],
+              "uv_v_axis": [
+                0.0,
+                -1.0,
+                -0.0
+              ]
             }
           ]
-        }
+        },
+        "bevy_ecs::name::Name": "Brush"
       }
     }
   ]

--- a/crates/jackdaw_animation/Cargo.toml
+++ b/crates/jackdaw_animation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_animation"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Animation authoring and playback for the Jackdaw editor — thin UI over Bevy's AnimationClip / AnimationGraph / AnimationPlayer."
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_avian_integration/Cargo.toml
+++ b/crates/jackdaw_avian_integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_avian_integration"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_camera/Cargo.toml
+++ b/crates/jackdaw_camera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_camera"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_commands/Cargo.toml
+++ b/crates/jackdaw_commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_commands"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_feathers/Cargo.toml
+++ b/crates/jackdaw_feathers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_feathers"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_geometry/Cargo.toml
+++ b/crates/jackdaw_geometry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_geometry"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_jsn/Cargo.toml
+++ b/crates/jackdaw_jsn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_jsn"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_jsn/src/format.rs
+++ b/crates/jackdaw_jsn/src/format.rs
@@ -216,8 +216,18 @@ pub struct JsnMetadata {
 ///   }
 /// }
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Clone, Debug, Default)]
 pub struct JsnAssets(pub HashMap<String, HashMap<String, serde_json::Value>>);
+
+impl<'de> serde::Deserialize<'de> for JsnAssets {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match serde_json::from_value(value) {
+            Ok(map) => Ok(JsnAssets(map)),
+            Err(_) => Ok(JsnAssets(HashMap::new())),
+        }
+    }
+}
 
 /// Reserved for editor-specific state. Currently unused.
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/crates/jackdaw_jsn/src/loader.rs
+++ b/crates/jackdaw_jsn/src/loader.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 use serde::de::DeserializeSeed;
 
-use crate::format::{JsnEntity, JsnScene};
+use crate::format::{JsnEntity, JsnScene, JsnSceneV2};
 
 /// Asset loader for `.jsn` files → `DynamicScene`.
 #[derive(Debug, TypePath)]
@@ -46,8 +46,13 @@ impl AssetLoader for JsnAssetLoader {
 
         let text = std::str::from_utf8(&bytes).map_err(|e| JsnLoadError::Parse(e.to_string()))?;
 
-        let jsn: JsnScene =
-            serde_json::from_str(text).map_err(|e| JsnLoadError::Parse(e.to_string()))?;
+        let jsn: JsnScene = match serde_json::from_str(text) {
+            Ok(jsn) => jsn,
+            Err(v3_err) => match serde_json::from_str::<JsnSceneV2>(text) {
+                Ok(v2) => v2.migrate_to_v3(),
+                Err(_) => return Err(JsnLoadError::Parse(v3_err.to_string())),
+            },
+        };
 
         // Build a DynamicScene by spawning into a temporary world
         let scene = build_dynamic_scene(&jsn.scene, &self.type_registry)

--- a/crates/jackdaw_node_graph/Cargo.toml
+++ b/crates/jackdaw_node_graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_node_graph"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Generic node-graph editor widget for the Jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_remote/Cargo.toml
+++ b/crates/jackdaw_remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_remote"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Remote game integration for the Jackdaw 3D level editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_runtime/Cargo.toml
+++ b/crates/jackdaw_runtime/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "jackdaw_runtime"
+version = "0.3.0"
+edition = "2024"
+description = "Runtime scene loading for games built with the Jackdaw editor"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jbuehler23/jackdaw"
+
+[dependencies]
+bevy.workspace = true
+jackdaw_jsn.workspace = true
+jackdaw_geometry.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/jackdaw_runtime/Cargo.toml
+++ b/crates/jackdaw_runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "jackdaw_runtime"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
-description = "Runtime scene loading for games built with the Jackdaw editor"
+description = "Runtime scene loader for the Jackdaw editor"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jbuehler23/jackdaw"
 

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -1,0 +1,555 @@
+use std::any::TypeId;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Formatter};
+use std::path::{Path, PathBuf};
+
+use bevy::asset::{
+    AssetLoader, LoadContext, ReflectAsset, ReflectHandle, UntypedHandle, io::Reader,
+};
+use bevy::ecs::reflect::AppTypeRegistry;
+use bevy::image::ImageLoaderSettings;
+use bevy::prelude::*;
+use bevy::reflect::serde::{ReflectDeserializerProcessor, TypedReflectDeserializer};
+use bevy::reflect::{TypeRegistration, TypeRegistry};
+use jackdaw_jsn::format::{JsnAssets, JsnScene, JsnSceneV2};
+use serde::Deserializer;
+use serde::de::{DeserializeSeed, Visitor};
+
+pub use jackdaw_jsn::{Brush, BrushFaceData, CustomProperties, GltfSource, PropertyValue};
+
+/// Runtime plugin for loading Jackdaw editor scenes in your game.
+///
+/// Registers an asset loader for `.jsn` scene files and systems for spawning
+/// scene entities and generating brush meshes.
+///
+/// ```rust,no_run
+/// use bevy::prelude::*;
+/// use jackdaw_runtime::{JackdawPlugin, JackdawSceneRoot};
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins((DefaultPlugins, JackdawPlugin))
+///         .add_systems(Startup, setup)
+///         .run();
+/// }
+///
+/// fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+///     commands.spawn(JackdawSceneRoot(asset_server.load("levels/my_level.jsn")));
+///     commands.spawn((
+///         Camera3d::default(),
+///         Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+///     ));
+/// }
+/// ```
+pub struct JackdawPlugin;
+
+impl Plugin for JackdawPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<jackdaw_jsn::Brush>()
+            .register_type::<jackdaw_jsn::BrushGroup>()
+            .register_type::<jackdaw_jsn::BrushFaceData>()
+            .register_type::<jackdaw_jsn::BrushPlane>()
+            .register_type::<jackdaw_jsn::CustomProperties>()
+            .register_type::<jackdaw_jsn::PropertyValue>()
+            .register_type::<jackdaw_jsn::GltfSource>()
+            .register_type::<jackdaw_jsn::JsnPrefab>()
+            .register_type::<jackdaw_jsn::NavmeshRegion>()
+            .register_type::<jackdaw_jsn::Terrain>();
+
+        app.init_asset::<JackdawScene>()
+            .init_asset_loader::<JackdawSceneLoader>();
+
+        app.add_systems(Update, spawn_loaded_scenes);
+        app.add_systems(Update, jackdaw_jsn::mesh_rebuild::rebuild_brush_meshes);
+    }
+}
+
+// ─────────────────────────────────────── Asset ───────────────────────────────────────
+
+#[derive(Asset, TypePath)]
+pub struct JackdawScene {
+    jsn: JsnScene,
+    parent_path: PathBuf,
+}
+
+/// Spawn this component on an entity to load and instantiate a Jackdaw scene.
+/// All scene entities become children of this entity.
+#[derive(Component, Deref)]
+pub struct JackdawSceneRoot(pub Handle<JackdawScene>);
+
+#[derive(Component)]
+struct SceneSpawned;
+
+// ─────────────────────────────────── Asset Loader ────────────────────────────────────
+
+#[derive(Debug, TypePath)]
+struct JackdawSceneLoader;
+
+impl FromWorld for JackdawSceneLoader {
+    fn from_world(_world: &mut World) -> Self {
+        Self
+    }
+}
+
+impl AssetLoader for JackdawSceneLoader {
+    type Asset = JackdawScene;
+    type Settings = ();
+    type Error = JackdawLoadError;
+
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut bytes = Vec::new();
+        reader
+            .read_to_end(&mut bytes)
+            .await
+            .map_err(|e| JackdawLoadError::Io(e.to_string()))?;
+
+        let text =
+            std::str::from_utf8(&bytes).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+
+        let jsn: JsnScene = match serde_json::from_str(text) {
+            Ok(jsn) => jsn,
+            Err(v3_err) => match serde_json::from_str::<JsnSceneV2>(text) {
+                Ok(v2) => v2.migrate_to_v3(),
+                Err(_) => return Err(JackdawLoadError::Parse(v3_err.to_string())),
+            },
+        };
+
+        let parent_path = load_context
+            .path()
+            .path()
+            .parent()
+            .unwrap_or(Path::new(""))
+            .to_owned();
+
+        Ok(JackdawScene { jsn, parent_path })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["jsn"]
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JackdawLoadError {
+    #[error("IO error: {0}")]
+    Io(String),
+    #[error("Parse error: {0}")]
+    Parse(String),
+}
+
+// ──────────────────────────────── Scene Spawning ─────────────────────────────────────
+
+fn spawn_loaded_scenes(world: &mut World) {
+    let mut query = world.query_filtered::<(Entity, &JackdawSceneRoot), Without<SceneSpawned>>();
+    let to_spawn: Vec<(Entity, Handle<JackdawScene>)> = query
+        .iter(world)
+        .map(|(e, root)| (e, root.0.clone()))
+        .collect();
+
+    for (root_entity, handle) in to_spawn {
+        let scenes = world.resource::<Assets<JackdawScene>>();
+        let Some(scene) = scenes.get(&handle) else {
+            continue;
+        };
+        let jsn = scene.jsn.clone();
+        let parent_path = scene.parent_path.clone();
+
+        let local_assets = load_inline_assets(world, &jsn.assets, &parent_path);
+        spawn_scene_entities(world, root_entity, &jsn.scene, &parent_path, &local_assets);
+
+        world.entity_mut(root_entity).insert(SceneSpawned);
+    }
+}
+
+fn spawn_scene_entities(
+    world: &mut World,
+    root_entity: Entity,
+    entities: &[jackdaw_jsn::format::JsnEntity],
+    parent_path: &Path,
+    local_assets: &HashMap<String, UntypedHandle>,
+) {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let asset_server = world.resource::<AssetServer>().clone();
+
+    let mut spawned: Vec<Entity> = Vec::new();
+    for _ in entities {
+        spawned.push(world.spawn_empty().id());
+    }
+
+    for (i, jsn) in entities.iter().enumerate() {
+        let parent = match jsn.parent {
+            Some(idx) => spawned.get(idx).copied().unwrap_or(root_entity),
+            None => root_entity,
+        };
+        world.entity_mut(spawned[i]).insert(ChildOf(parent));
+    }
+
+    let registry_guard = registry.read();
+    for (i, jsn) in entities.iter().enumerate() {
+        for (type_path, value) in &jsn.components {
+            let Some(registration) = registry_guard.get_with_type_path(type_path) else {
+                warn!("Unknown type '{type_path}' -- skipping");
+                continue;
+            };
+            let Some(reflect_component) = registration.data::<ReflectComponent>() else {
+                continue;
+            };
+
+            let mut processor = RuntimeDeserializerProcessor {
+                asset_server: &asset_server,
+                parent_path,
+                local_assets,
+                entity_map: &spawned,
+            };
+            let deserializer = TypedReflectDeserializer::with_processor(
+                registration,
+                &registry_guard,
+                &mut processor,
+            );
+            let Ok(reflected) = deserializer.deserialize(value) else {
+                warn!("Failed to deserialize '{type_path}' -- skipping");
+                continue;
+            };
+
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                reflect_component.insert(
+                    &mut world.entity_mut(spawned[i]),
+                    reflected.as_ref(),
+                    &registry_guard,
+                );
+            }));
+            if result.is_err() {
+                warn!("Panic while inserting component '{type_path}' -- skipping");
+            }
+        }
+    }
+    drop(registry_guard);
+
+    // Trigger GLTF scene loading for GltfSource entities
+    let gltf_entities: Vec<(Entity, String, usize)> = spawned
+        .iter()
+        .filter_map(|&e| {
+            world
+                .get::<jackdaw_jsn::GltfSource>(e)
+                .map(|gs| (e, gs.path.clone(), gs.scene_index))
+        })
+        .collect();
+    for (entity, gltf_path, scene_index) in gltf_entities {
+        let resolved = if Path::new(&gltf_path).is_relative() {
+            parent_path.join(&gltf_path).to_string_lossy().into_owned()
+        } else {
+            gltf_path
+        };
+        let label = format!("Scene{scene_index}");
+        let full_path = format!("{resolved}#{label}");
+        let scene_handle: Handle<Scene> = asset_server.load(full_path);
+        world.entity_mut(entity).insert(SceneRoot(scene_handle));
+    }
+}
+
+// ────────────────────────────── Inline Asset Loading ─────────────────────────────────
+
+fn load_inline_assets(
+    world: &mut World,
+    assets: &JsnAssets,
+    parent_path: &Path,
+) -> HashMap<String, UntypedHandle> {
+    let mut local_assets: HashMap<String, UntypedHandle> = HashMap::new();
+    let linear_image_names = collect_linear_image_names(assets);
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let registry_guard = registry.read();
+    let asset_server = world.resource::<AssetServer>().clone();
+
+    // First pass: external file references (string entries)
+    for (type_path, named_entries) in &assets.0 {
+        for (name, json_value) in named_entries {
+            let serde_json::Value::String(rel_path) = json_value else {
+                continue;
+            };
+            if rel_path.starts_with('@') {
+                warn!(
+                    "Catalog asset '{rel_path}' referenced by '{name}' is not supported at runtime"
+                );
+                continue;
+            }
+
+            let resolved = if Path::new(rel_path.as_str()).is_relative() {
+                parent_path.join(rel_path).to_string_lossy().into_owned()
+            } else {
+                rel_path.clone()
+            };
+
+            let handle = if type_path == "bevy_image::image::Image" {
+                if linear_image_names.contains(name) {
+                    asset_server
+                        .load_with_settings::<Image, ImageLoaderSettings>(
+                            &resolved,
+                            |s: &mut ImageLoaderSettings| s.is_srgb = false,
+                        )
+                        .untyped()
+                } else {
+                    asset_server.load::<Image>(&resolved).untyped()
+                }
+            } else {
+                asset_server
+                    .load::<bevy::asset::LoadedUntypedAsset>(&resolved)
+                    .untyped()
+            };
+            local_assets.insert(name.clone(), handle);
+        }
+    }
+
+    // Second pass: inline asset definitions (object entries like materials)
+    for (type_path, named_entries) in &assets.0 {
+        let Some(registration) = registry_guard.get_with_type_path(type_path) else {
+            warn!("Unknown asset type '{type_path}' in inline assets -- skipping");
+            continue;
+        };
+        let Some(reflect_asset) = registration.data::<ReflectAsset>() else {
+            continue;
+        };
+
+        for (name, json_value) in named_entries {
+            if json_value.is_string() {
+                continue;
+            }
+
+            let mut processor = RuntimeDeserializerProcessor {
+                asset_server: &asset_server,
+                parent_path,
+                local_assets: &local_assets,
+                entity_map: &[],
+            };
+            let deserializer = TypedReflectDeserializer::with_processor(
+                registration,
+                &registry_guard,
+                &mut processor,
+            );
+            let Ok(reflected) = deserializer.deserialize(json_value) else {
+                warn!("Failed to deserialize inline asset '{name}' of type '{type_path}'");
+                continue;
+            };
+
+            let handle = reflect_asset.add(world, reflected.as_ref());
+            local_assets.insert(name.clone(), handle);
+        }
+    }
+
+    local_assets
+}
+
+fn collect_linear_image_names(assets: &JsnAssets) -> HashSet<String> {
+    const LINEAR_SLOTS: &[&str] = &[
+        "normal_map_texture",
+        "metallic_roughness_texture",
+        "occlusion_texture",
+        "depth_map",
+    ];
+    let mut linear_names = HashSet::new();
+    if let Some(materials) = assets.0.get("bevy_pbr::pbr_material::StandardMaterial") {
+        for json_value in materials.values() {
+            if let serde_json::Value::Object(obj) = json_value {
+                for slot in LINEAR_SLOTS {
+                    if let Some(serde_json::Value::String(img_name)) = obj.get(*slot) {
+                        linear_names.insert(img_name.clone());
+                    }
+                }
+            }
+        }
+    }
+    linear_names
+}
+
+// ─────────────────────────── Deserialization Processor ────────────────────────────────
+
+struct RuntimeDeserializerProcessor<'a> {
+    asset_server: &'a AssetServer,
+    parent_path: &'a Path,
+    local_assets: &'a HashMap<String, UntypedHandle>,
+    entity_map: &'a [Entity],
+}
+
+impl ReflectDeserializerProcessor for RuntimeDeserializerProcessor<'_> {
+    fn try_deserialize<'de, D>(
+        &mut self,
+        registration: &TypeRegistration,
+        _registry: &TypeRegistry,
+        deserializer: D,
+    ) -> Result<Result<Box<dyn PartialReflect>, D>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Non-finite floats: round-trip through strings ("inf", "-inf", "NaN")
+        if registration.type_id() == TypeId::of::<f32>() {
+            let val = deserializer
+                .deserialize_any(F32Visitor)
+                .map_err(|e| <D::Error as serde::de::Error>::custom(e))?;
+            return Ok(Ok(Box::new(val).into_partial_reflect()));
+        }
+        if registration.type_id() == TypeId::of::<f64>() {
+            let val = deserializer
+                .deserialize_any(F64Visitor)
+                .map_err(|e| <D::Error as serde::de::Error>::custom(e))?;
+            return Ok(Ok(Box::new(val).into_partial_reflect()));
+        }
+
+        // Handle<T> -- resolve from inline #Name, external path, or null
+        if registration.data::<ReflectHandle>().is_some() {
+            let path_str = match deserializer.deserialize_any(StringOrNullVisitor) {
+                Ok(p) => p,
+                Err(e) => return Err(e),
+            };
+
+            if path_str.is_empty() {
+                if let Some(rd) = registration.data::<ReflectDefault>() {
+                    return Ok(Ok(rd.default().into_partial_reflect()));
+                }
+            }
+
+            if path_str.starts_with('@') {
+                warn!("Catalog asset '{path_str}' is not supported at runtime -- using default");
+                if let Some(rd) = registration.data::<ReflectDefault>() {
+                    return Ok(Ok(rd.default().into_partial_reflect()));
+                }
+            }
+
+            if let Some(handle) = self.local_assets.get(&path_str) {
+                return Ok(Ok(Box::new(handle.clone()).into_partial_reflect()));
+            }
+
+            let label_pos = path_str.find('#').unwrap_or(path_str.len());
+            let file_part = &path_str[..label_pos];
+            let label_part = &path_str[label_pos..];
+            let resolved = if Path::new(file_part).is_relative() && !file_part.is_empty() {
+                self.parent_path
+                    .join(file_part)
+                    .to_string_lossy()
+                    .into_owned()
+            } else {
+                file_part.to_owned()
+            };
+            let handle = self
+                .asset_server
+                .load_untyped(format!("{resolved}{label_part}"));
+            return Ok(Ok(Box::new(handle).into_partial_reflect()));
+        }
+
+        // Entity -- resolve from scene-local index
+        if registration.type_id() == TypeId::of::<Entity>() {
+            let idx_str = match deserializer.deserialize_any(StringOrNullVisitor) {
+                Ok(s) => s,
+                Err(_) => {
+                    return Ok(Ok(Box::new(Entity::PLACEHOLDER).into_partial_reflect()));
+                }
+            };
+            let idx: usize = idx_str.parse().unwrap_or(usize::MAX);
+            let entity = self
+                .entity_map
+                .get(idx)
+                .copied()
+                .unwrap_or(Entity::PLACEHOLDER);
+            return Ok(Ok(Box::new(entity).into_partial_reflect()));
+        }
+
+        Ok(Err(deserializer))
+    }
+}
+
+// ────────────────────────────── Visitor Helpers ──────────────────────────────────────
+
+struct StringOrNullVisitor;
+
+impl Visitor<'_> for StringOrNullVisitor {
+    type Value = String;
+
+    fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "a string, integer, or null")
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(String::new())
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(v.to_owned())
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        Ok(v.to_string())
+    }
+}
+
+struct F32Visitor;
+
+impl Visitor<'_> for F32Visitor {
+    type Value = f32;
+
+    fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "a number or float string (inf, -inf, NaN)")
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+        Ok(v as f32)
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+        Ok(v as f32)
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        Ok(v as f32)
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        match v {
+            "inf" | "Infinity" => Ok(f32::INFINITY),
+            "-inf" | "-Infinity" => Ok(f32::NEG_INFINITY),
+            "NaN" | "nan" => Ok(f32::NAN),
+            _ => Err(E::custom(format!("unexpected float string: {v}"))),
+        }
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(0.0)
+    }
+}
+
+struct F64Visitor;
+
+impl Visitor<'_> for F64Visitor {
+    type Value = f64;
+
+    fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "a number or float string (inf, -inf, NaN)")
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+        Ok(v)
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+        Ok(v as f64)
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        Ok(v as f64)
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        match v {
+            "inf" | "Infinity" => Ok(f64::INFINITY),
+            "-inf" | "-Infinity" => Ok(f64::NEG_INFINITY),
+            "NaN" | "nan" => Ok(f64::NAN),
+            _ => Err(E::custom(format!("unexpected float string: {v}"))),
+        }
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(0.0)
+    }
+}

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -17,30 +17,6 @@ use serde::de::{DeserializeSeed, Visitor};
 
 pub use jackdaw_jsn::{Brush, BrushFaceData, CustomProperties, GltfSource, PropertyValue};
 
-/// Runtime plugin for loading Jackdaw editor scenes in your game.
-///
-/// Registers an asset loader for `.jsn` scene files and systems for spawning
-/// scene entities and generating brush meshes.
-///
-/// ```rust,no_run
-/// use bevy::prelude::*;
-/// use jackdaw_runtime::{JackdawPlugin, JackdawSceneRoot};
-///
-/// fn main() {
-///     App::new()
-///         .add_plugins((DefaultPlugins, JackdawPlugin))
-///         .add_systems(Startup, setup)
-///         .run();
-/// }
-///
-/// fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-///     commands.spawn(JackdawSceneRoot(asset_server.load("levels/my_level.jsn")));
-///     commands.spawn((
-///         Camera3d::default(),
-///         Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-///     ));
-/// }
-/// ```
 pub struct JackdawPlugin;
 
 impl Plugin for JackdawPlugin {
@@ -64,23 +40,18 @@ impl Plugin for JackdawPlugin {
     }
 }
 
-// ─────────────────────────────────────── Asset ───────────────────────────────────────
-
 #[derive(Asset, TypePath)]
 pub struct JackdawScene {
     jsn: JsnScene,
     parent_path: PathBuf,
 }
 
-/// Spawn this component on an entity to load and instantiate a Jackdaw scene.
-/// All scene entities become children of this entity.
+/// Scene entities become children of the entity this is spawned on.
 #[derive(Component, Deref)]
 pub struct JackdawSceneRoot(pub Handle<JackdawScene>);
 
 #[derive(Component)]
 struct SceneSpawned;
-
-// ─────────────────────────────────── Asset Loader ────────────────────────────────────
 
 #[derive(Debug, TypePath)]
 struct JackdawSceneLoader;
@@ -141,8 +112,6 @@ pub enum JackdawLoadError {
     #[error("Parse error: {0}")]
     Parse(String),
 }
-
-// ──────────────────────────────── Scene Spawning ─────────────────────────────────────
 
 fn spawn_loaded_scenes(world: &mut World) {
     let mut query = world.query_filtered::<(Entity, &JackdawSceneRoot), Without<SceneSpawned>>();
@@ -230,7 +199,6 @@ fn spawn_scene_entities(
     }
     drop(registry_guard);
 
-    // Trigger GLTF scene loading for GltfSource entities
     let gltf_entities: Vec<(Entity, String, usize)> = spawned
         .iter()
         .filter_map(|&e| {
@@ -252,8 +220,6 @@ fn spawn_scene_entities(
     }
 }
 
-// ────────────────────────────── Inline Asset Loading ─────────────────────────────────
-
 fn load_inline_assets(
     world: &mut World,
     assets: &JsnAssets,
@@ -265,7 +231,6 @@ fn load_inline_assets(
     let registry_guard = registry.read();
     let asset_server = world.resource::<AssetServer>().clone();
 
-    // First pass: external file references (string entries)
     for (type_path, named_entries) in &assets.0 {
         for (name, json_value) in named_entries {
             let serde_json::Value::String(rel_path) = json_value else {
@@ -304,7 +269,6 @@ fn load_inline_assets(
         }
     }
 
-    // Second pass: inline asset definitions (object entries like materials)
     for (type_path, named_entries) in &assets.0 {
         let Some(registration) = registry_guard.get_with_type_path(type_path) else {
             warn!("Unknown asset type '{type_path}' in inline assets -- skipping");
@@ -365,8 +329,6 @@ fn collect_linear_image_names(assets: &JsnAssets) -> HashSet<String> {
     linear_names
 }
 
-// ─────────────────────────── Deserialization Processor ────────────────────────────────
-
 struct RuntimeDeserializerProcessor<'a> {
     asset_server: &'a AssetServer,
     parent_path: &'a Path,
@@ -384,7 +346,6 @@ impl ReflectDeserializerProcessor for RuntimeDeserializerProcessor<'_> {
     where
         D: Deserializer<'de>,
     {
-        // Non-finite floats: round-trip through strings ("inf", "-inf", "NaN")
         if registration.type_id() == TypeId::of::<f32>() {
             let val = deserializer
                 .deserialize_any(F32Visitor)
@@ -398,12 +359,8 @@ impl ReflectDeserializerProcessor for RuntimeDeserializerProcessor<'_> {
             return Ok(Ok(Box::new(val).into_partial_reflect()));
         }
 
-        // Handle<T> -- resolve from inline #Name, external path, or null
         if registration.data::<ReflectHandle>().is_some() {
-            let path_str = match deserializer.deserialize_any(StringOrNullVisitor) {
-                Ok(p) => p,
-                Err(e) => return Err(e),
-            };
+            let path_str = deserializer.deserialize_any(StringOrNullVisitor)?;
 
             if path_str.is_empty() {
                 if let Some(rd) = registration.data::<ReflectDefault>() {
@@ -439,7 +396,6 @@ impl ReflectDeserializerProcessor for RuntimeDeserializerProcessor<'_> {
             return Ok(Ok(Box::new(handle).into_partial_reflect()));
         }
 
-        // Entity -- resolve from scene-local index
         if registration.type_id() == TypeId::of::<Entity>() {
             let idx_str = match deserializer.deserialize_any(StringOrNullVisitor) {
                 Ok(s) => s,
@@ -459,8 +415,6 @@ impl ReflectDeserializerProcessor for RuntimeDeserializerProcessor<'_> {
         Ok(Err(deserializer))
     }
 }
-
-// ────────────────────────────── Visitor Helpers ──────────────────────────────────────
 
 struct StringOrNullVisitor;
 

--- a/crates/jackdaw_terrain/Cargo.toml
+++ b/crates/jackdaw_terrain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_terrain"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/crates/jackdaw_widgets/Cargo.toml
+++ b/crates/jackdaw_widgets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackdaw_widgets"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal crate for the jackdaw editor"
 license = "MIT OR Apache-2.0"

--- a/examples/jsn_load.rs
+++ b/examples/jsn_load.rs
@@ -1,4 +1,4 @@
-//! Minimal example: load a `.jsn` scene exported from the editor.
+//! Minimal example: load a `.jsn` scene exported from the Jackdaw editor.
 //!
 //! Place a scene file at `assets/examples/scenes/scene.jsn` (use the editor's
 //! Ctrl+S to export one), then run:
@@ -8,40 +8,22 @@
 //! ```
 
 use bevy::prelude::*;
-use jackdaw_jsn::JsnPlugin;
+use jackdaw_runtime::{JackdawPlugin, JackdawSceneRoot};
 
 fn main() -> AppExit {
     App::new()
-        .add_plugins((DefaultPlugins, JsnPlugin::default()))
+        .add_plugins((DefaultPlugins, JackdawPlugin))
         .add_systems(Startup, setup)
         .run()
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Load a .jsn scene exported from the editor.
-    // JsnPlugin registers the asset loader and auto-generates meshes for Brush components.
-    commands.spawn(DynamicSceneRoot(
+    commands.spawn(JackdawSceneRoot(
         asset_server.load("examples/scenes/scene.jsn"),
     ));
 
-    // Camera
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-    ));
-
-    // Light
-    commands.spawn((
-        DirectionalLight {
-            shadows_enabled: true,
-            illuminance: 10000.0,
-            ..default()
-        },
-        Transform::from_xyz(10.0, 20.0, 10.0).with_rotation(Quat::from_euler(
-            EulerRot::XYZ,
-            -0.8,
-            0.4,
-            0.0,
-        )),
     ));
 }

--- a/examples/jsn_load.rs
+++ b/examples/jsn_load.rs
@@ -1,11 +1,11 @@
-//! Minimal example: load a `.jsn` scene exported from the Jackdaw editor.
+//! Load a `.jsn` scene exported from the Jackdaw editor.
 //!
-//! Place a scene file at `assets/examples/scenes/scene.jsn` (use the editor's
-//! Ctrl+S to export one), then run:
+//! 1. Add `jackdaw_runtime` to your `Cargo.toml`
+//! 2. Add `JackdawPlugin` to your app
+//! 3. Spawn a `JackdawSceneRoot` with an asset server load
 //!
-//! ```sh
-//! cargo run --example jsn_load
-//! ```
+//! The scene includes lights, brushes, and any other entities
+//! saved from the editor. You only need to provide a camera.
 
 use bevy::prelude::*;
 use jackdaw_runtime::{JackdawPlugin, JackdawSceneRoot};


### PR DESCRIPTION
a bug was introduced with the AST migration, which removed the jackdaw_runtime crate (and i never committed it back!). updated example to demonstrate in `jsn_load`