### PR TITLE
Display `GlobalTransform`s (`Affine3A`s specifically) properly

### DIFF
--- a/crates/jackdaw_feathers/src/text_edit.rs
+++ b/crates/jackdaw_feathers/src/text_edit.rs
@@ -132,6 +132,7 @@ pub struct TextEditConfig {
     auto_focus: bool,
     allow_empty: bool,
     drag_bottom: bool,
+    disabled: bool,
     pub initialized: bool,
 }
 
@@ -145,6 +146,7 @@ pub struct TextEditProps {
     pub suffix: Option<String>,
     pub min: f64,
     pub max: f64,
+    pub disabled: bool,
     pub auto_focus: bool,
     pub allow_empty: bool,
     pub drag_bottom: bool,
@@ -163,6 +165,7 @@ impl Default for TextEditProps {
             suffix: None,
             min: f64::MIN,
             max: f64::MAX,
+            disabled: false,
             auto_focus: false,
             allow_empty: false,
             drag_bottom: false,
@@ -216,6 +219,13 @@ impl TextEditProps {
         self.auto_focus = true;
         self
     }
+    pub fn disabled(self) -> Self {
+        self.with_disabled(true)
+    }
+    pub fn with_disabled(mut self, value: bool) -> Self {
+        self.disabled = value;
+        self
+    }
     pub fn numeric_f32(mut self) -> Self {
         self.variant = TextEditVariant::NumericF32;
         self.filter = Some(FilterType::Decimal);
@@ -256,6 +266,7 @@ pub fn text_edit(props: TextEditProps) -> impl Bundle {
         auto_focus,
         allow_empty,
         drag_bottom,
+        disabled,
         grow: _,
     } = props;
 
@@ -281,6 +292,7 @@ pub fn text_edit(props: TextEditProps) -> impl Bundle {
             auto_focus,
             allow_empty,
             drag_bottom,
+            disabled,
             initialized: false,
         },
         TextEditValue::default(),
@@ -392,7 +404,7 @@ fn setup_text_edit_input(
 
         commands.entity(entity).add_child(wrapper_entity);
 
-        if is_numeric && !config.drag_bottom {
+        if is_numeric && !config.drag_bottom && !config.disabled {
             // When there's a prefix (XYZ label), the drag hitbox covers ONLY the
             // label area so clicking the value area still lets you type.
             // Without a prefix, the hitbox covers the left portion of the input.
@@ -485,6 +497,7 @@ fn setup_text_edit_input(
                 mode: TextInputMode::SingleLine,
                 clear_on_submit: false,
                 unfocus_on_submit: true,
+                is_enabled: !config.disabled,
                 ..default()
             },
             TextFont {

--- a/src/inspector/reflect_fields.rs
+++ b/src/inspector/reflect_fields.rs
@@ -5,6 +5,7 @@ use bevy::{
     ecs::reflect::{AppTypeRegistry, ReflectComponent},
     feathers::theme::ThemedText,
     input_focus::InputFocus,
+    math::Vec3A,
     prelude::*,
     reflect::ReflectRef,
     ui_widgets::observe,
@@ -472,6 +473,7 @@ fn spawn_field_row(
             source_entity,
             type_path,
             depth,
+            false,
         );
         return;
     }
@@ -487,6 +489,7 @@ fn spawn_field_row(
             source_entity,
             type_path,
             depth,
+            false,
         );
         return;
     }
@@ -505,6 +508,7 @@ fn spawn_field_row(
             source_entity,
             type_path,
             depth,
+            false,
         );
         return;
     }
@@ -523,6 +527,24 @@ fn spawn_field_row(
             source_entity,
             type_path,
             depth,
+            false,
+        );
+        return;
+    }
+
+    // Vec3A is a SIMD version of Vec3, used in affine transformation matrices (global transforms)
+    if let Some(vec3) = value.try_downcast_ref::<Vec3A>() {
+        spawn_vec3_row(
+            commands,
+            parent,
+            name,
+            &vec3.to_vec3(),
+            field_path,
+            source_entity,
+            type_path,
+            depth,
+            // A Vec3A is not editable!
+            true,
         );
         return;
     }
@@ -855,6 +877,7 @@ fn spawn_vec3_row(
     source_entity: Entity,
     type_path: &str,
     depth: usize,
+    disabled: bool,
 ) {
     let left_padding = depth as f32 * tokens::SPACING_MD;
     // Column container: label above, axis inputs below.
@@ -913,6 +936,7 @@ fn spawn_vec3_row(
         format!("{field_path}.x"),
         source_entity,
         type_path,
+        disabled,
     );
     spawn_axis_input(
         commands,
@@ -923,6 +947,7 @@ fn spawn_vec3_row(
         format!("{field_path}.y"),
         source_entity,
         type_path,
+        disabled,
     );
     spawn_axis_input(
         commands,
@@ -933,6 +958,7 @@ fn spawn_vec3_row(
         format!("{field_path}.z"),
         source_entity,
         type_path,
+        disabled,
     );
 }
 
@@ -945,6 +971,7 @@ fn spawn_vec2_row(
     source_entity: Entity,
     type_path: &str,
     depth: usize,
+    disabled: bool,
 ) {
     let left_padding = depth as f32 * tokens::SPACING_MD;
     let col = commands
@@ -993,6 +1020,7 @@ fn spawn_vec2_row(
         format!("{field_path}.x"),
         source_entity,
         type_path,
+        disabled,
     );
     spawn_axis_input(
         commands,
@@ -1003,6 +1031,7 @@ fn spawn_vec2_row(
         format!("{field_path}.y"),
         source_entity,
         type_path,
+        disabled,
     );
 }
 
@@ -1018,6 +1047,7 @@ fn spawn_vec4_row(
     source_entity: Entity,
     type_path: &str,
     depth: usize,
+    disabled: bool,
 ) {
     let left_padding = depth as f32 * tokens::SPACING_MD;
     let col = commands
@@ -1072,6 +1102,7 @@ fn spawn_vec4_row(
         format!("{field_path}.x"),
         source_entity,
         type_path,
+        disabled,
     );
     spawn_axis_input(
         commands,
@@ -1082,6 +1113,7 @@ fn spawn_vec4_row(
         format!("{field_path}.y"),
         source_entity,
         type_path,
+        disabled,
     );
     spawn_axis_input(
         commands,
@@ -1092,6 +1124,7 @@ fn spawn_vec4_row(
         format!("{field_path}.z"),
         source_entity,
         type_path,
+        disabled,
     );
     spawn_axis_input(
         commands,
@@ -1102,6 +1135,7 @@ fn spawn_vec4_row(
         format!("{field_path}.w"),
         source_entity,
         type_path,
+        disabled,
     );
 }
 
@@ -1114,6 +1148,7 @@ fn spawn_axis_input(
     field_path: String,
     source_entity: Entity,
     type_path: &str,
+    disabled: bool,
 ) {
     // Numeric input with colored axis prefix (X/Y/Z/W label inside the input)
     commands.spawn((
@@ -1121,6 +1156,7 @@ fn spawn_axis_input(
             TextEditProps::default()
                 .numeric_f32()
                 .with_default_value(value.to_string())
+                .with_disabled(disabled)
                 .with_prefix(text_edit::TextEditPrefix::Label {
                     label: label.to_string(),
                     size: tokens::TEXT_SIZE,


### PR DESCRIPTION
Global transforms now show in the inspector properly
This was done by making the `Vec3A` struct, a SIMD version of `Vec3` use the vector fields
It also can't be modified, so the text edits are disabled

Before:
<img width="325" height="656" alt="image" src="https://github.com/user-attachments/assets/e1361293-6deb-4501-960c-6ab5b9926537" />

After:
<img width="324" height="239" alt="image" src="https://github.com/user-attachments/assets/4ceb5117-c59a-4820-8f85-02e81e2dfb94" />

However this doesn't display the transform's actual translation position and rotation, since that's not how they're represented internally. I don't think special-casing global transforms right now is a good idea though, that should be done once we have functionality for custom inspector drawing