### PR TITLE
Use relative path for material browser

### DIFF
--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -1329,6 +1329,7 @@ fn update_material_browser_ui(
     registry: Res<MaterialRegistry>,
     state: Res<MaterialBrowserState>,
     materials: Res<Assets<StandardMaterial>>,
+    project_root: Res<crate::project::ProjectRoot>,
     grid_query: Query<(Entity, Option<&Children>), With<MaterialBrowserGrid>>,
     mut root_label_query: Query<&mut Text, With<MaterialBrowserRootLabel>>,
 ) {
@@ -1338,7 +1339,10 @@ fn update_material_browser_ui(
     }
 
     for mut text in root_label_query.iter_mut() {
-        **text = state.scan_directory.to_string_lossy().to_string();
+        **text = project_root
+            .to_relative(&state.scan_directory)
+            .to_string_lossy()
+            .to_string();
     }
 
     let Ok((grid_entity, grid_children)) = grid_query.single() else {
@@ -1483,7 +1487,7 @@ pub fn material_browser_panel(icon_font: Handle<Font>) -> impl Bundle {
                     align_items: AlignItems::Center,
                     justify_content: JustifyContent::SpaceBetween,
                     width: Val::Percent(100.0),
-                    height: Val::Px(tokens::ROW_HEIGHT),
+                    min_height: Val::Px(tokens::ROW_HEIGHT),
                     padding: UiRect::horizontal(Val::Px(tokens::SPACING_MD)),
                     flex_shrink: 0.0,
                     ..Default::default()
@@ -1511,6 +1515,10 @@ pub fn material_browser_panel(icon_font: Handle<Font>) -> impl Bundle {
                             ),
                             (
                                 MaterialBrowserRootLabel,
+                                Node {
+                                    margin: UiRect::vertical(Val::Px(tokens::SPACING_MD)),
+                                    ..Default::default()
+                                },
                                 Text::new(""),
                                 TextFont {
                                     font_size: tokens::FONT_SM,

--- a/src/project.rs
+++ b/src/project.rs
@@ -18,6 +18,10 @@ impl ProjectRoot {
     pub fn assets_dir(&self) -> PathBuf {
         self.root.join("assets")
     }
+    pub fn to_relative(&self, path: impl AsRef<Path>) -> PathBuf {
+        let path = path.as_ref();
+        path.strip_prefix(&self.root).unwrap_or(path).into()
+    }
 }
 
 #[derive(Serialize, Deserialize, Default)]


### PR DESCRIPTION
Use a path relative to the project root for displaying the folder in the material browser
Also fix long paths overflowing

Before:
<img width="331" height="70" alt="image" src="https://github.com/user-attachments/assets/04712c66-fcd9-4103-bba9-fe9f88519042" />
After:
<img width="326" height="65" alt="image" src="https://github.com/user-attachments/assets/40331ca1-40ed-47cc-b0cc-318250042b54" />