### PR TITLE
Tweak some spacing to look nicer

### DIFF
--- a/crates/jackdaw_feathers/src/text_edit.rs
+++ b/crates/jackdaw_feathers/src/text_edit.rs
@@ -10,8 +10,8 @@ pub use bevy_ui_text_input::{TextInputBuffer, TextInputQueue};
 use crate::cursor::{ActiveCursor, HoverCursor};
 use crate::icons::EditorFont;
 use crate::tokens::{
-    AXIS_LABEL_BG, BORDER_COLOR, ELEVATED_BG, PRIMARY_COLOR, SHADOW_COLOR_LIGHT, TEXT_BODY_COLOR,
-    TEXT_MUTED_COLOR, TEXT_SIZE, TEXT_SIZE_SM,
+    self, AXIS_LABEL_BG, BORDER_COLOR, ELEVATED_BG, PRIMARY_COLOR, SHADOW_COLOR_LIGHT,
+    TEXT_BODY_COLOR, TEXT_MUTED_COLOR, TEXT_SIZE, TEXT_SIZE_SM,
 };
 
 pub fn plugin(app: &mut App) {
@@ -330,20 +330,25 @@ fn setup_text_edit_input(
                 Node {
                     width: percent(100),
                     height: px(INPUT_HEIGHT),
-                    // If prefix, no left padding so the label sits flush at the edge
+                    // If prefix, only a small bit of left padding so the label sits close to the edge
                     padding: if has_prefix {
-                        UiRect::new(px(0), px(8), px(0), px(0))
+                        UiRect::new(
+                            px(tokens::SPACING_XS),
+                            px(tokens::SPACING_MD),
+                            px(tokens::SPACING_SM),
+                            px(tokens::SPACING_SM),
+                        )
                     } else {
-                        UiRect::axes(px(8), px(4))
+                        UiRect::axes(px(tokens::SPACING_MD), px(tokens::SPACING_SM))
                     },
-                    border_radius: BorderRadius::all(px(4)),
+                    border_radius: BorderRadius::all(px(tokens::BORDER_RADIUS_MD)),
                     // Stretch so prefix fills full height
                     align_items: if has_prefix {
                         AlignItems::Stretch
                     } else {
                         AlignItems::Center
                     },
-                    column_gap: px(6),
+                    column_gap: px(tokens::SPACING_MD),
                     ..default()
                 },
                 BackgroundColor(ELEVATED_BG),

--- a/src/inspector/physics_display.rs
+++ b/src/inspector/physics_display.rs
@@ -127,7 +127,7 @@ pub(super) fn spawn_physics_section(
             Node {
                 flex_direction: FlexDirection::Column,
                 width: Val::Percent(100.0),
-                padding: UiRect::horizontal(Val::Px(tokens::SPACING_MD)),
+                padding: UiRect::all(Val::Px(tokens::SPACING_MD)),
                 row_gap: Val::Px(tokens::SPACING_SM),
                 ..Default::default()
             },


### PR DESCRIPTION
Added vertical padding to physics checkbox
Before:
<img width="122" height="59" alt="image" src="https://github.com/user-attachments/assets/69548a23-0f87-4098-8fb0-840d33404146" />
After:
<img width="320" height="70" alt="image" src="https://github.com/user-attachments/assets/930b387f-587e-4b81-8831-c73943c87897" />

Tweaked padding and spacing on text edits
Before:
<img width="328" height="257" alt="image" src="https://github.com/user-attachments/assets/91927b3e-5147-44e6-80ed-bd64eccd4b30" />
After:
<img width="340" height="257" alt="image" src="https://github.com/user-attachments/assets/895c8740-f880-4e74-bd53-f2f25eeee6be" />

