### PR TITLE
feat: extension API: operators, triggers, modal, dogfooded built-ins

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
             jackdaw_avian_integration
             jackdaw_remote
             jackdaw_panels
+            jackdaw_api
             jackdaw_jsn
             jackdaw_camera
             jackdaw_feathers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_enhanced_input"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd528e0238ebc77e1e4737e55aa8f51188b7405eebc281f2498a627ae51a2e3"
+dependencies = [
+ "bevy",
+ "bevy_enhanced_input_macros",
+ "bitflags 2.11.1",
+ "log",
+ "smallvec",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_enhanced_input_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ee73d4e362e2eb15ac58331c94e5076f6b5065761f008ca7dc930d446d205b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bevy_feathers"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4429,6 +4454,7 @@ dependencies = [
  "avian3d",
  "base64",
  "bevy",
+ "bevy_enhanced_input",
  "bevy_infinite_grid",
  "bevy_monitors",
  "bevy_rerecast",
@@ -4476,6 +4502,7 @@ name = "jackdaw_api"
 version = "0.3.1"
 dependencies = [
  "bevy",
+ "bevy_enhanced_input",
  "jackdaw_commands",
  "jackdaw_panels",
 ]
@@ -6501,6 +6528,7 @@ name = "sample_extension"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_enhanced_input",
  "jackdaw_api",
  "jackdaw_commands",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,6 +4483,7 @@ dependencies = [
  "sample_extension",
  "serde",
  "serde_json",
+ "viewable_camera_extension",
 ]
 
 [[package]]
@@ -7547,6 +7548,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "viewable_camera_extension"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy_enhanced_input",
+ "jackdaw_api",
+ "jackdaw_commands",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4437,6 +4437,7 @@ dependencies = [
  "dirs",
  "ehttp",
  "jackdaw_animation",
+ "jackdaw_api",
  "jackdaw_avian_integration",
  "jackdaw_camera",
  "jackdaw_commands",
@@ -4453,6 +4454,7 @@ dependencies = [
  "pathdiff",
  "regex",
  "rfd",
+ "sample_extension",
  "serde",
  "serde_json",
 ]
@@ -4467,6 +4469,15 @@ dependencies = [
  "jackdaw_node_graph",
  "lucide-icons",
  "serde",
+]
+
+[[package]]
+name = "jackdaw_api"
+version = "0.3.1"
+dependencies = [
+ "bevy",
+ "jackdaw_commands",
+ "jackdaw_panels",
 ]
 
 [[package]]
@@ -6483,6 +6494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sample_extension"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "jackdaw_api",
+ "jackdaw_commands",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ jackdaw_animation.workspace = true
 jackdaw_avian_integration.workspace = true
 jackdaw_panels.workspace = true
 jackdaw_api.workspace = true
+bevy_enhanced_input.workspace = true
 sample_extension = { path = "examples/sample_extension" }
 serde.workspace = true
 serde_json.workspace = true
@@ -77,6 +78,7 @@ jackdaw_avian_integration = { version = "0.3.1", path = "crates/jackdaw_avian_in
 jackdaw_runtime = { version = "0.3.1", path = "crates/jackdaw_runtime" }
 jackdaw_panels = { version = "0.3.1", path = "crates/jackdaw_panels" }
 jackdaw_api = { version = "0.3.1", path = "crates/jackdaw_api" }
+bevy_enhanced_input = "0.24"
 rfd = "0.15"
 bevy_rerecast = { version = "0.4", default-features = true }
 ehttp = { version = "0.5", default-features = false, features = ["native-async", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,11 @@ default = []
 hot-reload = ["dep:bevy_simple_subsecond_system"]
 
 [workspace]
-members = ["crates/*", "examples/sample_extension"]
+members = [
+    "crates/*",
+    "examples/sample_extension",
+    "examples/viewable_camera_extension",
+]
 
 [dependencies]
 bevy.workspace = true
@@ -36,6 +40,7 @@ jackdaw_panels.workspace = true
 jackdaw_api.workspace = true
 bevy_enhanced_input.workspace = true
 sample_extension = { path = "examples/sample_extension" }
+viewable_camera_extension = { path = "examples/viewable_camera_extension" }
 serde.workspace = true
 serde_json.workspace = true
 avian3d.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 hot-reload = ["dep:bevy_simple_subsecond_system"]
 
 [workspace]
-members = ["crates/*"]
+members = ["crates/*", "examples/sample_extension"]
 
 [dependencies]
 bevy.workspace = true
@@ -33,6 +33,8 @@ jackdaw_node_graph.workspace = true
 jackdaw_animation.workspace = true
 jackdaw_avian_integration.workspace = true
 jackdaw_panels.workspace = true
+jackdaw_api.workspace = true
+sample_extension = { path = "examples/sample_extension" }
 serde.workspace = true
 serde_json.workspace = true
 avian3d.workspace = true
@@ -74,6 +76,7 @@ avian3d = { version = "0.5", default-features = false, features = ["3d", "parry-
 jackdaw_avian_integration = { version = "0.3.1", path = "crates/jackdaw_avian_integration" }
 jackdaw_runtime = { version = "0.3.1", path = "crates/jackdaw_runtime" }
 jackdaw_panels = { version = "0.3.1", path = "crates/jackdaw_panels" }
+jackdaw_api = { version = "0.3.1", path = "crates/jackdaw_api" }
 rfd = "0.15"
 bevy_rerecast = { version = "0.4", default-features = true }
 ehttp = { version = "0.5", default-features = false, features = ["native-async", "json"] }

--- a/crates/jackdaw_api/Cargo.toml
+++ b/crates/jackdaw_api/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/jbuehler23/jackdaw"
 
 [dependencies]
 bevy.workspace = true
+bevy_enhanced_input.workspace = true
 jackdaw_panels.workspace = true
 jackdaw_commands.workspace = true
 

--- a/crates/jackdaw_api/Cargo.toml
+++ b/crates/jackdaw_api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "jackdaw_api"
+version = "0.3.1"
+edition = "2024"
+description = "Public API for Jackdaw editor extensions"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jbuehler23/jackdaw"
+
+[dependencies]
+bevy.workspace = true
+jackdaw_panels.workspace = true
+jackdaw_commands.workspace = true
+
+[lints]
+workspace = true

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -65,20 +65,20 @@ use jackdaw_panels::{
 };
 
 pub use lifecycle::{
-    Extension, ExtensionCatalog, ExtensionCtor, OperatorEntity, OperatorIndex,
-    RegisteredPanelExtension, RegisteredWindow, RegisteredWorkspace, disable_extension,
-    enable_extension, register_extension, unload_extension,
+    ActiveModalOperator, Extension, ExtensionCatalog, ExtensionCtor, OperatorEntity, OperatorIndex,
+    RegisteredMenuEntry, RegisteredPanelExtension, RegisteredWindow, RegisteredWorkspace,
+    disable_extension, enable_extension, register_extension, tick_modal_operator, unload_extension,
 };
-pub use operator::{Operator, OperatorCommandBuffer, OperatorResult};
+pub use operator::{Operator, OperatorCommandBuffer, OperatorResult, Trigger};
 pub use registries::PanelExtensionRegistry;
 
 /// Re-exports plugin authors will want in one import.
 pub mod prelude {
     pub use crate::lifecycle::{Extension, ExtensionCatalog, OperatorEntity, OperatorIndex};
-    pub use crate::operator::{Operator, OperatorCommandBuffer, OperatorResult};
+    pub use crate::operator::{Operator, OperatorCommandBuffer, OperatorResult, Trigger};
     pub use crate::{
-        ExtensionContext, ExtensionPoint, JackdawExtension, PanelContext, SectionBuildFn,
-        WindowDescriptor,
+        ExtensionContext, ExtensionPoint, JackdawExtension, MenuEntryDescriptor, PanelContext,
+        SectionBuildFn, WindowDescriptor,
     };
     // BEI types extension authors need for `actions!` / `bindings!` / observers.
     pub use bevy_enhanced_input::prelude::*;
@@ -193,8 +193,9 @@ impl<'a> ExtensionContext<'a> {
     }
 
     /// Register an operator. Spawns an `OperatorEntity` as a child of the
-    /// extension entity; spawns an observer under the operator entity that
-    /// dispatches the operator when its BEI action fires.
+    /// extension entity; spawns a BEI observer that dispatches the operator
+    /// based on the operator's `TRIGGER` const (`Start`, `Fire`, `Complete`,
+    /// or `Manual` which skips observer spawning).
     pub fn register_operator<O: Operator>(&mut self) {
         let ext = self.extension_entity;
 
@@ -220,30 +221,58 @@ impl<'a> ExtensionContext<'a> {
                     execute,
                     invoke,
                     poll,
+                    modal: O::MODAL,
                 },
                 ChildOf(ext),
             ))
             .id();
 
-        // Spawn the `Start<O>` observer as a child of the operator entity.
-        // We use `Start` rather than `Fire` so the operator fires exactly
-        // once per key press, matching Blender's operator semantics. BEI's
-        // `Fire<A>` triggers every frame while the key is held, which is
-        // correct for continuous actions (camera movement, dragging) but
-        // wrong for discrete ops that should be in the undo history once
-        // per invocation. Continuous-fire cases don't go through operators
-        // anyway — extensions spawn plain BEI observers for those.
+        // Wire up the BEI observer based on O::TRIGGER.
         //
-        // When the operator entity despawns, this observer goes with it.
-        let observer = Observer::new(
-            move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Start<O>>,
-                  mut commands: Commands| {
-                commands.queue(move |world: &mut World| {
-                    crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
-                });
-            },
-        );
-        self.world.spawn((observer, ChildOf(op_entity)));
+        // The observer is spawned as a child of the operator entity, so
+        // despawning the operator automatically drops the observer.
+        // `Trigger::Manual` is a special case: no observer is spawned, and
+        // the caller is expected to invoke the operator via
+        // `dispatch_operator_by_id` (e.g. from a menu or button click).
+        match O::TRIGGER {
+            crate::operator::Trigger::Start => {
+                let observer = Observer::new(
+                    move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Start<O>>,
+                          mut commands: Commands| {
+                        commands.queue(move |world: &mut World| {
+                            crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
+                        });
+                    },
+                );
+                self.world.spawn((observer, ChildOf(op_entity)));
+            }
+            crate::operator::Trigger::Fire => {
+                let observer = Observer::new(
+                    move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Fire<O>>,
+                          mut commands: Commands| {
+                        commands.queue(move |world: &mut World| {
+                            crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
+                        });
+                    },
+                );
+                self.world.spawn((observer, ChildOf(op_entity)));
+            }
+            crate::operator::Trigger::Complete => {
+                let observer = Observer::new(
+                    move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Complete<O>>,
+                          mut commands: Commands| {
+                        commands.queue(move |world: &mut World| {
+                            crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
+                        });
+                    },
+                );
+                self.world.spawn((observer, ChildOf(op_entity)));
+            }
+            crate::operator::Trigger::Manual => {
+                // No observer. Callers invoke the operator directly via
+                // `lifecycle::dispatch_operator_by_id`.
+            }
+        }
     }
 
     /// Inject a section into an existing panel (e.g. add a sub-section to
@@ -263,6 +292,46 @@ impl<'a> ExtensionContext<'a> {
             ChildOf(ext),
         ));
     }
+
+    /// Contribute an entry to one of the editor's top-level menus
+    /// (`"Add"`, `"Tools"`, etc.). Clicking the entry dispatches the
+    /// referenced operator.
+    ///
+    /// The menu bar rebuilds automatically when entries are added or
+    /// removed. When the extension unloads, its menu entries despawn
+    /// with it and the menu rebuilds without them.
+    ///
+    /// ```ignore
+    /// ctx.register_menu_entry(MenuEntryDescriptor {
+    ///     menu: "Add".into(),
+    ///     label: "My Camera".into(),
+    ///     operator_id: PlaceMyCamera::ID,
+    /// });
+    /// ```
+    pub fn register_menu_entry(&mut self, descriptor: MenuEntryDescriptor) {
+        let ext = self.extension_entity;
+        self.world.spawn((
+            RegisteredMenuEntry {
+                menu: descriptor.menu,
+                label: descriptor.label,
+                operator_id: descriptor.operator_id,
+            },
+            ChildOf(ext),
+        ));
+    }
+}
+
+/// Extension-facing descriptor for a menu bar entry. See
+/// [`ExtensionContext::register_menu_entry`].
+pub struct MenuEntryDescriptor {
+    /// Top-level menu name (`"Add"`, `"Tools"`, etc.).
+    pub menu: String,
+    /// Text shown on the menu item.
+    pub label: String,
+    /// ID of an operator registered on the same extension (or any loaded
+    /// extension — ids are global). Clicking the menu entry dispatches
+    /// this operator.
+    pub operator_id: &'static str,
 }
 
 /// Window registration info — the extension-facing version of

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -1,97 +1,297 @@
+//! Public API for Jackdaw editor extensions.
+//!
+//! Extensions are entities: an extension entity holds an [`Extension`]
+//! component, and every registration (operators, windows, BEI contexts,
+//! panel extensions) spawns child entities under it. Unloading an extension
+//! is `world.entity_mut(ext).despawn()` — Bevy cascades through the children
+//! and a few observers handle the non-ECS cleanup.
+//!
+//! Extension authors:
+//!
+//! ```ignore
+//! use bevy::prelude::*;
+//! use bevy_enhanced_input::prelude::*;
+//! use jackdaw_api::prelude::*;
+//!
+//! // Operators ARE BEI actions.
+//! #[derive(Default, InputAction)]
+//! #[action_output(bool)]
+//! pub struct PlaceCube;
+//!
+//! impl Operator for PlaceCube {
+//!     const ID: &'static str = "sample.place_cube";
+//!     const LABEL: &'static str = "Place Cube";
+//!     fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
+//!         commands.register_system(place_cube)
+//!     }
+//! }
+//!
+//! fn place_cube(mut buffer: ResMut<OperatorCommandBuffer>) -> OperatorResult {
+//!     // record scene-mutating EditorCommands here
+//!     OperatorResult::Finished
+//! }
+//!
+//! #[derive(Component, Default)]
+//! pub struct SamplePluginContext;
+//!
+//! pub struct SamplePlugin;
+//!
+//! impl JackdawExtension for SamplePlugin {
+//!     fn name(&self) -> &str { "Sample Plugin" }
+//!     fn register(&self, ctx: &mut ExtensionContext) {
+//!         ctx.register_operator::<PlaceCube>();
+//!         ctx.add_input_context::<SamplePluginContext>();
+//!         ctx.spawn((
+//!             SamplePluginContext,
+//!             actions!(SamplePluginContext[
+//!                 Action::<PlaceCube>::new(),
+//!                 bindings![KeyCode::C],
+//!             ]),
+//!         ));
+//!     }
+//! }
+//! ```
+
+pub mod lifecycle;
 mod operator;
 mod registries;
 
-pub use operator::{Operator, OperatorContext, OperatorResult};
-pub use registries::{
-    KeyCombo, KeybindRegistry, Modifiers, OperatorRegistry, PanelExtensionRegistry,
-};
-
 use std::sync::Arc;
 
+use bevy::ecs::world::EntityWorldMut;
 use bevy::prelude::*;
 use jackdaw_panels::{
     DockWindowDescriptor, WindowRegistry, WorkspaceDescriptor, WorkspaceRegistry,
 };
 
+pub use lifecycle::{
+    Extension, ExtensionCatalog, ExtensionCtor, OperatorEntity, OperatorIndex,
+    RegisteredPanelExtension, RegisteredWindow, RegisteredWorkspace, disable_extension,
+    enable_extension, register_extension, unload_extension,
+};
+pub use operator::{Operator, OperatorCommandBuffer, OperatorResult};
+pub use registries::PanelExtensionRegistry;
+
+/// Re-exports plugin authors will want in one import.
 pub mod prelude {
+    pub use crate::lifecycle::{Extension, ExtensionCatalog, OperatorEntity, OperatorIndex};
+    pub use crate::operator::{Operator, OperatorCommandBuffer, OperatorResult};
     pub use crate::{
         ExtensionContext, ExtensionPoint, JackdawExtension, PanelContext, SectionBuildFn,
         WindowDescriptor,
     };
-    pub use crate::{KeyCombo, Modifiers};
-    pub use crate::{Operator, OperatorContext, OperatorResult};
+    // BEI types extension authors need for `actions!` / `bindings!` / observers.
+    pub use bevy_enhanced_input::prelude::*;
+    // Re-export Bevy's SystemId here so Operator impls don't need to import it.
+    pub use bevy::ecs::system::SystemId;
 }
 
+/// Plugin-author-facing trait. An extension declares its name and its
+/// registration logic; everything else is handled by the framework.
 pub trait JackdawExtension: Send + Sync + 'static {
     fn name(&self) -> &str;
+
+    /// One-time hook for BEI input context registration. Called exactly
+    /// once per catalog entry at app startup, before any `register()` call.
+    ///
+    /// Why separate from `register`: BEI's `add_input_context::<C>()` must
+    /// only be called once per context type per app lifetime. `register`
+    /// can be called multiple times across enable/disable cycles, so
+    /// context registration belongs elsewhere.
+    ///
+    /// Default: no-op. Extensions without BEI contexts don't need to
+    /// implement this.
+    fn register_input_contexts(&self, _app: &mut App) {}
+
+    /// Main registration logic. Called each time the extension is enabled.
+    /// Spawn operators, windows, BEI action entities, etc. here.
     fn register(&self, ctx: &mut ExtensionContext);
-    fn unregister(&self, _ctx: &mut ExtensionContext) {}
+
+    /// Optional hook called before the extension entity despawns. Most
+    /// extensions don't need this — entity-based cleanup handles registered
+    /// windows, operators, BEI contexts, and observers automatically. Use
+    /// this only for non-ECS state (open file handles, web sessions, etc.).
+    fn unregister(&self, _world: &mut World, _extension_entity: Entity) {}
 }
 
+/// Passed to `JackdawExtension::register`. Holds the extension entity and
+/// provides convenience methods that spawn child entities under it.
+///
+/// Wraps `&mut World` rather than `&mut App` so extensions can be loaded
+/// from contexts that only have world access (e.g. the Plugins dialog
+/// observer calling `enable_extension` via a queued world callback). One-
+/// time setup that genuinely needs App access (BEI input context
+/// registration) goes through `JackdawExtension::register_input_contexts`
+/// which is called once at catalog registration time.
 pub struct ExtensionContext<'a> {
-    app: &'a mut App,
+    world: &'a mut World,
+    extension_entity: Entity,
 }
 
 impl<'a> ExtensionContext<'a> {
-    pub fn new(app: &'a mut App) -> Self {
-        Self { app }
+    pub fn new(world: &'a mut World, extension_entity: Entity) -> Self {
+        Self {
+            world,
+            extension_entity,
+        }
     }
 
-    pub fn app(&mut self) -> &mut App {
-        self.app
+    /// Direct access to the underlying `World`. Extensions that need to
+    /// insert resources or spawn additional entities use this.
+    pub fn world(&mut self) -> &mut World {
+        self.world
     }
 
+    /// The root `Extension` entity. Use this if you want to manually spawn
+    /// additional child entities that should be torn down on unload.
+    pub fn entity(&self) -> Entity {
+        self.extension_entity
+    }
+
+    /// Register a dock window. Spawns a `RegisteredWindow` marker entity as
+    /// a child of the extension entity; a cleanup observer calls
+    /// `WindowRegistry::unregister` when the marker despawns.
     pub fn register_window(&mut self, descriptor: WindowDescriptor) {
+        let ext = self.extension_entity;
         let dock_descriptor = DockWindowDescriptor {
-            id: descriptor.id,
+            id: descriptor.id.clone(),
             name: descriptor.name,
             icon: descriptor.icon,
-            default_area: String::new(),
-            priority: 100,
+            default_area: descriptor.default_area.unwrap_or_default(),
+            priority: descriptor.priority.unwrap_or(100),
             build: descriptor.build,
         };
-        self.app
-            .world_mut()
+        self.world
             .resource_mut::<WindowRegistry>()
             .register(dock_descriptor);
+        self.world
+            .spawn((RegisteredWindow { id: descriptor.id }, ChildOf(ext)));
     }
 
+    /// Register a workspace.
     pub fn register_workspace(&mut self, descriptor: WorkspaceDescriptor) {
-        self.app
-            .world_mut()
+        let ext = self.extension_entity;
+        let id = descriptor.id.clone();
+        self.world
             .resource_mut::<WorkspaceRegistry>()
             .register(descriptor);
+        self.world.spawn((RegisteredWorkspace { id }, ChildOf(ext)));
     }
 
-    pub fn register_operator<O: Operator + Default>(&mut self) {
-        self.app
-            .world_mut()
-            .resource_mut::<OperatorRegistry>()
-            .register::<O>();
+    /// Spawn an entity as a child of the extension entity. Used for BEI
+    /// context entities with action bindings — e.g.
+    /// `ctx.spawn((MyContext, actions!(MyContext[...])))`.
+    ///
+    /// The returned `EntityWorldMut` lets the caller continue to add more
+    /// components or children; anything spawned this way is torn down when
+    /// the extension unloads.
+    pub fn spawn<'w>(&'w mut self, bundle: impl Bundle) -> EntityWorldMut<'w> {
+        let ext = self.extension_entity;
+        let mut ec = self.world.spawn(bundle);
+        ec.insert(ChildOf(ext));
+        ec
     }
 
-    pub fn register_keybind(&mut self, keys: KeyCombo, operator_id: &str) {
-        self.app
-            .world_mut()
-            .resource_mut::<KeybindRegistry>()
-            .bind(keys, operator_id.to_string());
+    /// Register an operator. Spawns an `OperatorEntity` as a child of the
+    /// extension entity; spawns an observer under the operator entity that
+    /// dispatches the operator when its BEI action fires.
+    pub fn register_operator<O: Operator>(&mut self) {
+        let ext = self.extension_entity;
+
+        // Register execute/invoke/poll as real Bevy systems.
+        let (execute, invoke, poll) = {
+            let mut queue = bevy::ecs::world::CommandQueue::default();
+            let mut commands = Commands::new(&mut queue, self.world);
+            let execute = O::register_execute(&mut commands);
+            let invoke = O::register_invoke(&mut commands);
+            let poll = O::register_poll(&mut commands);
+            queue.apply(self.world);
+            (execute, invoke, poll)
+        };
+
+        // Spawn the operator entity as a child of the extension.
+        let op_entity = self
+            .world
+            .spawn((
+                OperatorEntity {
+                    id: O::ID,
+                    label: O::LABEL,
+                    description: O::DESCRIPTION,
+                    execute,
+                    invoke,
+                    poll,
+                },
+                ChildOf(ext),
+            ))
+            .id();
+
+        // Spawn the `Start<O>` observer as a child of the operator entity.
+        // We use `Start` rather than `Fire` so the operator fires exactly
+        // once per key press, matching Blender's operator semantics. BEI's
+        // `Fire<A>` triggers every frame while the key is held, which is
+        // correct for continuous actions (camera movement, dragging) but
+        // wrong for discrete ops that should be in the undo history once
+        // per invocation. Continuous-fire cases don't go through operators
+        // anyway — extensions spawn plain BEI observers for those.
+        //
+        // When the operator entity despawns, this observer goes with it.
+        let observer = Observer::new(
+            move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Start<O>>,
+                  mut commands: Commands| {
+                commands.queue(move |world: &mut World| {
+                    crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
+                });
+            },
+        );
+        self.world.spawn((observer, ChildOf(op_entity)));
     }
 
+    /// Inject a section into an existing panel (e.g. add a sub-section to
+    /// the Inspector window). Section runs with `In<PanelContext>` each time
+    /// the panel re-renders.
     pub fn extend_window<W: ExtensionPoint>(&mut self, section: SectionBuildFn) {
-        self.app
-            .world_mut()
-            .resource_mut::<PanelExtensionRegistry>()
-            .add(W::ID.to_string(), section);
+        let ext = self.extension_entity;
+        let panel_id = W::ID.to_string();
+        let mut registry = self.world.resource_mut::<PanelExtensionRegistry>();
+        let section_index = registry.get(&panel_id).len();
+        registry.add(panel_id.clone(), section);
+        self.world.spawn((
+            RegisteredPanelExtension {
+                panel_id,
+                section_index,
+            },
+            ChildOf(ext),
+        ));
     }
 }
 
+/// Window registration info — the extension-facing version of
+/// `DockWindowDescriptor`. External extensions leave `default_area` as
+/// `None` so their windows aren't auto-placed; built-in Jackdaw extensions
+/// set it to preserve the default layout.
 pub struct WindowDescriptor {
     pub id: String,
     pub name: String,
     pub icon: Option<String>,
+    pub default_area: Option<String>,
+    pub priority: Option<i32>,
     pub build: Arc<dyn Fn(&mut World, Entity) + Send + Sync>,
 }
 
+impl Default for WindowDescriptor {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            icon: None,
+            default_area: None,
+            priority: None,
+            build: Arc::new(|_, _| {}),
+        }
+    }
+}
+
+/// Marker trait for panels that accept extension sections.
 pub trait ExtensionPoint: 'static {
     const ID: &'static str;
 }
@@ -106,6 +306,7 @@ impl ExtensionPoint for HierarchyWindow {
     const ID: &'static str = "jackdaw.hierarchy";
 }
 
+/// Context passed to a panel-extension section when it's rendered.
 pub struct PanelContext {
     pub window_id: String,
     pub panel_entity: Entity,
@@ -113,8 +314,34 @@ pub struct PanelContext {
 
 pub type SectionBuildFn = Arc<dyn Fn(&mut World, PanelContext) + Send + Sync>;
 
-pub fn load_static_extension(app: &mut App, extension: &dyn JackdawExtension) {
-    info!("Loading extension: {}", extension.name());
-    let mut ctx = ExtensionContext::new(app);
+/// Load an extension statically. Spawns an `Extension` entity, runs
+/// `extension.register()` against it, returns the entity.
+///
+/// Takes `&mut World` (not `&mut App`) so this can be called from
+/// world-scoped contexts like observer callbacks. BEI input context
+/// registration belongs in
+/// [`JackdawExtension::register_input_contexts`], which is called at
+/// catalog registration time with App access.
+pub fn load_static_extension(world: &mut World, extension: Box<dyn JackdawExtension>) -> Entity {
+    let name = extension.name().to_string();
+    info!("Loading extension: {}", name);
+
+    let extension_entity = world.spawn(Extension { name }).id();
+
+    let mut ctx = ExtensionContext::new(world, extension_entity);
     extension.register(&mut ctx);
+
+    // Store the extension trait object on the entity so `unload_extension`
+    // can call `unregister` before despawn.
+    world
+        .entity_mut(extension_entity)
+        .insert(StoredExtension(extension));
+
+    extension_entity
 }
+
+/// Internal component holding the extension trait object for the duration
+/// of its lifetime. Used by `unload_extension` to invoke the optional
+/// `unregister` hook before despawning.
+#[derive(Component)]
+pub(crate) struct StoredExtension(pub(crate) Box<dyn JackdawExtension>);

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -1,19 +1,19 @@
 //! Public API for Jackdaw editor extensions.
 //!
-//! Extensions are entities: an extension entity holds an [`Extension`]
+//! Extensions are entities. An extension entity holds an [`Extension`]
 //! component, and every registration (operators, windows, BEI contexts,
-//! panel extensions) spawns child entities under it. Unloading an extension
-//! is `world.entity_mut(ext).despawn()` — Bevy cascades through the children
-//! and a few observers handle the non-ECS cleanup.
+//! panel extensions) spawns child entities under it. Unloading an
+//! extension is `world.entity_mut(ext).despawn()`; Bevy cascades through
+//! the children and a few observers handle the non-ECS cleanup.
 //!
-//! Extension authors:
+//! Minimal extension:
 //!
 //! ```ignore
 //! use bevy::prelude::*;
 //! use bevy_enhanced_input::prelude::*;
 //! use jackdaw_api::prelude::*;
 //!
-//! // Operators ARE BEI actions.
+//! // An operator is also a BEI action, so one type covers both.
 //! #[derive(Default, InputAction)]
 //! #[action_output(bool)]
 //! pub struct PlaceCube;
@@ -26,8 +26,7 @@
 //!     }
 //! }
 //!
-//! fn place_cube(mut buffer: ResMut<OperatorCommandBuffer>) -> OperatorResult {
-//!     // record scene-mutating EditorCommands here
+//! fn place_cube(mut _buffer: ResMut<OperatorCommandBuffer>) -> OperatorResult {
 //!     OperatorResult::Finished
 //! }
 //!
@@ -65,16 +64,19 @@ use jackdaw_panels::{
 };
 
 pub use lifecycle::{
-    ActiveModalOperator, Extension, ExtensionCatalog, ExtensionCtor, OperatorEntity, OperatorIndex,
-    RegisteredMenuEntry, RegisteredPanelExtension, RegisteredWindow, RegisteredWorkspace,
-    disable_extension, enable_extension, register_extension, tick_modal_operator, unload_extension,
+    ActiveModalOperator, Extension, ExtensionCatalog, ExtensionCtor, ExtensionKind, OperatorEntity,
+    OperatorIndex, RegisteredMenuEntry, RegisteredPanelExtension, RegisteredWindow,
+    RegisteredWorkspace, disable_extension, enable_extension, register_extension,
+    tick_modal_operator, unload_extension,
 };
 pub use operator::{Operator, OperatorCommandBuffer, OperatorResult, Trigger};
 pub use registries::PanelExtensionRegistry;
 
 /// Re-exports plugin authors will want in one import.
 pub mod prelude {
-    pub use crate::lifecycle::{Extension, ExtensionCatalog, OperatorEntity, OperatorIndex};
+    pub use crate::lifecycle::{
+        Extension, ExtensionCatalog, ExtensionKind, OperatorEntity, OperatorIndex,
+    };
     pub use crate::operator::{Operator, OperatorCommandBuffer, OperatorResult, Trigger};
     pub use crate::{
         ExtensionContext, ExtensionPoint, JackdawExtension, MenuEntryDescriptor, PanelContext,
@@ -86,43 +88,53 @@ pub mod prelude {
     pub use bevy::ecs::system::SystemId;
 }
 
-/// Plugin-author-facing trait. An extension declares its name and its
-/// registration logic; everything else is handled by the framework.
+/// Trait implemented by every extension. Declares the extension's name
+/// and registration logic; the framework handles everything else.
 pub trait JackdawExtension: Send + Sync + 'static {
     fn name(&self) -> &str;
 
-    /// One-time hook for BEI input context registration. Called exactly
-    /// once per catalog entry at app startup, before any `register()` call.
+    /// Classify this extension. Defaults to [`ExtensionKind::Custom`].
     ///
-    /// Why separate from `register`: BEI's `add_input_context::<C>()` must
-    /// only be called once per context type per app lifetime. `register`
-    /// can be called multiple times across enable/disable cycles, so
-    /// context registration belongs elsewhere.
+    /// The Extensions dialog reads this to split the list into Built-in
+    /// and Custom sections. Reserved as a future hook for marketplace
+    /// categories.
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Custom
+    }
+
+    /// Hook for one-time BEI input-context registration.
     ///
-    /// Default: no-op. Extensions without BEI contexts don't need to
-    /// implement this.
+    /// Called once per catalog entry at app startup, before any
+    /// `register()` call. BEI's `add_input_context::<C>()` must run
+    /// exactly once per context type per app lifetime, so it cannot live
+    /// inside `register` which runs on every enable.
+    ///
+    /// Defaults to no-op; override only if the extension adds BEI
+    /// contexts.
     fn register_input_contexts(&self, _app: &mut App) {}
 
-    /// Main registration logic. Called each time the extension is enabled.
-    /// Spawn operators, windows, BEI action entities, etc. here.
+    /// Main registration logic. Called each time the extension is
+    /// enabled. Spawn operators, windows, BEI action entities, and any
+    /// other owned state here.
     fn register(&self, ctx: &mut ExtensionContext);
 
-    /// Optional hook called before the extension entity despawns. Most
-    /// extensions don't need this — entity-based cleanup handles registered
-    /// windows, operators, BEI contexts, and observers automatically. Use
-    /// this only for non-ECS state (open file handles, web sessions, etc.).
+    /// Optional hook called before the extension entity despawns.
+    ///
+    /// Child-entity cleanup handles registered windows, operators, BEI
+    /// contexts, and observers automatically. Override only for non-ECS
+    /// state (file handles, network sessions, and the like).
     fn unregister(&self, _world: &mut World, _extension_entity: Entity) {}
 }
 
-/// Passed to `JackdawExtension::register`. Holds the extension entity and
-/// provides convenience methods that spawn child entities under it.
+/// Passed to [`JackdawExtension::register`]. Holds the extension entity
+/// and provides helpers that spawn child entities under it.
 ///
-/// Wraps `&mut World` rather than `&mut App` so extensions can be loaded
-/// from contexts that only have world access (e.g. the Plugins dialog
-/// observer calling `enable_extension` via a queued world callback). One-
-/// time setup that genuinely needs App access (BEI input context
-/// registration) goes through `JackdawExtension::register_input_contexts`
-/// which is called once at catalog registration time.
+/// Wraps `&mut World` rather than `&mut App` because extensions may be
+/// loaded from world-only contexts such as the Extensions dialog's
+/// enable/disable observer. One-time setup that genuinely requires App
+/// access (BEI input-context registration) runs through
+/// [`JackdawExtension::register_input_contexts`] at catalog-registration
+/// time.
 pub struct ExtensionContext<'a> {
     world: &'a mut World,
     extension_entity: Entity,
@@ -142,15 +154,16 @@ impl<'a> ExtensionContext<'a> {
         self.world
     }
 
-    /// The root `Extension` entity. Use this if you want to manually spawn
-    /// additional child entities that should be torn down on unload.
+    /// The root [`Extension`] entity. Useful when an extension wants to
+    /// spawn additional child entities that should be torn down on
+    /// unload.
     pub fn entity(&self) -> Entity {
         self.extension_entity
     }
 
-    /// Register a dock window. Spawns a `RegisteredWindow` marker entity as
-    /// a child of the extension entity; a cleanup observer calls
-    /// `WindowRegistry::unregister` when the marker despawns.
+    /// Register a dock window. Spawns a [`RegisteredWindow`] marker
+    /// entity as a child of the extension entity; a cleanup observer
+    /// calls `WindowRegistry::unregister` when the marker despawns.
     pub fn register_window(&mut self, descriptor: WindowDescriptor) {
         let ext = self.extension_entity;
         let dock_descriptor = DockWindowDescriptor {
@@ -178,13 +191,13 @@ impl<'a> ExtensionContext<'a> {
         self.world.spawn((RegisteredWorkspace { id }, ChildOf(ext)));
     }
 
-    /// Spawn an entity as a child of the extension entity. Used for BEI
-    /// context entities with action bindings — e.g.
+    /// Spawn an entity as a child of the extension entity. Typically
+    /// used for BEI context entities with action bindings:
     /// `ctx.spawn((MyContext, actions!(MyContext[...])))`.
     ///
-    /// The returned `EntityWorldMut` lets the caller continue to add more
-    /// components or children; anything spawned this way is torn down when
-    /// the extension unloads.
+    /// The returned [`EntityWorldMut`] lets the caller keep adding
+    /// components or children. Anything spawned this way is torn down
+    /// when the extension unloads.
     pub fn spawn<'w>(&'w mut self, bundle: impl Bundle) -> EntityWorldMut<'w> {
         let ext = self.extension_entity;
         let mut ec = self.world.spawn(bundle);
@@ -192,10 +205,12 @@ impl<'a> ExtensionContext<'a> {
         ec
     }
 
-    /// Register an operator. Spawns an `OperatorEntity` as a child of the
-    /// extension entity; spawns a BEI observer that dispatches the operator
-    /// based on the operator's `TRIGGER` const (`Start`, `Fire`, `Complete`,
-    /// or `Manual` which skips observer spawning).
+    /// Register an operator. Spawns an [`OperatorEntity`] as a child of
+    /// the extension entity and, based on the operator's
+    /// [`Operator::TRIGGER`], an observer that dispatches the operator
+    /// on `Start`, `Fire`, or `Complete`. `Trigger::Manual` skips the
+    /// observer; the caller is expected to invoke the operator through
+    /// [`crate::lifecycle::dispatch_operator_by_id`].
     pub fn register_operator<O: Operator>(&mut self) {
         let ext = self.extension_entity;
 
@@ -227,52 +242,40 @@ impl<'a> ExtensionContext<'a> {
             ))
             .id();
 
-        // Wire up the BEI observer based on O::TRIGGER.
-        //
-        // The observer is spawned as a child of the operator entity, so
-        // despawning the operator automatically drops the observer.
-        // `Trigger::Manual` is a special case: no observer is spawned, and
-        // the caller is expected to invoke the operator via
-        // `dispatch_operator_by_id` (e.g. from a menu or button click).
+        // Spawn the BEI observer for the configured trigger. The
+        // observer is parented to the operator entity so despawning the
+        // operator drops it automatically. `Trigger::Manual` skips the
+        // observer; callers dispatch through `dispatch_operator_by_id`.
+        use bevy_enhanced_input::prelude::{Complete, Fire, Start};
         match O::TRIGGER {
             crate::operator::Trigger::Start => {
-                let observer = Observer::new(
-                    move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Start<O>>,
-                          mut commands: Commands| {
-                        commands.queue(move |world: &mut World| {
-                            crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
-                        });
-                    },
-                );
-                self.world.spawn((observer, ChildOf(op_entity)));
+                self.spawn_trigger_observer::<O, Start<O>>(op_entity);
             }
             crate::operator::Trigger::Fire => {
-                let observer = Observer::new(
-                    move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Fire<O>>,
-                          mut commands: Commands| {
-                        commands.queue(move |world: &mut World| {
-                            crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
-                        });
-                    },
-                );
-                self.world.spawn((observer, ChildOf(op_entity)));
+                self.spawn_trigger_observer::<O, Fire<O>>(op_entity);
             }
             crate::operator::Trigger::Complete => {
-                let observer = Observer::new(
-                    move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Complete<O>>,
-                          mut commands: Commands| {
-                        commands.queue(move |world: &mut World| {
-                            crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
-                        });
-                    },
-                );
-                self.world.spawn((observer, ChildOf(op_entity)));
+                self.spawn_trigger_observer::<O, Complete<O>>(op_entity);
             }
-            crate::operator::Trigger::Manual => {
-                // No observer. Callers invoke the operator directly via
-                // `lifecycle::dispatch_operator_by_id`.
-            }
+            crate::operator::Trigger::Manual => {}
         }
+    }
+
+    /// Helper used by [`Self::register_operator`] to spawn a BEI observer
+    /// that dispatches the operator through
+    /// [`crate::lifecycle::dispatch_operator_by_id`]. Generic over the
+    /// event type so one body covers `Start<O>`, `Fire<O>`, and
+    /// `Complete<O>`.
+    fn spawn_trigger_observer<O: Operator, E: bevy::ecs::event::EntityEvent>(
+        &mut self,
+        op_entity: Entity,
+    ) {
+        let observer = Observer::new(move |_: bevy::prelude::On<E>, mut commands: Commands| {
+            commands.queue(move |world: &mut World| {
+                crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
+            });
+        });
+        self.world.spawn((observer, ChildOf(op_entity)));
     }
 
     /// Inject a section into an existing panel (e.g. add a sub-section to
@@ -328,16 +331,17 @@ pub struct MenuEntryDescriptor {
     pub menu: String,
     /// Text shown on the menu item.
     pub label: String,
-    /// ID of an operator registered on the same extension (or any loaded
-    /// extension — ids are global). Clicking the menu entry dispatches
-    /// this operator.
+    /// ID of an operator registered on the same extension, or any other
+    /// loaded extension. Operator IDs are global. Clicking the menu
+    /// entry dispatches this operator.
     pub operator_id: &'static str,
 }
 
-/// Window registration info — the extension-facing version of
-/// `DockWindowDescriptor`. External extensions leave `default_area` as
-/// `None` so their windows aren't auto-placed; built-in Jackdaw extensions
-/// set it to preserve the default layout.
+/// Extension-facing descriptor for a dock window. Mirrors
+/// [`jackdaw_panels::DockWindowDescriptor`] but with `default_area`
+/// optional: third-party extensions leave it `None` so their windows are
+/// not auto-placed, while built-in Jackdaw extensions set it to preserve
+/// the default layout.
 pub struct WindowDescriptor {
     pub id: String,
     pub name: String,

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -1,0 +1,120 @@
+mod operator;
+mod registries;
+
+pub use operator::{Operator, OperatorContext, OperatorResult};
+pub use registries::{
+    KeyCombo, KeybindRegistry, Modifiers, OperatorRegistry, PanelExtensionRegistry,
+};
+
+use std::sync::Arc;
+
+use bevy::prelude::*;
+use jackdaw_panels::{
+    DockWindowDescriptor, WindowRegistry, WorkspaceDescriptor, WorkspaceRegistry,
+};
+
+pub mod prelude {
+    pub use crate::{
+        ExtensionContext, ExtensionPoint, JackdawExtension, PanelContext, SectionBuildFn,
+        WindowDescriptor,
+    };
+    pub use crate::{KeyCombo, Modifiers};
+    pub use crate::{Operator, OperatorContext, OperatorResult};
+}
+
+pub trait JackdawExtension: Send + Sync + 'static {
+    fn name(&self) -> &str;
+    fn register(&self, ctx: &mut ExtensionContext);
+    fn unregister(&self, _ctx: &mut ExtensionContext) {}
+}
+
+pub struct ExtensionContext<'a> {
+    app: &'a mut App,
+}
+
+impl<'a> ExtensionContext<'a> {
+    pub fn new(app: &'a mut App) -> Self {
+        Self { app }
+    }
+
+    pub fn app(&mut self) -> &mut App {
+        self.app
+    }
+
+    pub fn register_window(&mut self, descriptor: WindowDescriptor) {
+        let dock_descriptor = DockWindowDescriptor {
+            id: descriptor.id,
+            name: descriptor.name,
+            icon: descriptor.icon,
+            default_area: String::new(),
+            priority: 100,
+            build: descriptor.build,
+        };
+        self.app
+            .world_mut()
+            .resource_mut::<WindowRegistry>()
+            .register(dock_descriptor);
+    }
+
+    pub fn register_workspace(&mut self, descriptor: WorkspaceDescriptor) {
+        self.app
+            .world_mut()
+            .resource_mut::<WorkspaceRegistry>()
+            .register(descriptor);
+    }
+
+    pub fn register_operator<O: Operator + Default>(&mut self) {
+        self.app
+            .world_mut()
+            .resource_mut::<OperatorRegistry>()
+            .register::<O>();
+    }
+
+    pub fn register_keybind(&mut self, keys: KeyCombo, operator_id: &str) {
+        self.app
+            .world_mut()
+            .resource_mut::<KeybindRegistry>()
+            .bind(keys, operator_id.to_string());
+    }
+
+    pub fn extend_window<W: ExtensionPoint>(&mut self, section: SectionBuildFn) {
+        self.app
+            .world_mut()
+            .resource_mut::<PanelExtensionRegistry>()
+            .add(W::ID.to_string(), section);
+    }
+}
+
+pub struct WindowDescriptor {
+    pub id: String,
+    pub name: String,
+    pub icon: Option<String>,
+    pub build: Arc<dyn Fn(&mut World, Entity) + Send + Sync>,
+}
+
+pub trait ExtensionPoint: 'static {
+    const ID: &'static str;
+}
+
+pub struct InspectorWindow;
+impl ExtensionPoint for InspectorWindow {
+    const ID: &'static str = "jackdaw.inspector.components";
+}
+
+pub struct HierarchyWindow;
+impl ExtensionPoint for HierarchyWindow {
+    const ID: &'static str = "jackdaw.hierarchy";
+}
+
+pub struct PanelContext {
+    pub window_id: String,
+    pub panel_entity: Entity,
+}
+
+pub type SectionBuildFn = Arc<dyn Fn(&mut World, PanelContext) + Send + Sync>;
+
+pub fn load_static_extension(app: &mut App, extension: &dyn JackdawExtension) {
+    info!("Loading extension: {}", extension.name());
+    let mut ctx = ExtensionContext::new(app);
+    extension.register(&mut ctx);
+}

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -1,0 +1,351 @@
+//! Entity-based lifecycle primitives for extensions.
+//!
+//! An extension is represented as an `Entity` with an [`Extension`] component.
+//! Everything it registers — operators, BEI context entities, dock windows,
+//! workspaces — is spawned as a child of that entity. Unloading is just
+//! `world.entity_mut(ext).despawn()`, and Bevy cascades through the children.
+//! A small set of observers in the `ExtensionLoaderPlugin` handles the cleanup
+//! that can't be expressed purely as entity despawn (unregistering stored
+//! `SystemId`s, removing from the dock `WindowRegistry`, etc.).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bevy::ecs::system::SystemId;
+use bevy::prelude::*;
+
+use crate::operator::OperatorResult;
+
+/// Root component for an extension.
+///
+/// Despawning this entity tears down all of the extension's child entities:
+/// operators, BEI context/action entities, registered windows/workspaces, and
+/// observer entities. Non-ECS cleanup (unregistering `SystemId`s, removing
+/// entries from `WindowRegistry`) is handled by observers reacting to the
+/// child-entity despawns.
+#[derive(Component, Debug)]
+pub struct Extension {
+    pub name: String,
+}
+
+/// An operator — child of an [`Extension`].
+///
+/// Holds the `SystemId`s that the dispatcher runs. An observer on
+/// `On<Remove, OperatorEntity>` unregisters those systems when this entity
+/// despawns, and keeps the [`OperatorIndex`] in sync.
+#[derive(Component, Clone)]
+pub struct OperatorEntity {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub description: &'static str,
+    pub execute: SystemId<(), OperatorResult>,
+    pub invoke: SystemId<(), OperatorResult>,
+    pub poll: Option<SystemId<(), bool>>,
+}
+
+/// Marks an entity as tracking a dock window registration.
+///
+/// Spawned as a child of the [`Extension`] entity when `register_window` is
+/// called. An observer on `On<Remove, RegisteredWindow>` calls
+/// `WindowRegistry::unregister(id)` so the window disappears from the
+/// add-window popup when the extension unloads.
+#[derive(Component, Clone, Debug)]
+pub struct RegisteredWindow {
+    pub id: String,
+}
+
+/// Marks an entity as tracking a workspace registration.
+#[derive(Component, Clone, Debug)]
+pub struct RegisteredWorkspace {
+    pub id: String,
+}
+
+/// Marks an entity as tracking a panel-extension registration (a section
+/// injected into an existing panel via `ExtensionContext::extend_window`).
+#[derive(Component, Clone, Debug)]
+pub struct RegisteredPanelExtension {
+    pub panel_id: String,
+    pub section_index: usize,
+}
+
+/// Reactive index from operator id → operator entity. Maintained by the
+/// `index_operator_on_add` / `deindex_operator_on_remove` observers.
+/// Lets the dispatcher resolve an id to a `SystemId` in O(1).
+#[derive(Resource, Default)]
+pub struct OperatorIndex {
+    pub(crate) by_id: HashMap<&'static str, Entity>,
+}
+
+impl OperatorIndex {
+    pub fn get(&self, id: &str) -> Option<Entity> {
+        self.by_id.get(id).copied()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, Entity)> + '_ {
+        self.by_id.iter().map(|(k, v)| (*k, *v))
+    }
+}
+
+/// Constructor function for an extension. Stored in [`ExtensionCatalog`].
+pub type ExtensionCtor = Arc<dyn Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync>;
+
+/// Registry of all extensions compiled into this build of Jackdaw.
+///
+/// Populated once during startup by calling `ExtensionCatalog::register` for
+/// each built-in extension. External extensions (if/when dylib loading lands)
+/// would register themselves here too. Toggle UIs read the catalog to list
+/// available extensions.
+#[derive(Resource, Default)]
+pub struct ExtensionCatalog {
+    constructors: HashMap<String, ExtensionCtor>,
+}
+
+impl ExtensionCatalog {
+    pub fn register<F>(&mut self, name: impl Into<String>, ctor: F)
+    where
+        F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
+    {
+        self.constructors.insert(name.into(), Arc::new(ctor));
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.constructors.contains_key(name)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.constructors.keys().map(|s| s.as_str())
+    }
+
+    /// Construct a fresh instance of the named extension, if registered.
+    pub fn construct(&self, name: &str) -> Option<Box<dyn crate::JackdawExtension>> {
+        self.constructors.get(name).map(|f| f())
+    }
+}
+
+/// Register an extension into the catalog and perform its one-time BEI
+/// input-context registration.
+///
+/// Call this once per extension during app setup. Registering the constructor
+/// lets the Plugins dialog list the extension; running
+/// `register_input_contexts` ensures its BEI context types are known to the
+/// framework. Enabling and disabling the extension later only re-runs
+/// `register()`, never `register_input_contexts()` (BEI panics on duplicate
+/// registrations).
+pub fn register_extension<F>(app: &mut App, name: &str, ctor: F)
+where
+    F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
+{
+    // Construct a throwaway instance just to register context types.
+    let sample = ctor();
+    sample.register_input_contexts(app);
+    drop(sample);
+
+    // Store the constructor in the catalog for runtime enable/disable.
+    app.world_mut()
+        .resource_mut::<ExtensionCatalog>()
+        .register(name, ctor);
+}
+
+// ============================================================================
+// Dispatch
+// ============================================================================
+
+use crate::operator::OperatorCommandBuffer;
+use jackdaw_commands::{CommandGroup, CommandHistory};
+
+/// Dispatch an operator by id. Used by the BEI `Fire<O>` observers spawned
+/// in `ExtensionContext::register_operator`.
+pub fn dispatch_operator_by_id(world: &mut World, id: &'static str, creates_history_entry: bool) {
+    // Resolve operator via the reactive index.
+    let Some(op_entity) = world.resource::<OperatorIndex>().by_id.get(id).copied() else {
+        warn!("Tried to dispatch unknown operator: {}", id);
+        return;
+    };
+    let Some(op) = world.get::<OperatorEntity>(op_entity).cloned() else {
+        return;
+    };
+
+    // Poll (optional).
+    if let Some(poll) = op.poll {
+        if !world.run_system(poll).unwrap_or(false) {
+            return;
+        }
+    }
+
+    // Prep the command buffer, run the invoke system, drain the buffer.
+    world
+        .resource_mut::<OperatorCommandBuffer>()
+        .prepare(creates_history_entry);
+
+    let result = match world.run_system(op.invoke) {
+        Ok(r) => r,
+        Err(err) => {
+            error!("Failed to run operator {}: {:?}", op.id, err);
+            return;
+        }
+    };
+
+    // First pass: treat `Running` like `Finished`. Modal support is future.
+    let finished = matches!(result, OperatorResult::Finished | OperatorResult::Running);
+    if !finished {
+        // Cancelled — drop the recorded commands.
+        world.resource_mut::<OperatorCommandBuffer>().take();
+        return;
+    }
+
+    let (recorded, creates_history) = world.resource_mut::<OperatorCommandBuffer>().take();
+
+    if creates_history && !recorded.is_empty() {
+        let group = Box::new(CommandGroup {
+            commands: recorded,
+            label: op.label.to_string(),
+        });
+        world.resource_mut::<CommandHistory>().push_executed(group);
+    }
+}
+
+// ============================================================================
+// Loading / unloading / enable / disable
+// ============================================================================
+
+/// Unload an extension. Just despawns the root entity; the cascade + cleanup
+/// observers take care of the rest.
+pub fn unload_extension(world: &mut World, ext_entity: Entity) {
+    let ext_name = world
+        .get::<Extension>(ext_entity)
+        .map(|e| e.name.clone())
+        .unwrap_or_default();
+    info!("Unloading extension: {}", ext_name);
+
+    // Invoke the optional `unregister` hook before despawning.
+    if let Some(stored) = world
+        .entity_mut(ext_entity)
+        .take::<crate::StoredExtension>()
+    {
+        stored.0.unregister(world, ext_entity);
+    }
+    if let Ok(ec) = world.get_entity_mut(ext_entity) {
+        ec.despawn();
+    }
+}
+
+/// Enable a named extension via the catalog. Returns the new extension
+/// entity if the extension existed in the catalog and wasn't already loaded.
+pub fn enable_extension(world: &mut World, name: &str) -> Option<Entity> {
+    // Short-circuit if already loaded.
+    {
+        let mut query = world.query::<&Extension>();
+        if query.iter(world).any(|e| e.name == name) {
+            return None;
+        }
+    }
+
+    let extension = world.resource::<ExtensionCatalog>().construct(name)?;
+
+    Some(crate::load_static_extension(world, extension))
+}
+
+/// Disable a named extension. Finds the matching `Extension` entity and
+/// despawns it.
+pub fn disable_extension(world: &mut World, name: &str) -> bool {
+    let mut query = world.query::<(Entity, &Extension)>();
+    let Some(ext_entity) = query
+        .iter(world)
+        .find(|(_, e)| e.name == name)
+        .map(|(e, _)| e)
+    else {
+        return false;
+    };
+    unload_extension(world, ext_entity);
+    true
+}
+
+// ============================================================================
+// Cleanup observers — added by ExtensionLoaderPlugin
+// ============================================================================
+
+/// Observer: keep `OperatorIndex` in sync on add.
+pub fn index_operator_on_add(
+    trigger: On<Add, OperatorEntity>,
+    operators: Query<&OperatorEntity>,
+    mut index: ResMut<OperatorIndex>,
+) {
+    if let Ok(op) = operators.get(trigger.event_target()) {
+        index.by_id.insert(op.id, trigger.event_target());
+    }
+}
+
+/// Observer: keep `OperatorIndex` in sync on remove. Also unregister the
+/// operator's Bevy `SystemId`s so they don't leak across enable/disable
+/// cycles.
+pub fn deindex_and_cleanup_operator_on_remove(
+    trigger: On<Remove, OperatorEntity>,
+    operators: Query<&OperatorEntity>,
+    mut index: ResMut<OperatorIndex>,
+    mut commands: Commands,
+) {
+    let Ok(op) = operators.get(trigger.event_target()) else {
+        return;
+    };
+    info!("Unregistering operator: {}", op.id);
+    index.by_id.remove(op.id);
+    let (exec, inv, poll) = (op.execute, op.invoke, op.poll);
+    commands.queue(move |world: &mut World| {
+        let _ = world.unregister_system(exec);
+        if exec != inv {
+            let _ = world.unregister_system(inv);
+        }
+        if let Some(p) = poll {
+            let _ = world.unregister_system(p);
+        }
+    });
+}
+
+/// Observer: unregister a dock window from `WindowRegistry` when its
+/// `RegisteredWindow` marker entity despawns. Also removes any docked
+/// instances of the window from the live `DockTree` and every workspace's
+/// stored tree so the UI actually reflects the disable.
+pub fn cleanup_window_on_remove(
+    trigger: On<Remove, RegisteredWindow>,
+    windows: Query<&RegisteredWindow>,
+    mut registry: ResMut<jackdaw_panels::WindowRegistry>,
+    mut dock_tree: ResMut<jackdaw_panels::tree::DockTree>,
+    mut workspaces: ResMut<jackdaw_panels::WorkspaceRegistry>,
+) {
+    let Ok(w) = windows.get(trigger.event_target()) else {
+        return;
+    };
+    info!("Unregistering window: {}", w.id);
+    registry.unregister(&w.id);
+    // Remove from the live tree so any currently-docked instance vanishes.
+    dock_tree.remove_window(&w.id);
+    // And from each stored workspace tree so switching workspaces doesn't
+    // resurrect it.
+    for workspace in workspaces.workspaces.iter_mut() {
+        workspace.tree.remove_window(&w.id);
+    }
+}
+
+/// Observer: unregister a workspace when its `RegisteredWorkspace` marker
+/// entity despawns.
+pub fn cleanup_workspace_on_remove(
+    trigger: On<Remove, RegisteredWorkspace>,
+    workspaces: Query<&RegisteredWorkspace>,
+    mut registry: ResMut<jackdaw_panels::WorkspaceRegistry>,
+) {
+    if let Ok(w) = workspaces.get(trigger.event_target()) {
+        registry.unregister(&w.id);
+    }
+}
+
+/// Observer: remove a panel extension section from the registry when its
+/// marker entity despawns.
+pub fn cleanup_panel_extension_on_remove(
+    trigger: On<Remove, RegisteredPanelExtension>,
+    registrations: Query<&RegisteredPanelExtension>,
+    mut registry: ResMut<crate::PanelExtensionRegistry>,
+) {
+    if let Ok(r) = registrations.get(trigger.event_target()) {
+        registry.remove(&r.panel_id, r.section_index);
+    }
+}

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -41,6 +41,34 @@ pub struct OperatorEntity {
     pub execute: SystemId<(), OperatorResult>,
     pub invoke: SystemId<(), OperatorResult>,
     pub poll: Option<SystemId<(), bool>>,
+    /// Mirrors [`crate::Operator::MODAL`]. Set at registration so the
+    /// dispatcher can enter modal mode without re-resolving the generic
+    /// operator type.
+    pub modal: bool,
+}
+
+/// Tracks the currently-active modal operator. Exactly zero or one at a
+/// time — starting a second modal while one is active is refused.
+///
+/// While set, `tick_modal_operator` re-runs the invoke system every frame
+/// and the [`crate::OperatorCommandBuffer`] stays prepared across frames
+/// so every `record` call lands in the same `CommandGroup`.
+#[derive(Resource, Default)]
+pub struct ActiveModalOperator {
+    pub(crate) id: Option<&'static str>,
+    pub(crate) operator_entity: Option<Entity>,
+    pub(crate) invoke_system: Option<SystemId<(), OperatorResult>>,
+    pub(crate) label: Option<String>,
+}
+
+impl ActiveModalOperator {
+    pub fn is_active(&self) -> bool {
+        self.id.is_some()
+    }
+
+    pub fn id(&self) -> Option<&'static str> {
+        self.id
+    }
 }
 
 /// Marks an entity as tracking a dock window registration.
@@ -66,6 +94,23 @@ pub struct RegisteredWorkspace {
 pub struct RegisteredPanelExtension {
     pub panel_id: String,
     pub section_index: usize,
+}
+
+/// An extension-contributed entry in the editor menu bar.
+///
+/// Spawned as a child of the [`Extension`] entity via
+/// [`crate::ExtensionContext::register_menu_entry`]. The editor's
+/// `populate_menu` system queries these and inserts them into the right
+/// menu. Clicking one dispatches the referenced operator.
+///
+/// `menu` is the top-level menu name (`"Add"`, `"Tools"`, etc.). For now
+/// we're flat — no sub-menus — but the field is a path so that's easy to
+/// extend later (e.g. `"Add/Cameras"`).
+#[derive(Component, Clone, Debug)]
+pub struct RegisteredMenuEntry {
+    pub menu: String,
+    pub label: String,
+    pub operator_id: &'static str,
 }
 
 /// Reactive index from operator id → operator entity. Maintained by the
@@ -153,10 +198,29 @@ where
 use crate::operator::OperatorCommandBuffer;
 use jackdaw_commands::{CommandGroup, CommandHistory};
 
-/// Dispatch an operator by id. Used by the BEI `Fire<O>` observers spawned
-/// in `ExtensionContext::register_operator`.
-pub fn dispatch_operator_by_id(world: &mut World, id: &'static str, creates_history_entry: bool) {
-    // Resolve operator via the reactive index.
+/// Dispatch an operator by id. Used by the BEI trigger observers spawned
+/// in `ExtensionContext::register_operator`, and callable directly for
+/// `Trigger::Manual` operators (UI buttons, F3 search, etc.).
+///
+/// - Non-modal operators: runs once and pushes a history entry immediately.
+/// - Modal operators: if the invoke returns `Running`, enters modal mode.
+///   The tick system takes over from the next frame.
+///
+/// If another modal operator is already active, the dispatch is refused
+/// with a warn log (matches Blender's "one modal at a time" rule).
+pub fn dispatch_operator_by_id(world: &mut World, id: &str, creates_history_entry: bool) {
+    // Refuse if another modal operator is active.
+    if let Some(active_id) = world.resource::<ActiveModalOperator>().id {
+        warn!(
+            "Ignoring operator '{}' — modal operator '{}' is currently active",
+            id, active_id
+        );
+        return;
+    }
+
+    // Resolve operator via the reactive index. The index keys are
+    // `&'static str` from each operator's trait, but `HashMap` lookup
+    // hashes by string content, so a plain `&str` works.
     let Some(op_entity) = world.resource::<OperatorIndex>().by_id.get(id).copied() else {
         warn!("Tried to dispatch unknown operator: {}", id);
         return;
@@ -172,7 +236,7 @@ pub fn dispatch_operator_by_id(world: &mut World, id: &'static str, creates_hist
         }
     }
 
-    // Prep the command buffer, run the invoke system, drain the buffer.
+    // Prep the command buffer, run the invoke system.
     world
         .resource_mut::<OperatorCommandBuffer>()
         .prepare(creates_history_entry);
@@ -181,27 +245,84 @@ pub fn dispatch_operator_by_id(world: &mut World, id: &'static str, creates_hist
         Ok(r) => r,
         Err(err) => {
             error!("Failed to run operator {}: {:?}", op.id, err);
+            world.resource_mut::<OperatorCommandBuffer>().take();
             return;
         }
     };
 
-    // First pass: treat `Running` like `Finished`. Modal support is future.
-    let finished = matches!(result, OperatorResult::Finished | OperatorResult::Running);
-    if !finished {
-        // Cancelled — drop the recorded commands.
-        world.resource_mut::<OperatorCommandBuffer>().take();
+    match result {
+        OperatorResult::Running if op.modal => {
+            // Enter modal mode. The tick system picks up from next frame;
+            // the command buffer stays prepared across frames.
+            let mut active = world.resource_mut::<ActiveModalOperator>();
+            active.id = Some(op.id);
+            active.operator_entity = Some(op_entity);
+            active.invoke_system = Some(op.invoke);
+            active.label = Some(op.label.to_string());
+        }
+        OperatorResult::Running | OperatorResult::Finished => {
+            // Non-modal `Running` collapses to `Finished` — one-shot behavior.
+            finalize_operator_session(world, &op.label, true);
+        }
+        OperatorResult::Cancelled => {
+            finalize_operator_session(world, &op.label, false);
+        }
+    }
+}
+
+/// Drain the command buffer and, if committing and history-tracked, push a
+/// `CommandGroup` to `CommandHistory`.
+fn finalize_operator_session(world: &mut World, label: &str, commit: bool) {
+    let (recorded, creates_history) = world.resource_mut::<OperatorCommandBuffer>().take();
+    if !commit {
         return;
     }
-
-    let (recorded, creates_history) = world.resource_mut::<OperatorCommandBuffer>().take();
-
     if creates_history && !recorded.is_empty() {
         let group = Box::new(CommandGroup {
             commands: recorded,
-            label: op.label.to_string(),
+            label: label.to_string(),
         });
         world.resource_mut::<CommandHistory>().push_executed(group);
     }
+}
+
+/// Tick system added to Update by `ExtensionLoaderPlugin`. If a modal
+/// operator is active, re-runs its invoke system once per frame and
+/// transitions out of modal on `Finished` or `Cancelled`.
+pub fn tick_modal_operator(world: &mut World) {
+    let Some(invoke) = world.resource::<ActiveModalOperator>().invoke_system else {
+        return;
+    };
+    let result = match world.run_system(invoke) {
+        Ok(r) => r,
+        Err(err) => {
+            error!(
+                "Modal operator's invoke system failed: {:?}; cancelling",
+                err
+            );
+            finalize_modal(world, false);
+            return;
+        }
+    };
+    match result {
+        OperatorResult::Running => { /* stay modal */ }
+        OperatorResult::Finished => finalize_modal(world, true),
+        OperatorResult::Cancelled => finalize_modal(world, false),
+    }
+}
+
+/// Exit modal mode. Drains the command buffer; commits as a history entry
+/// if `commit` is true and the buffer is non-empty, otherwise discards.
+fn finalize_modal(world: &mut World, commit: bool) {
+    let label = {
+        let mut active = world.resource_mut::<ActiveModalOperator>();
+        let label = active.label.take().unwrap_or_default();
+        active.id = None;
+        active.operator_entity = None;
+        active.invoke_system = None;
+        label
+    };
+    finalize_operator_session(world, &label, commit);
 }
 
 // ============================================================================
@@ -347,5 +468,20 @@ pub fn cleanup_panel_extension_on_remove(
 ) {
     if let Ok(r) = registrations.get(trigger.event_target()) {
         registry.remove(&r.panel_id, r.section_index);
+    }
+}
+
+/// Logs the menu entry on add. Actual menu rebuilds are driven by a
+/// separate flag resource in the main crate (`MenuBarDirty`) because this
+/// crate doesn't know about the concrete menu-bar implementation.
+pub fn log_menu_entry_on_add(
+    trigger: On<Add, RegisteredMenuEntry>,
+    entries: Query<&RegisteredMenuEntry>,
+) {
+    if let Ok(entry) = entries.get(trigger.event_target()) {
+        info!(
+            "Registered menu entry: {} > {} -> {}",
+            entry.menu, entry.label, entry.operator_id
+        );
     }
 }

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -1,12 +1,13 @@
 //! Entity-based lifecycle primitives for extensions.
 //!
-//! An extension is represented as an `Entity` with an [`Extension`] component.
-//! Everything it registers — operators, BEI context entities, dock windows,
-//! workspaces — is spawned as a child of that entity. Unloading is just
-//! `world.entity_mut(ext).despawn()`, and Bevy cascades through the children.
-//! A small set of observers in the `ExtensionLoaderPlugin` handles the cleanup
-//! that can't be expressed purely as entity despawn (unregistering stored
-//! `SystemId`s, removing from the dock `WindowRegistry`, etc.).
+//! An extension is represented as an [`Entity`] carrying an [`Extension`]
+//! component. Everything it registers (operators, BEI context entities,
+//! dock windows, workspaces) is spawned as a child of that entity.
+//! Unloading is `world.entity_mut(ext).despawn()`; Bevy cascades through
+//! the children. A small set of observers in `ExtensionLoaderPlugin`
+//! handles cleanup that can't be expressed purely as entity despawn:
+//! unregistering stored `SystemId`s, removing entries from the dock
+//! `WindowRegistry`, and so on.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,7 +29,7 @@ pub struct Extension {
     pub name: String,
 }
 
-/// An operator — child of an [`Extension`].
+/// Child of an [`Extension`]; represents a single operator.
 ///
 /// Holds the `SystemId`s that the dispatcher runs. An observer on
 /// `On<Remove, OperatorEntity>` unregisters those systems when this entity
@@ -47,8 +48,9 @@ pub struct OperatorEntity {
     pub modal: bool,
 }
 
-/// Tracks the currently-active modal operator. Exactly zero or one at a
-/// time — starting a second modal while one is active is refused.
+/// Tracks the currently-active modal operator. Exactly zero or one is
+/// active at any time; starting a second modal while one is running is
+/// refused.
 ///
 /// While set, `tick_modal_operator` re-runs the invoke system every frame
 /// and the [`crate::OperatorCommandBuffer`] stays prepared across frames
@@ -103,9 +105,9 @@ pub struct RegisteredPanelExtension {
 /// `populate_menu` system queries these and inserts them into the right
 /// menu. Clicking one dispatches the referenced operator.
 ///
-/// `menu` is the top-level menu name (`"Add"`, `"Tools"`, etc.). For now
-/// we're flat — no sub-menus — but the field is a path so that's easy to
-/// extend later (e.g. `"Add/Cameras"`).
+/// `menu` is the top-level menu name (`"Add"`, `"Tools"`, etc.). The
+/// menu system is flat today; using a path-like string here leaves room
+/// for nested menus later without breaking callers.
 #[derive(Component, Clone, Debug)]
 pub struct RegisteredMenuEntry {
     pub menu: String,
@@ -142,28 +144,75 @@ pub type ExtensionCtor = Arc<dyn Fn() -> Box<dyn crate::JackdawExtension> + Send
 /// available extensions.
 #[derive(Resource, Default)]
 pub struct ExtensionCatalog {
-    constructors: HashMap<String, ExtensionCtor>,
+    entries: HashMap<String, CatalogEntry>,
+}
+
+struct CatalogEntry {
+    ctor: ExtensionCtor,
+    kind: ExtensionKind,
+}
+
+/// Classifies an entry in the catalog. Surfaced in toggle UIs so
+/// Jackdaw-shipped feature areas and third-party extensions can be
+/// presented separately. Extensions declare their own kind via
+/// [`crate::JackdawExtension::kind`]; registration captures it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExtensionKind {
+    /// Ships with Jackdaw as a core feature area (scene tree, inspector,
+    /// asset browser, etc.). Present in every build.
+    Builtin,
+    /// Everything else: example extensions bundled for demonstration,
+    /// third-party extensions loaded from disk, user-authored addons.
+    Custom,
 }
 
 impl ExtensionCatalog {
-    pub fn register<F>(&mut self, name: impl Into<String>, ctor: F)
+    /// Register a constructor with its declared kind. Most callers
+    /// should use [`register_extension`] instead, which handles BEI
+    /// context registration.
+    pub fn register<F>(&mut self, name: impl Into<String>, kind: ExtensionKind, ctor: F)
     where
         F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     {
-        self.constructors.insert(name.into(), Arc::new(ctor));
+        self.entries.insert(
+            name.into(),
+            CatalogEntry {
+                ctor: Arc::new(ctor),
+                kind,
+            },
+        );
     }
 
     pub fn contains(&self, name: &str) -> bool {
-        self.constructors.contains_key(name)
+        self.entries.contains_key(name)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &str> {
-        self.constructors.keys().map(|s| s.as_str())
+        self.entries.keys().map(|s| s.as_str())
+    }
+
+    /// Iterate names with their declared [`ExtensionKind`]. Useful for
+    /// grouping the Extensions dialog into Built-in and Custom sections.
+    pub fn iter_with_kind(&self) -> impl Iterator<Item = (&str, ExtensionKind)> {
+        self.entries
+            .iter()
+            .map(|(name, entry)| (name.as_str(), entry.kind))
+    }
+
+    /// Look up the declared [`ExtensionKind`] for a registered name.
+    pub fn kind(&self, name: &str) -> Option<ExtensionKind> {
+        self.entries.get(name).map(|e| e.kind)
+    }
+
+    /// Whether the named extension is a Jackdaw-shipped built-in.
+    /// Returns `false` for unknown names.
+    pub fn is_builtin(&self, name: &str) -> bool {
+        self.kind(name) == Some(ExtensionKind::Builtin)
     }
 
     /// Construct a fresh instance of the named extension, if registered.
     pub fn construct(&self, name: &str) -> Option<Box<dyn crate::JackdawExtension>> {
-        self.constructors.get(name).map(|f| f())
+        self.entries.get(name).map(|e| (e.ctor)())
     }
 }
 
@@ -180,15 +229,17 @@ pub fn register_extension<F>(app: &mut App, name: &str, ctor: F)
 where
     F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
 {
-    // Construct a throwaway instance just to register context types.
+    // Construct a throwaway instance to (a) register context types and
+    // (b) read the extension's declared `kind`. Doing both against the
+    // same instance avoids a second construction just to classify.
     let sample = ctor();
     sample.register_input_contexts(app);
+    let kind = sample.kind();
     drop(sample);
 
-    // Store the constructor in the catalog for runtime enable/disable.
     app.world_mut()
         .resource_mut::<ExtensionCatalog>()
-        .register(name, ctor);
+        .register(name, kind, ctor);
 }
 
 // ============================================================================
@@ -211,10 +262,7 @@ use jackdaw_commands::{CommandGroup, CommandHistory};
 pub fn dispatch_operator_by_id(world: &mut World, id: &str, creates_history_entry: bool) {
     // Refuse if another modal operator is active.
     if let Some(active_id) = world.resource::<ActiveModalOperator>().id {
-        warn!(
-            "Ignoring operator '{}' — modal operator '{}' is currently active",
-            id, active_id
-        );
+        warn!("Ignoring operator '{id}': modal operator '{active_id}' is currently active");
         return;
     }
 
@@ -261,11 +309,11 @@ pub fn dispatch_operator_by_id(world: &mut World, id: &str, creates_history_entr
             active.label = Some(op.label.to_string());
         }
         OperatorResult::Running | OperatorResult::Finished => {
-            // Non-modal `Running` collapses to `Finished` — one-shot behavior.
-            finalize_operator_session(world, &op.label, true);
+            // Non-modal `Running` collapses to `Finished` for one-shot behavior.
+            finalize_operator_session(world, op.label, true);
         }
         OperatorResult::Cancelled => {
-            finalize_operator_session(world, &op.label, false);
+            finalize_operator_session(world, op.label, false);
         }
     }
 }
@@ -382,7 +430,7 @@ pub fn disable_extension(world: &mut World, name: &str) -> bool {
 }
 
 // ============================================================================
-// Cleanup observers — added by ExtensionLoaderPlugin
+// Cleanup observers. Added by `ExtensionLoaderPlugin`.
 // ============================================================================
 
 /// Observer: keep `OperatorIndex` in sync on add.

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -242,10 +242,6 @@ where
         .register(name, kind, ctor);
 }
 
-// ============================================================================
-// Dispatch
-// ============================================================================
-
 use crate::operator::OperatorCommandBuffer;
 use jackdaw_commands::{CommandGroup, CommandHistory};
 
@@ -373,12 +369,8 @@ fn finalize_modal(world: &mut World, commit: bool) {
     finalize_operator_session(world, &label, commit);
 }
 
-// ============================================================================
-// Loading / unloading / enable / disable
-// ============================================================================
-
-/// Unload an extension. Just despawns the root entity; the cascade + cleanup
-/// observers take care of the rest.
+/// Unload an extension. Despawns the root entity; the cascade and
+/// cleanup observers handle the rest.
 pub fn unload_extension(world: &mut World, ext_entity: Entity) {
     let ext_name = world
         .get::<Extension>(ext_entity)
@@ -386,7 +378,6 @@ pub fn unload_extension(world: &mut World, ext_entity: Entity) {
         .unwrap_or_default();
     info!("Unloading extension: {}", ext_name);
 
-    // Invoke the optional `unregister` hook before despawning.
     if let Some(stored) = world
         .entity_mut(ext_entity)
         .take::<crate::StoredExtension>()
@@ -399,9 +390,8 @@ pub fn unload_extension(world: &mut World, ext_entity: Entity) {
 }
 
 /// Enable a named extension via the catalog. Returns the new extension
-/// entity if the extension existed in the catalog and wasn't already loaded.
+/// entity, or `None` if the name is unknown or already loaded.
 pub fn enable_extension(world: &mut World, name: &str) -> Option<Entity> {
-    // Short-circuit if already loaded.
     {
         let mut query = world.query::<&Extension>();
         if query.iter(world).any(|e| e.name == name) {
@@ -410,12 +400,10 @@ pub fn enable_extension(world: &mut World, name: &str) -> Option<Entity> {
     }
 
     let extension = world.resource::<ExtensionCatalog>().construct(name)?;
-
     Some(crate::load_static_extension(world, extension))
 }
 
-/// Disable a named extension. Finds the matching `Extension` entity and
-/// despawns it.
+/// Disable a named extension by despawning its root entity.
 pub fn disable_extension(world: &mut World, name: &str) -> bool {
     let mut query = world.query::<(Entity, &Extension)>();
     let Some(ext_entity) = query
@@ -429,11 +417,7 @@ pub fn disable_extension(world: &mut World, name: &str) -> bool {
     true
 }
 
-// ============================================================================
-// Cleanup observers. Added by `ExtensionLoaderPlugin`.
-// ============================================================================
-
-/// Observer: keep `OperatorIndex` in sync on add.
+/// Keep [`OperatorIndex`] in sync when an operator entity is spawned.
 pub fn index_operator_on_add(
     trigger: On<Add, OperatorEntity>,
     operators: Query<&OperatorEntity>,
@@ -444,9 +428,9 @@ pub fn index_operator_on_add(
     }
 }
 
-/// Observer: keep `OperatorIndex` in sync on remove. Also unregister the
-/// operator's Bevy `SystemId`s so they don't leak across enable/disable
-/// cycles.
+/// Keep [`OperatorIndex`] in sync and free the operator's `SystemId`s
+/// when its entity is removed, so they don't leak across enable /
+/// disable cycles.
 pub fn deindex_and_cleanup_operator_on_remove(
     trigger: On<Remove, OperatorEntity>,
     operators: Query<&OperatorEntity>,
@@ -470,10 +454,10 @@ pub fn deindex_and_cleanup_operator_on_remove(
     });
 }
 
-/// Observer: unregister a dock window from `WindowRegistry` when its
-/// `RegisteredWindow` marker entity despawns. Also removes any docked
-/// instances of the window from the live `DockTree` and every workspace's
-/// stored tree so the UI actually reflects the disable.
+/// Unregister a dock window from [`jackdaw_panels::WindowRegistry`] and
+/// purge it from the live dock tree and every stored workspace tree when
+/// its marker entity despawns, so disabling an extension visibly removes
+/// its windows.
 pub fn cleanup_window_on_remove(
     trigger: On<Remove, RegisteredWindow>,
     windows: Query<&RegisteredWindow>,
@@ -486,17 +470,13 @@ pub fn cleanup_window_on_remove(
     };
     info!("Unregistering window: {}", w.id);
     registry.unregister(&w.id);
-    // Remove from the live tree so any currently-docked instance vanishes.
     dock_tree.remove_window(&w.id);
-    // And from each stored workspace tree so switching workspaces doesn't
-    // resurrect it.
     for workspace in workspaces.workspaces.iter_mut() {
         workspace.tree.remove_window(&w.id);
     }
 }
 
-/// Observer: unregister a workspace when its `RegisteredWorkspace` marker
-/// entity despawns.
+/// Unregister a workspace when its marker entity despawns.
 pub fn cleanup_workspace_on_remove(
     trigger: On<Remove, RegisteredWorkspace>,
     workspaces: Query<&RegisteredWorkspace>,
@@ -507,8 +487,8 @@ pub fn cleanup_workspace_on_remove(
     }
 }
 
-/// Observer: remove a panel extension section from the registry when its
-/// marker entity despawns.
+/// Remove a panel extension section from the registry when its marker
+/// entity despawns.
 pub fn cleanup_panel_extension_on_remove(
     trigger: On<Remove, RegisteredPanelExtension>,
     registrations: Query<&RegisteredPanelExtension>,
@@ -519,9 +499,9 @@ pub fn cleanup_panel_extension_on_remove(
     }
 }
 
-/// Logs the menu entry on add. Actual menu rebuilds are driven by a
-/// separate flag resource in the main crate (`MenuBarDirty`) because this
-/// crate doesn't know about the concrete menu-bar implementation.
+/// Log menu-entry registrations. Actual menu rebuilds are driven by
+/// the main crate's `MenuBarDirty` flag because this crate doesn't know
+/// the menu-bar implementation.
 pub fn log_menu_entry_on_add(
     trigger: On<Add, RegisteredMenuEntry>,
     entries: Query<&RegisteredMenuEntry>,

--- a/crates/jackdaw_api/src/operator.rs
+++ b/crates/jackdaw_api/src/operator.rs
@@ -120,13 +120,12 @@ pub enum OperatorResult {
 
 /// Resource operator systems use to record `EditorCommand`s for undo.
 ///
-/// The dispatcher calls [`Self::prepare`] before running the operator and
-/// [`Self::take`] after. During the operator's execute/invoke system, the
-/// operator pushes commands via [`Self::record`]; the command's `execute`
-/// has already been run by the caller (or is implicit in how the system
-/// modified state).
+/// Operators call [`Self::record`] from their execute/invoke system.
+/// The dispatcher handles preparing and draining the buffer around each
+/// invocation. The command's `execute` must already have been run by
+/// the caller (or be implicit in how the system modified state).
 ///
-/// All scene mutations should go through an `EditorCommand`. Operators never
+/// All scene mutations go through an `EditorCommand`. Operators never
 /// mutate `SceneJsnAst` directly.
 #[derive(Resource, Default)]
 pub struct OperatorCommandBuffer {

--- a/crates/jackdaw_api/src/operator.rs
+++ b/crates/jackdaw_api/src/operator.rs
@@ -1,78 +1,133 @@
+use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
-use jackdaw_commands::{CommandGroup, CommandHistory, EditorCommand};
+use bevy_enhanced_input::prelude::InputAction;
+use jackdaw_commands::EditorCommand;
 
-pub trait Operator: Send + Sync + 'static {
+/// A Blender-style operator.
+///
+/// The trait is bounded on [`InputAction`] so the operator type itself can be
+/// used as a BEI action:
+///
+/// ```ignore
+/// use bevy_enhanced_input::prelude::*;
+///
+/// #[derive(Default, InputAction)]
+/// #[action_output(bool)]
+/// struct PlaceCube;
+///
+/// impl Operator for PlaceCube {
+///     const ID: &'static str = "sample.place_cube";
+///     const LABEL: &'static str = "Place Cube";
+///
+///     fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
+///         commands.register_system(place_cube_system)
+///     }
+/// }
+/// ```
+///
+/// Extensions then bind the operator to a key via pure BEI syntax:
+///
+/// ```ignore
+/// ctx.spawn((
+///     MyPluginContext,
+///     actions!(MyPluginContext[
+///         Action::<PlaceCube>::new(),
+///         bindings![KeyCode::C],
+///     ]),
+/// ));
+/// ```
+pub trait Operator: InputAction + 'static {
     const ID: &'static str;
     const LABEL: &'static str;
     const DESCRIPTION: &'static str = "";
 
-    fn poll(&self, ctx: &OperatorContext) -> bool {
-        let _ = ctx;
-        true
+    /// Register the primary execute system. Called once during
+    /// `ExtensionContext::register_operator::<Self>()`. The returned
+    /// `SystemId` is stored on the operator entity and unregistered on
+    /// despawn.
+    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult>;
+
+    /// Register an optional poll system. Returns `true` if the operator is
+    /// currently callable; `false` skips execution. Default: always callable.
+    fn register_poll(_commands: &mut Commands) -> Option<SystemId<(), bool>> {
+        None
     }
 
-    fn execute(&mut self, ctx: &mut OperatorContext) -> OperatorResult;
-
-    fn invoke(&mut self, ctx: &mut OperatorContext) -> OperatorResult {
-        self.execute(ctx)
+    /// Register an optional invoke system. Invoke is what UI/keybind/F3
+    /// trigger — it may differ from execute (e.g. opens a modal dialog,
+    /// starts a drag). Default: identical to execute.
+    fn register_invoke(commands: &mut Commands) -> SystemId<(), OperatorResult> {
+        Self::register_execute(commands)
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OperatorResult {
+    /// Operator finished successfully. Any recorded commands are grouped and
+    /// pushed to `CommandHistory` as a single undo entry.
     Finished,
+    /// Operator explicitly cancelled. Recorded commands are dropped.
     Cancelled,
+    /// Operator is in a modal state (drag, dialog). The dispatcher re-runs
+    /// the invoke system next frame until `Finished` or `Cancelled`.
+    /// Modal support is future work; first pass treats `Running` like
+    /// `Finished` to simplify the dispatcher.
     Running,
 }
 
-pub struct OperatorContext<'a> {
-    world: &'a mut World,
-    recorded_commands: Vec<Box<dyn EditorCommand>>,
-    creates_history_entry: bool,
+/// Resource operator systems use to record `EditorCommand`s for undo.
+///
+/// The dispatcher calls [`Self::prepare`] before running the operator and
+/// [`Self::take`] after. During the operator's execute/invoke system, the
+/// operator pushes commands via [`Self::record`]; the command's `execute`
+/// has already been run by the caller (or is implicit in how the system
+/// modified state).
+///
+/// All scene mutations should go through an `EditorCommand`. Operators never
+/// mutate `SceneJsnAst` directly.
+#[derive(Resource, Default)]
+pub struct OperatorCommandBuffer {
+    pub(crate) recorded: Vec<Box<dyn EditorCommand>>,
+    pub(crate) creates_history_entry: bool,
 }
 
-impl<'a> OperatorContext<'a> {
-    pub fn new(world: &'a mut World, creates_history_entry: bool) -> Self {
-        Self {
-            world,
-            recorded_commands: Vec::new(),
-            creates_history_entry,
-        }
+impl OperatorCommandBuffer {
+    /// Record an already-executed command for undo. Use this when your
+    /// operator system constructs commands that have already been applied
+    /// to the world (e.g. by using `cmd.execute(world)` before calling
+    /// record, or by doing the mutation directly and then recording a
+    /// command that can reverse it on undo).
+    pub fn record(&mut self, cmd: Box<dyn EditorCommand>) {
+        self.recorded.push(cmd);
     }
 
-    pub fn world(&self) -> &World {
-        self.world
+    /// Execute a command and record it. Convenience for operators that
+    /// have `&mut World` (exclusive systems).
+    pub fn execute_and_record(&mut self, mut cmd: Box<dyn EditorCommand>, world: &mut World) {
+        cmd.execute(world);
+        self.recorded.push(cmd);
     }
 
-    pub fn world_mut(&mut self) -> &mut World {
-        self.world
+    /// Called by the dispatcher before running the operator's invoke system.
+    pub(crate) fn prepare(&mut self, creates_history_entry: bool) {
+        self.recorded.clear();
+        self.creates_history_entry = creates_history_entry;
     }
 
-    pub fn execute_command(&mut self, mut cmd: Box<dyn EditorCommand>) {
-        cmd.execute(self.world);
-        self.recorded_commands.push(cmd);
+    /// Called by the dispatcher after the operator finishes. Returns the
+    /// recorded commands and whether they should be turned into a history
+    /// entry.
+    pub(crate) fn take(&mut self) -> (Vec<Box<dyn EditorCommand>>, bool) {
+        let recorded = std::mem::take(&mut self.recorded);
+        let creates_history = self.creates_history_entry;
+        self.creates_history_entry = false;
+        (recorded, creates_history)
     }
 
-    pub fn invoke_operator<O: Operator + Default>(&mut self) -> OperatorResult {
-        let mut op = O::default();
-        let mut nested_ctx = OperatorContext {
-            world: self.world,
-            recorded_commands: Vec::new(),
-            creates_history_entry: false,
-        };
-        let result = op.invoke(&mut nested_ctx);
-        self.recorded_commands.extend(nested_ctx.recorded_commands);
-        result
-    }
-
-    pub fn finish(self, operator_label: &str) {
-        if !self.creates_history_entry || self.recorded_commands.is_empty() {
-            return;
-        }
-        let group = CommandGroup {
-            commands: self.recorded_commands,
-            label: operator_label.to_string(),
-        };
-        let mut history = self.world.resource_mut::<CommandHistory>();
-        history.push_executed(Box::new(group));
+    /// Whether the current operator run will create a history entry. Useful
+    /// if an operator's execute system wants to behave differently when
+    /// called from a nested context (e.g. skip dialog prompts).
+    pub fn creates_history_entry(&self) -> bool {
+        self.creates_history_entry
     }
 }

--- a/crates/jackdaw_api/src/operator.rs
+++ b/crates/jackdaw_api/src/operator.rs
@@ -41,6 +41,35 @@ pub trait Operator: InputAction + 'static {
     const LABEL: &'static str;
     const DESCRIPTION: &'static str = "";
 
+    /// Which BEI event triggers the operator's invoke system.
+    ///
+    /// - `Trigger::Start` (default): key down. Discrete one-shot semantics,
+    ///   matches Blender and the common case.
+    /// - `Trigger::Fire`: every frame while the input is held. Rarely right
+    ///   on its own — pair with `MODAL = true` for state-tracking sessions,
+    ///   or use for per-frame probes.
+    /// - `Trigger::Complete`: key up. "Press to arm, release to commit"
+    ///   without a full modal state machine.
+    /// - `Trigger::Manual`: don't auto-wire any BEI observer. Extensions
+    ///   invoke the operator themselves via
+    ///   [`crate::lifecycle::dispatch_operator_by_id`] — useful for
+    ///   operators driven by UI buttons, F3 search, or other code paths.
+    const TRIGGER: Trigger = Trigger::Start;
+
+    /// Modal operators stay active across frames.
+    ///
+    /// When `MODAL = true` and the invoke system returns
+    /// [`OperatorResult::Running`], the dispatcher keeps the
+    /// [`OperatorCommandBuffer`] prepared and re-runs the invoke system
+    /// every frame until it returns `Finished` or `Cancelled`. Every
+    /// `record` call across those frames lands in the same `CommandGroup`,
+    /// so the entire modal session commits as one undo entry.
+    ///
+    /// When `MODAL = false` (default), `Running` is treated like `Finished`
+    /// — the operator runs once, the buffer is drained, and a history
+    /// entry is pushed immediately.
+    const MODAL: bool = false;
+
     /// Register the primary execute system. Called once during
     /// `ExtensionContext::register_operator::<Self>()`. The returned
     /// `SystemId` is stored on the operator entity and unregistered on
@@ -59,6 +88,19 @@ pub trait Operator: InputAction + 'static {
     fn register_invoke(commands: &mut Commands) -> SystemId<(), OperatorResult> {
         Self::register_execute(commands)
     }
+}
+
+/// Which BEI event an operator reacts to. See [`Operator::TRIGGER`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// Key/button down (`Start<A>`). One-shot, discrete.
+    Start,
+    /// Every frame while held (`Fire<A>`). Usually paired with `MODAL = true`.
+    Fire,
+    /// Key/button up (`Complete<A>`).
+    Complete,
+    /// No auto-wired observer. Caller dispatches explicitly.
+    Manual,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/jackdaw_api/src/operator.rs
+++ b/crates/jackdaw_api/src/operator.rs
@@ -43,17 +43,17 @@ pub trait Operator: InputAction + 'static {
 
     /// Which BEI event triggers the operator's invoke system.
     ///
-    /// - `Trigger::Start` (default): key down. Discrete one-shot semantics,
-    ///   matches Blender and the common case.
-    /// - `Trigger::Fire`: every frame while the input is held. Rarely right
-    ///   on its own — pair with `MODAL = true` for state-tracking sessions,
-    ///   or use for per-frame probes.
-    /// - `Trigger::Complete`: key up. "Press to arm, release to commit"
-    ///   without a full modal state machine.
-    /// - `Trigger::Manual`: don't auto-wire any BEI observer. Extensions
-    ///   invoke the operator themselves via
-    ///   [`crate::lifecycle::dispatch_operator_by_id`] — useful for
-    ///   operators driven by UI buttons, F3 search, or other code paths.
+    /// - `Trigger::Start` (default): fires on key down. Discrete,
+    ///   one-shot semantics matching Blender's common case.
+    /// - `Trigger::Fire`: fires every frame the input is held. Usually
+    ///   paired with `MODAL = true` for state-tracking sessions; also
+    ///   useful for per-frame probes.
+    /// - `Trigger::Complete`: fires on key up. Useful for "press to arm,
+    ///   release to commit" flows that don't need a modal state machine.
+    /// - `Trigger::Manual`: no BEI observer is wired up. Callers invoke
+    ///   the operator directly through
+    ///   [`crate::lifecycle::dispatch_operator_by_id`], for example from
+    ///   UI buttons, F3 search, or other code paths.
     const TRIGGER: Trigger = Trigger::Start;
 
     /// Modal operators stay active across frames.
@@ -65,9 +65,9 @@ pub trait Operator: InputAction + 'static {
     /// `record` call across those frames lands in the same `CommandGroup`,
     /// so the entire modal session commits as one undo entry.
     ///
-    /// When `MODAL = false` (default), `Running` is treated like `Finished`
-    /// — the operator runs once, the buffer is drained, and a history
-    /// entry is pushed immediately.
+    /// When `MODAL = false` (default), `Running` is treated like
+    /// `Finished`: the operator runs once, the buffer is drained, and a
+    /// history entry is pushed immediately.
     const MODAL: bool = false;
 
     /// Register the primary execute system. Called once during
@@ -82,9 +82,10 @@ pub trait Operator: InputAction + 'static {
         None
     }
 
-    /// Register an optional invoke system. Invoke is what UI/keybind/F3
-    /// trigger — it may differ from execute (e.g. opens a modal dialog,
-    /// starts a drag). Default: identical to execute.
+    /// Register an optional invoke system. `invoke` is what UI,
+    /// keybinds, and F3 search run; it can differ from `execute` when
+    /// the caller wants to open a dialog or start a drag before the
+    /// primary work happens. Defaults to `execute`.
     fn register_invoke(commands: &mut Commands) -> SystemId<(), OperatorResult> {
         Self::register_execute(commands)
     }

--- a/crates/jackdaw_api/src/operator.rs
+++ b/crates/jackdaw_api/src/operator.rs
@@ -1,0 +1,78 @@
+use bevy::prelude::*;
+use jackdaw_commands::{CommandGroup, CommandHistory, EditorCommand};
+
+pub trait Operator: Send + Sync + 'static {
+    const ID: &'static str;
+    const LABEL: &'static str;
+    const DESCRIPTION: &'static str = "";
+
+    fn poll(&self, ctx: &OperatorContext) -> bool {
+        let _ = ctx;
+        true
+    }
+
+    fn execute(&mut self, ctx: &mut OperatorContext) -> OperatorResult;
+
+    fn invoke(&mut self, ctx: &mut OperatorContext) -> OperatorResult {
+        self.execute(ctx)
+    }
+}
+
+pub enum OperatorResult {
+    Finished,
+    Cancelled,
+    Running,
+}
+
+pub struct OperatorContext<'a> {
+    world: &'a mut World,
+    recorded_commands: Vec<Box<dyn EditorCommand>>,
+    creates_history_entry: bool,
+}
+
+impl<'a> OperatorContext<'a> {
+    pub fn new(world: &'a mut World, creates_history_entry: bool) -> Self {
+        Self {
+            world,
+            recorded_commands: Vec::new(),
+            creates_history_entry,
+        }
+    }
+
+    pub fn world(&self) -> &World {
+        self.world
+    }
+
+    pub fn world_mut(&mut self) -> &mut World {
+        self.world
+    }
+
+    pub fn execute_command(&mut self, mut cmd: Box<dyn EditorCommand>) {
+        cmd.execute(self.world);
+        self.recorded_commands.push(cmd);
+    }
+
+    pub fn invoke_operator<O: Operator + Default>(&mut self) -> OperatorResult {
+        let mut op = O::default();
+        let mut nested_ctx = OperatorContext {
+            world: self.world,
+            recorded_commands: Vec::new(),
+            creates_history_entry: false,
+        };
+        let result = op.invoke(&mut nested_ctx);
+        self.recorded_commands.extend(nested_ctx.recorded_commands);
+        result
+    }
+
+    pub fn finish(self, operator_label: &str) {
+        if !self.creates_history_entry || self.recorded_commands.is_empty() {
+            return;
+        }
+        let group = CommandGroup {
+            commands: self.recorded_commands,
+            label: operator_label.to_string(),
+        };
+        let mut history = self.world.resource_mut::<CommandHistory>();
+        history.push_executed(Box::new(group));
+    }
+}

--- a/crates/jackdaw_api/src/registries.rs
+++ b/crates/jackdaw_api/src/registries.rs
@@ -1,131 +1,13 @@
+//! Panel-extension registry. Operators now live as entities (see
+//! [`crate::lifecycle::OperatorEntity`]) and keybinds go through BEI, so
+//! this file is much smaller than in v1 — only the panel-extension mapping
+//! remains.
+
 use std::collections::HashMap;
 
 use bevy::prelude::*;
 
 use crate::SectionBuildFn;
-use crate::operator::{Operator, OperatorContext, OperatorResult};
-
-trait OperatorFactory: Send + Sync {
-    fn id(&self) -> &str;
-    fn label(&self) -> &str;
-    fn description(&self) -> &str;
-    fn create(&self) -> Box<dyn OperatorInstance>;
-}
-
-pub trait OperatorInstance: Send + Sync {
-    fn poll(&self, ctx: &OperatorContext) -> bool;
-    fn execute(&mut self, ctx: &mut OperatorContext) -> OperatorResult;
-    fn invoke(&mut self, ctx: &mut OperatorContext) -> OperatorResult;
-}
-
-struct ConcreteFactory<O: Operator + Default>(std::marker::PhantomData<O>);
-
-impl<O: Operator + Default> OperatorFactory for ConcreteFactory<O> {
-    fn id(&self) -> &str {
-        O::ID
-    }
-    fn label(&self) -> &str {
-        O::LABEL
-    }
-    fn description(&self) -> &str {
-        O::DESCRIPTION
-    }
-    fn create(&self) -> Box<dyn OperatorInstance> {
-        Box::new(O::default())
-    }
-}
-
-impl<O: Operator> OperatorInstance for O {
-    fn poll(&self, ctx: &OperatorContext) -> bool {
-        Operator::poll(self, ctx)
-    }
-    fn execute(&mut self, ctx: &mut OperatorContext) -> OperatorResult {
-        Operator::execute(self, ctx)
-    }
-    fn invoke(&mut self, ctx: &mut OperatorContext) -> OperatorResult {
-        Operator::invoke(self, ctx)
-    }
-}
-
-#[derive(Resource, Default)]
-pub struct OperatorRegistry {
-    factories: HashMap<String, Box<dyn OperatorFactory>>,
-}
-
-impl OperatorRegistry {
-    pub fn register<O: Operator + Default>(&mut self) {
-        self.factories.insert(
-            O::ID.to_string(),
-            Box::new(ConcreteFactory::<O>(std::marker::PhantomData)),
-        );
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &str)> {
-        self.factories
-            .values()
-            .map(|f| (f.id(), f.label(), f.description()))
-    }
-
-    pub fn create(&self, id: &str) -> Option<Box<dyn OperatorInstance>> {
-        self.factories.get(id).map(|f| f.create())
-    }
-}
-
-#[derive(Resource, Default)]
-pub struct KeybindRegistry {
-    bindings: HashMap<KeyCombo, String>,
-}
-
-impl KeybindRegistry {
-    pub fn bind(&mut self, keys: KeyCombo, operator_id: String) {
-        self.bindings.insert(keys, operator_id);
-    }
-
-    pub fn lookup(&self, keys: &KeyCombo) -> Option<&str> {
-        self.bindings.get(keys).map(|s| s.as_str())
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&KeyCombo, &str)> {
-        self.bindings.iter().map(|(k, v)| (k, v.as_str()))
-    }
-}
-
-#[derive(Clone, Hash, Eq, PartialEq)]
-pub struct KeyCombo {
-    pub key: KeyCode,
-    pub modifiers: Modifiers,
-}
-
-#[derive(Clone, Copy, Hash, Eq, PartialEq, Default)]
-pub struct Modifiers {
-    pub ctrl: bool,
-    pub shift: bool,
-    pub alt: bool,
-}
-
-impl KeyCombo {
-    pub fn new(key: KeyCode) -> Self {
-        Self {
-            key,
-            modifiers: Modifiers::default(),
-        }
-    }
-
-    pub fn ctrl(mut self) -> Self {
-        self.modifiers.ctrl = true;
-        self
-    }
-
-    pub fn shift(mut self) -> Self {
-        self.modifiers.shift = true;
-        self
-    }
-
-    pub fn alt(mut self) -> Self {
-        self.modifiers.alt = true;
-        self
-    }
-}
 
 #[derive(Resource, Default)]
 pub struct PanelExtensionRegistry {
@@ -135,6 +17,17 @@ pub struct PanelExtensionRegistry {
 impl PanelExtensionRegistry {
     pub fn add(&mut self, panel_id: String, section: SectionBuildFn) {
         self.extensions.entry(panel_id).or_default().push(section);
+    }
+
+    pub fn remove(&mut self, panel_id: &str, section_index: usize) {
+        if let Some(sections) = self.extensions.get_mut(panel_id) {
+            if section_index < sections.len() {
+                sections.remove(section_index);
+            }
+            if sections.is_empty() {
+                self.extensions.remove(panel_id);
+            }
+        }
     }
 
     pub fn get(&self, panel_id: &str) -> &[SectionBuildFn] {

--- a/crates/jackdaw_api/src/registries.rs
+++ b/crates/jackdaw_api/src/registries.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+
+use crate::SectionBuildFn;
+use crate::operator::{Operator, OperatorContext, OperatorResult};
+
+trait OperatorFactory: Send + Sync {
+    fn id(&self) -> &str;
+    fn label(&self) -> &str;
+    fn description(&self) -> &str;
+    fn create(&self) -> Box<dyn OperatorInstance>;
+}
+
+pub trait OperatorInstance: Send + Sync {
+    fn poll(&self, ctx: &OperatorContext) -> bool;
+    fn execute(&mut self, ctx: &mut OperatorContext) -> OperatorResult;
+    fn invoke(&mut self, ctx: &mut OperatorContext) -> OperatorResult;
+}
+
+struct ConcreteFactory<O: Operator + Default>(std::marker::PhantomData<O>);
+
+impl<O: Operator + Default> OperatorFactory for ConcreteFactory<O> {
+    fn id(&self) -> &str {
+        O::ID
+    }
+    fn label(&self) -> &str {
+        O::LABEL
+    }
+    fn description(&self) -> &str {
+        O::DESCRIPTION
+    }
+    fn create(&self) -> Box<dyn OperatorInstance> {
+        Box::new(O::default())
+    }
+}
+
+impl<O: Operator> OperatorInstance for O {
+    fn poll(&self, ctx: &OperatorContext) -> bool {
+        Operator::poll(self, ctx)
+    }
+    fn execute(&mut self, ctx: &mut OperatorContext) -> OperatorResult {
+        Operator::execute(self, ctx)
+    }
+    fn invoke(&mut self, ctx: &mut OperatorContext) -> OperatorResult {
+        Operator::invoke(self, ctx)
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct OperatorRegistry {
+    factories: HashMap<String, Box<dyn OperatorFactory>>,
+}
+
+impl OperatorRegistry {
+    pub fn register<O: Operator + Default>(&mut self) {
+        self.factories.insert(
+            O::ID.to_string(),
+            Box::new(ConcreteFactory::<O>(std::marker::PhantomData)),
+        );
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &str)> {
+        self.factories
+            .values()
+            .map(|f| (f.id(), f.label(), f.description()))
+    }
+
+    pub fn create(&self, id: &str) -> Option<Box<dyn OperatorInstance>> {
+        self.factories.get(id).map(|f| f.create())
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct KeybindRegistry {
+    bindings: HashMap<KeyCombo, String>,
+}
+
+impl KeybindRegistry {
+    pub fn bind(&mut self, keys: KeyCombo, operator_id: String) {
+        self.bindings.insert(keys, operator_id);
+    }
+
+    pub fn lookup(&self, keys: &KeyCombo) -> Option<&str> {
+        self.bindings.get(keys).map(|s| s.as_str())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&KeyCombo, &str)> {
+        self.bindings.iter().map(|(k, v)| (k, v.as_str()))
+    }
+}
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct KeyCombo {
+    pub key: KeyCode,
+    pub modifiers: Modifiers,
+}
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Default)]
+pub struct Modifiers {
+    pub ctrl: bool,
+    pub shift: bool,
+    pub alt: bool,
+}
+
+impl KeyCombo {
+    pub fn new(key: KeyCode) -> Self {
+        Self {
+            key,
+            modifiers: Modifiers::default(),
+        }
+    }
+
+    pub fn ctrl(mut self) -> Self {
+        self.modifiers.ctrl = true;
+        self
+    }
+
+    pub fn shift(mut self) -> Self {
+        self.modifiers.shift = true;
+        self
+    }
+
+    pub fn alt(mut self) -> Self {
+        self.modifiers.alt = true;
+        self
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct PanelExtensionRegistry {
+    extensions: HashMap<String, Vec<SectionBuildFn>>,
+}
+
+impl PanelExtensionRegistry {
+    pub fn add(&mut self, panel_id: String, section: SectionBuildFn) {
+        self.extensions.entry(panel_id).or_default().push(section);
+    }
+
+    pub fn get(&self, panel_id: &str) -> &[SectionBuildFn] {
+        self.extensions
+            .get(panel_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+}

--- a/crates/jackdaw_commands/src/lib.rs
+++ b/crates/jackdaw_commands/src/lib.rs
@@ -34,6 +34,11 @@ impl CommandHistory {
             self.undo_stack.push(command);
         }
     }
+
+    pub fn push_executed(&mut self, command: Box<dyn EditorCommand>) {
+        self.undo_stack.push(command);
+        self.redo_stack.clear();
+    }
 }
 
 pub struct CommandGroup {

--- a/crates/jackdaw_node_graph/src/lib.rs
+++ b/crates/jackdaw_node_graph/src/lib.rs
@@ -85,7 +85,12 @@ impl Plugin for NodeGraphPlugin {
                 connection::update_pending_remove_markers,
                 // Keyboard.
                 interaction::handle_delete_key,
-                interaction::handle_undo_redo_keys,
+                // Note: undo/redo is handled globally by the main editor's
+                // `handle_undo_redo_keys` system against the same shared
+                // `CommandHistory`. Having a duplicate handler here caused
+                // Ctrl+Z to pop two commands at once (issue seen when drawing
+                // brushes + applying material: undo removed the material AND
+                // the last brush).
                 add_node_popover::handle_tab_quick_add,
                 add_node_popover::handle_popover_escape,
             ),

--- a/crates/jackdaw_panels/src/registry.rs
+++ b/crates/jackdaw_panels/src/registry.rs
@@ -27,6 +27,21 @@ impl WindowRegistry {
         self.windows.push(descriptor);
     }
 
+    /// Remove a window by id. Returns true if the window was found.
+    /// Rebuilds the id -> index mapping after removal.
+    pub fn unregister(&mut self, id: &str) -> bool {
+        let Some(idx) = self.index.remove(id) else {
+            return false;
+        };
+        self.windows.remove(idx);
+        // Re-index remaining entries since positions shifted.
+        self.index.clear();
+        for (i, w) in self.windows.iter().enumerate() {
+            self.index.insert(w.id.clone(), i);
+        }
+        true
+    }
+
     pub fn get(&self, id: &str) -> Option<&DockWindowDescriptor> {
         self.index.get(id).map(|&i| &self.windows[i])
     }

--- a/crates/jackdaw_panels/src/workspace.rs
+++ b/crates/jackdaw_panels/src/workspace.rs
@@ -31,6 +31,20 @@ impl WorkspaceRegistry {
         self.workspaces.push(descriptor);
     }
 
+    /// Remove a workspace by id. If it was the active workspace, falls
+    /// back to the first remaining workspace (or `None` if none remain).
+    /// Returns true if a workspace was removed.
+    pub fn unregister(&mut self, id: &str) -> bool {
+        let Some(idx) = self.workspaces.iter().position(|w| w.id == id) else {
+            return false;
+        };
+        self.workspaces.remove(idx);
+        if self.active.as_deref() == Some(id) {
+            self.active = self.workspaces.first().map(|w| w.id.clone());
+        }
+        true
+    }
+
     pub fn get(&self, id: &str) -> Option<&WorkspaceDescriptor> {
         self.workspaces.iter().find(|w| w.id == id)
     }

--- a/examples/sample_extension/Cargo.toml
+++ b/examples/sample_extension/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sample_extension"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+bevy.workspace = true
+bevy_enhanced_input.workspace = true
+jackdaw_api.workspace = true
+jackdaw_commands.workspace = true

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -1,0 +1,84 @@
+//! Sample extension demonstrating the jackdaw_api v2 surface.
+//!
+//! Registers:
+//! - A "Hello Extension" dock window (plain UI, no input).
+//! - A `HelloOp` operator bound to `F9` via a BEI context owned by this plugin.
+//!
+//! Toggling this plugin off via `File > Plugins...` should make both the
+//! window entry disappear from the add-window popup and the keybind go dead.
+
+use std::sync::Arc;
+
+use bevy::ecs::system::SystemId;
+use bevy::prelude::*;
+use bevy_enhanced_input::prelude::*;
+use jackdaw_api::prelude::*;
+
+pub struct SampleExtension;
+
+impl JackdawExtension for SampleExtension {
+    fn name(&self) -> &str {
+        "sample"
+    }
+
+    fn register_input_contexts(&self, app: &mut App) {
+        app.add_input_context::<SampleContext>();
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        // 1. Register the dock window (same behavior as the v1 sample).
+        ctx.register_window(WindowDescriptor {
+            id: "sample.hello".into(),
+            name: "Hello Extension".into(),
+            icon: None,
+            default_area: None,
+            priority: None,
+            build: Arc::new(build_hello_panel),
+        });
+
+        // 2. Register the operator — internally registers the execute
+        // system, stores an OperatorEntity as a child of the extension
+        // entity, and spawns a Fire<HelloOp> observer that dispatches it.
+        ctx.register_operator::<HelloOp>();
+
+        // 3. Spawn a BEI context entity with an Action<HelloOp> bound to
+        // F9. The context *type* was registered once at startup via
+        // `register_input_contexts`; this is just the runtime entity that
+        // holds the action bindings. Spawned via ctx.spawn so it's a
+        // child of the extension entity (cleaned up on disable).
+        ctx.spawn((
+            SampleContext,
+            actions!(SampleContext[
+                (Action::<HelloOp>::new(), bindings![KeyCode::F9]),
+            ]),
+        ));
+    }
+}
+
+fn build_hello_panel(world: &mut World, parent: Entity) {
+    world.spawn((ChildOf(parent), Text::new("Hello from an extension!")));
+}
+
+/// BEI input context. One per extension.
+#[derive(Component, Default)]
+pub struct SampleContext;
+
+/// Operator bound to F9. Emits a log message.
+#[derive(Default, InputAction)]
+#[action_output(bool)]
+pub struct HelloOp;
+
+impl Operator for HelloOp {
+    const ID: &'static str = "sample.hello";
+    const LABEL: &'static str = "Hello";
+    const DESCRIPTION: &'static str = "Logs a hello message";
+
+    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
+        commands.register_system(hello_op_system)
+    }
+}
+
+fn hello_op_system() -> OperatorResult {
+    info!("Hello from the sample extension operator!");
+    OperatorResult::Finished
+}

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -4,8 +4,9 @@
 //! - A "Hello Extension" dock window (plain UI, no input).
 //! - A `HelloOp` operator bound to `F9` via a BEI context owned by this plugin.
 //!
-//! Toggling this plugin off via `File > Plugins...` should make both the
-//! window entry disappear from the add-window popup and the keybind go dead.
+//! Toggling this extension off via `File > Extensions...` should make both
+//! the window entry disappear from the add-window popup and the keybind go
+//! dead.
 
 use std::sync::Arc;
 

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -37,9 +37,9 @@ impl JackdawExtension for SampleExtension {
             build: Arc::new(build_hello_panel),
         });
 
-        // 2. Register the operator — internally registers the execute
-        // system, stores an OperatorEntity as a child of the extension
-        // entity, and spawns a Fire<HelloOp> observer that dispatches it.
+        // 2. Register the operator. This registers the execute system,
+        // stores an OperatorEntity as a child of the extension entity,
+        // and spawns a Fire<HelloOp> observer that dispatches it.
         ctx.register_operator::<HelloOp>();
 
         // 3. Spawn a BEI context entity with an Action<HelloOp> bound to

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -1,12 +1,6 @@
-//! Sample extension demonstrating the jackdaw_api v2 surface.
-//!
-//! Registers:
-//! - A "Hello Extension" dock window (plain UI, no input).
-//! - A `HelloOp` operator bound to `F9` via a BEI context owned by this plugin.
-//!
-//! Toggling this extension off via `File > Extensions...` should make both
-//! the window entry disappear from the add-window popup and the keybind go
-//! dead.
+//! Sample extension. Registers a dock window and a `HelloOp` operator
+//! bound to F9. Disabling it in File > Extensions should remove the
+//! window entry and kill the keybind.
 
 use std::sync::Arc;
 
@@ -27,7 +21,6 @@ impl JackdawExtension for SampleExtension {
     }
 
     fn register(&self, ctx: &mut ExtensionContext) {
-        // 1. Register the dock window (same behavior as the v1 sample).
         ctx.register_window(WindowDescriptor {
             id: "sample.hello".into(),
             name: "Hello Extension".into(),
@@ -37,16 +30,8 @@ impl JackdawExtension for SampleExtension {
             build: Arc::new(build_hello_panel),
         });
 
-        // 2. Register the operator. This registers the execute system,
-        // stores an OperatorEntity as a child of the extension entity,
-        // and spawns a Fire<HelloOp> observer that dispatches it.
         ctx.register_operator::<HelloOp>();
 
-        // 3. Spawn a BEI context entity with an Action<HelloOp> bound to
-        // F9. The context *type* was registered once at startup via
-        // `register_input_contexts`; this is just the runtime entity that
-        // holds the action bindings. Spawned via ctx.spawn so it's a
-        // child of the extension entity (cleaned up on disable).
         ctx.spawn((
             SampleContext,
             actions!(SampleContext[
@@ -60,11 +45,9 @@ fn build_hello_panel(world: &mut World, parent: Entity) {
     world.spawn((ChildOf(parent), Text::new("Hello from an extension!")));
 }
 
-/// BEI input context. One per extension.
 #[derive(Component, Default)]
 pub struct SampleContext;
 
-/// Operator bound to F9. Emits a log message.
 #[derive(Default, InputAction)]
 #[action_output(bool)]
 pub struct HelloOp;

--- a/examples/viewable_camera_extension/Cargo.toml
+++ b/examples/viewable_camera_extension/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "viewable_camera_extension"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+bevy.workspace = true
+bevy_enhanced_input.workspace = true
+jackdaw_api.workspace = true
+jackdaw_commands.workspace = true

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -1,0 +1,365 @@
+//! Viewable Camera extension.
+//!
+//! Demonstrates a more substantial extension that integrates with the
+//! editor's viewport camera and the undo/redo system:
+//!
+//! - **F6** places a "viewable" camera entity at the current editor camera
+//!   position. The placement is undoable via a custom `EditorCommand`.
+//! - **F7** toggles between the editor view and looking *through* the
+//!   selected viewable camera (or the only one, if there's just one).
+//!   Preview is a view state, not scene data, so it is intentionally NOT
+//!   recorded in the undo history.
+//!
+//! Undo / redo flow:
+//!
+//! 1. Press F6 → camera spawned at P0, undo stack: `[Place Viewable Camera]`
+//! 2. Select the camera in the hierarchy, drag it with the gizmo to P1 →
+//!    Jackdaw's existing `SetTransform` command is pushed.
+//! 3. Drag to P2 → another `SetTransform` is pushed.
+//! 4. Press F7 → you're now looking through the camera at P2. No history
+//!    entry created.
+//! 5. Press F7 again → back to the editor view.
+//! 6. Ctrl+Z twice → camera returns to P0 (the two moves undo).
+//! 7. Ctrl+Z → camera despawns (placement undoes). If preview was active,
+//!    the `Remove<ViewableCamera>` observer automatically exits preview so
+//!    the editor view snaps back on.
+
+use bevy::camera::RenderTarget;
+use bevy::ecs::system::SystemId;
+use bevy::prelude::*;
+use bevy_enhanced_input::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_commands::EditorCommand;
+
+// ============================================================================
+// Extension
+// ============================================================================
+
+pub struct ViewableCameraExtension;
+
+impl JackdawExtension for ViewableCameraExtension {
+    fn name(&self) -> &str {
+        "viewable_camera"
+    }
+
+    fn register_input_contexts(&self, app: &mut App) {
+        app.add_input_context::<ViewableCameraContext>();
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.world().init_resource::<CameraPreviewState>();
+
+        ctx.register_operator::<PlaceViewableCamera>();
+        ctx.register_operator::<ToggleCameraPreview>();
+
+        // Menu entries — contribute into the editor's Add menu. Menu
+        // entries dispatch through the same pipeline as keybinds, so
+        // clicking "Add > Viewable Camera" still produces one undo entry.
+        ctx.register_menu_entry(MenuEntryDescriptor {
+            menu: "Add".into(),
+            label: "Viewable Camera".into(),
+            operator_id: PlaceViewableCamera::ID,
+        });
+
+        // BEI context + action bindings. Spawned as a child of the
+        // extension entity so both are torn down on disable.
+        ctx.spawn((
+            ViewableCameraContext,
+            actions!(ViewableCameraContext[
+                (Action::<PlaceViewableCamera>::new(), bindings![KeyCode::F6]),
+                (Action::<ToggleCameraPreview>::new(), bindings![KeyCode::F7]),
+            ]),
+        ));
+
+        // Observer: if the currently-previewed camera gets despawned
+        // (e.g. the user undoes the placement while preview is active),
+        // exit preview so the viewport falls back to the editor camera.
+        let ext_entity = ctx.entity();
+        let observer = Observer::new(
+            move |trigger: On<Remove, ViewableCamera>,
+                  mut state: ResMut<CameraPreviewState>,
+                  mut commands: Commands| {
+                if state.active == Some(trigger.event_target()) {
+                    state.active = None;
+                    commands.queue(|world: &mut World| {
+                        restore_editor_camera(world);
+                    });
+                }
+            },
+        );
+        ctx.world().spawn((observer, ChildOf(ext_entity)));
+    }
+}
+
+// ============================================================================
+// Components, resources, markers
+// ============================================================================
+
+/// BEI context component. One per extension gives key-binding isolation.
+#[derive(Component, Default)]
+pub struct ViewableCameraContext;
+
+/// Marker component on camera entities created by this extension. These
+/// are scene entities (serialized with the scene), not editor-local
+/// machinery.
+#[derive(Component, Default, Reflect)]
+pub struct ViewableCamera;
+
+/// Editor-local state tracking the currently-previewed camera, if any.
+/// Not saved to the scene — reset on editor restart.
+#[derive(Resource, Default)]
+struct CameraPreviewState {
+    /// The `ViewableCamera` entity currently being previewed.
+    active: Option<Entity>,
+    /// Saved (editor-camera entity, render target) captured when entering
+    /// preview so it can be restored on exit.
+    saved: Option<(Entity, RenderTarget)>,
+}
+
+// ============================================================================
+// Operators
+// ============================================================================
+
+/// Place a new viewable camera at the editor camera's current position.
+/// One-shot, undoable.
+#[derive(Default, InputAction)]
+#[action_output(bool)]
+pub struct PlaceViewableCamera;
+
+impl Operator for PlaceViewableCamera {
+    const ID: &'static str = "viewable_camera.place";
+    const LABEL: &'static str = "Place Viewable Camera";
+    const DESCRIPTION: &'static str = "Place a camera at the viewport position";
+
+    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
+        commands.register_system(place_viewable_camera)
+    }
+}
+
+fn place_viewable_camera(world: &mut World) -> OperatorResult {
+    // Copy the editor camera's transform so the new camera starts where
+    // you're already looking — makes "look through" visually intuitive
+    // on the first toggle.
+    let spawn_transform = find_editor_camera(world)
+        .and_then(|e| world.get::<Transform>(e).copied())
+        .unwrap_or_default();
+
+    let mut cmd: Box<dyn EditorCommand> = Box::new(PlaceViewableCameraCommand {
+        spawned: None,
+        transform: spawn_transform,
+    });
+    cmd.execute(world);
+    world.resource_mut::<OperatorCommandBuffer>().record(cmd);
+    OperatorResult::Finished
+}
+
+/// Toggle "look through the viewable camera" vs. the editor view. Not
+/// undoable — it's a view state, not a scene edit.
+#[derive(Default, InputAction)]
+#[action_output(bool)]
+pub struct ToggleCameraPreview;
+
+impl Operator for ToggleCameraPreview {
+    const ID: &'static str = "viewable_camera.toggle_preview";
+    const LABEL: &'static str = "Toggle Camera Preview";
+    const DESCRIPTION: &'static str = "Look through the selected viewable camera";
+
+    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
+        commands.register_system(toggle_preview)
+    }
+}
+
+fn toggle_preview(world: &mut World) -> OperatorResult {
+    let currently_active = world.resource::<CameraPreviewState>().active;
+    if currently_active.is_some() {
+        restore_editor_camera(world);
+        info!("Exited viewable-camera preview");
+    } else {
+        let Some(target) = pick_preview_target(world) else {
+            warn!("No viewable camera to preview; press F6 to place one first");
+            return OperatorResult::Cancelled;
+        };
+        match enter_preview(world, target) {
+            Ok(()) => info!("Entered preview through viewable camera {target:?}"),
+            Err(reason) => warn!("Preview failed: {reason}"),
+        }
+    }
+    OperatorResult::Finished
+}
+
+// ============================================================================
+// Preview swap — RenderTarget handoff between editor cam and viewable cam
+// ============================================================================
+
+/// Walk the world looking for a camera that is currently acting as the
+/// editor viewport: one with a `Camera3d`, an `Image` render target, and
+/// `is_active = true`, that is NOT a viewable camera.
+fn find_editor_camera(world: &mut World) -> Option<Entity> {
+    let mut q = world.query_filtered::<
+        (Entity, &Camera, &RenderTarget),
+        (With<Camera3d>, Without<ViewableCamera>),
+    >();
+    for (entity, camera, target) in q.iter(world) {
+        if camera.is_active && matches!(target, RenderTarget::Image(_)) {
+            return Some(entity);
+        }
+    }
+    None
+}
+
+/// Pick which viewable camera to preview. Preference order:
+/// 1. Primary selection if it's a viewable camera.
+/// 2. The only viewable camera in the scene, if there's exactly one.
+/// 3. None.
+fn pick_preview_target(world: &mut World) -> Option<Entity> {
+    let cams: Vec<Entity> = world
+        .query_filtered::<Entity, With<ViewableCamera>>()
+        .iter(world)
+        .collect();
+    if cams.len() == 1 {
+        return Some(cams[0]);
+    }
+    // Fall back to first matching entity. (Extending this to honour the
+    // editor's `Selection` resource would require depending on the main
+    // jackdaw crate; the simple rule above is enough for the demo.)
+    cams.first().copied()
+}
+
+fn enter_preview(world: &mut World, target: Entity) -> Result<(), &'static str> {
+    let Some(editor_cam) = find_editor_camera(world) else {
+        return Err("couldn't find the editor viewport camera");
+    };
+    let render_target = world
+        .get::<RenderTarget>(editor_cam)
+        .cloned()
+        .ok_or("editor camera has no RenderTarget")?;
+
+    // Disable the editor camera.
+    if let Some(mut c) = world.get_mut::<Camera>(editor_cam) {
+        c.is_active = false;
+    }
+
+    // Hand its render target to the viewable camera and activate it.
+    if let Ok(mut ec) = world.get_entity_mut(target) {
+        ec.insert(render_target.clone());
+    }
+    if let Some(mut c) = world.get_mut::<Camera>(target) {
+        c.is_active = true;
+    }
+    // `camera_system` (Bevy's camera projection updater) only recomputes
+    // `camera.computed.target_info` when the Projection is marked changed,
+    // the viewport size differs, or the underlying image/window changes.
+    // Replacing the `RenderTarget` component via `insert` does none of
+    // those — so without this touch the viewable camera keeps a stale
+    // `target_info` from its previous RenderTarget (1x1 for our
+    // `RenderTarget::None` default), renders into a 1-pixel region, and
+    // the viewport appears empty. Poking Projection forces a recompute
+    // against the freshly-inserted Image target.
+    if let Some(mut proj) = world.get_mut::<Projection>(target) {
+        proj.set_changed();
+    }
+
+    let mut state = world.resource_mut::<CameraPreviewState>();
+    state.active = Some(target);
+    state.saved = Some((editor_cam, render_target));
+    Ok(())
+}
+
+/// Exit preview: revoke the render target from the viewable camera and
+/// re-activate the editor camera. Safe to call even if we're not
+/// currently previewing.
+fn restore_editor_camera(world: &mut World) {
+    let Some((editor_cam, _target)) = world.resource_mut::<CameraPreviewState>().saved.take()
+    else {
+        return;
+    };
+    let active = world.resource_mut::<CameraPreviewState>().active.take();
+
+    if let Some(preview) = active {
+        if let Ok(mut ec) = world.get_entity_mut(preview) {
+            // Replace the Image target with None rather than removing the
+            // component outright — Camera's required-components contract
+            // expects RenderTarget to exist, and leaving an Image target on
+            // an inactive camera can still trigger ambiguity warnings when
+            // the preview is re-entered.
+            ec.insert(RenderTarget::None {
+                size: UVec2::splat(1),
+            });
+        }
+        if let Some(mut c) = world.get_mut::<Camera>(preview) {
+            c.is_active = false;
+        }
+        // Match the Projection poke in `enter_preview` so Bevy's
+        // `camera_system` notices the RenderTarget swap. Not strictly
+        // required while the camera is inactive, but keeps both swap
+        // directions symmetric and avoids stale `target_info` if another
+        // system activates the camera before the next preview toggle.
+        if let Some(mut proj) = world.get_mut::<Projection>(preview) {
+            proj.set_changed();
+        }
+    }
+
+    if let Some(mut c) = world.get_mut::<Camera>(editor_cam) {
+        c.is_active = true;
+    }
+}
+
+// ============================================================================
+// Custom EditorCommand: spawn / despawn a viewable camera
+// ============================================================================
+
+/// Undoable placement of a viewable camera.
+///
+/// `execute` spawns a fresh camera entity with the stored transform and
+/// caches the new id. `undo` despawns whatever was last spawned. A redo
+/// (re-executing after undo) spawns again with a new id — downstream
+/// references to the old id are invalid, but that's fine for the scene
+/// tree and inspector which both resolve by id on each frame.
+struct PlaceViewableCameraCommand {
+    spawned: Option<Entity>,
+    transform: Transform,
+}
+
+impl EditorCommand for PlaceViewableCameraCommand {
+    fn execute(&mut self, world: &mut World) {
+        let entity = world
+            .spawn((
+                Name::new("Viewable Camera"),
+                ViewableCamera,
+                Camera3d::default(),
+                Camera {
+                    // is_active = false until we hand it the render target
+                    // via toggle preview. Keeps it from competing with the
+                    // editor viewport camera for rendering.
+                    is_active: false,
+                    order: -1,
+                    ..default()
+                },
+                // Explicit None target. Without this, `Camera`'s required
+                // components default to `RenderTarget::Window(Primary)`,
+                // which — if is_active ever flips true by accident — would
+                // render the scene on top of the editor UI. None keeps the
+                // camera inert until `enter_preview` swaps in the viewport
+                // image target.
+                RenderTarget::None {
+                    size: UVec2::splat(1),
+                },
+                self.transform,
+                Visibility::default(),
+            ))
+            .id();
+        self.spawned = Some(entity);
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        if let Some(entity) = self.spawned.take() {
+            if let Ok(ec) = world.get_entity_mut(entity) {
+                ec.despawn();
+            }
+        }
+    }
+
+    fn description(&self) -> &str {
+        "Place Viewable Camera"
+    }
+}

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -12,16 +12,16 @@
 //!
 //! Undo / redo flow:
 //!
-//! 1. Press F6 → camera spawned at P0, undo stack: `[Place Viewable Camera]`
-//! 2. Select the camera in the hierarchy, drag it with the gizmo to P1 →
+//! 1. Press F6. Camera spawned at P0; undo stack: `[Place Viewable Camera]`.
+//! 2. Select the camera in the hierarchy, drag it with the gizmo to P1.
 //!    Jackdaw's existing `SetTransform` command is pushed.
-//! 3. Drag to P2 → another `SetTransform` is pushed.
-//! 4. Press F7 → you're now looking through the camera at P2. No history
-//!    entry created.
-//! 5. Press F7 again → back to the editor view.
-//! 6. Ctrl+Z twice → camera returns to P0 (the two moves undo).
-//! 7. Ctrl+Z → camera despawns (placement undoes). If preview was active,
-//!    the `Remove<ViewableCamera>` observer automatically exits preview so
+//! 3. Drag to P2. Another `SetTransform` is pushed.
+//! 4. Press F7. The viewport now looks through the camera at P2. No
+//!    history entry is created.
+//! 5. Press F7 again. Back to the editor view.
+//! 6. Ctrl+Z twice. Camera returns to P0 (the two moves undo).
+//! 7. Ctrl+Z. Camera despawns (placement undoes). If preview was active,
+//!    the `Remove<ViewableCamera>` observer exits preview automatically so
 //!    the editor view snaps back on.
 
 use bevy::camera::RenderTarget;
@@ -52,9 +52,9 @@ impl JackdawExtension for ViewableCameraExtension {
         ctx.register_operator::<PlaceViewableCamera>();
         ctx.register_operator::<ToggleCameraPreview>();
 
-        // Menu entries — contribute into the editor's Add menu. Menu
-        // entries dispatch through the same pipeline as keybinds, so
-        // clicking "Add > Viewable Camera" still produces one undo entry.
+        // Contribute to the editor's Add menu. Menu entries dispatch
+        // through the same pipeline as keybinds, so clicking
+        // "Add > Viewable Camera" still produces exactly one undo entry.
         ctx.register_menu_entry(MenuEntryDescriptor {
             menu: "Add".into(),
             label: "Viewable Camera".into(),
@@ -106,7 +106,7 @@ pub struct ViewableCameraContext;
 pub struct ViewableCamera;
 
 /// Editor-local state tracking the currently-previewed camera, if any.
-/// Not saved to the scene — reset on editor restart.
+/// Not saved to the scene; reset on editor restart.
 #[derive(Resource, Default)]
 struct CameraPreviewState {
     /// The `ViewableCamera` entity currently being previewed.
@@ -138,8 +138,8 @@ impl Operator for PlaceViewableCamera {
 
 fn place_viewable_camera(world: &mut World) -> OperatorResult {
     // Copy the editor camera's transform so the new camera starts where
-    // you're already looking — makes "look through" visually intuitive
-    // on the first toggle.
+    // the user is already looking. That makes "look through" visually
+    // intuitive on the first toggle.
     let spawn_transform = find_editor_camera(world)
         .and_then(|e| world.get::<Transform>(e).copied())
         .unwrap_or_default();
@@ -154,7 +154,7 @@ fn place_viewable_camera(world: &mut World) -> OperatorResult {
 }
 
 /// Toggle "look through the viewable camera" vs. the editor view. Not
-/// undoable — it's a view state, not a scene edit.
+/// undoable: preview is view state, not a scene edit.
 #[derive(Default, InputAction)]
 #[action_output(bool)]
 pub struct ToggleCameraPreview;
@@ -188,7 +188,7 @@ fn toggle_preview(world: &mut World) -> OperatorResult {
 }
 
 // ============================================================================
-// Preview swap — RenderTarget handoff between editor cam and viewable cam
+// Preview swap: RenderTarget handoff between editor cam and viewable cam
 // ============================================================================
 
 /// Walk the world looking for a camera that is currently acting as the
@@ -246,15 +246,15 @@ fn enter_preview(world: &mut World, target: Entity) -> Result<(), &'static str> 
     if let Some(mut c) = world.get_mut::<Camera>(target) {
         c.is_active = true;
     }
-    // `camera_system` (Bevy's camera projection updater) only recomputes
-    // `camera.computed.target_info` when the Projection is marked changed,
-    // the viewport size differs, or the underlying image/window changes.
-    // Replacing the `RenderTarget` component via `insert` does none of
-    // those — so without this touch the viewable camera keeps a stale
-    // `target_info` from its previous RenderTarget (1x1 for our
-    // `RenderTarget::None` default), renders into a 1-pixel region, and
-    // the viewport appears empty. Poking Projection forces a recompute
-    // against the freshly-inserted Image target.
+    // Bevy's `camera_system` only recomputes `camera.computed.target_info`
+    // when the Projection is marked changed, the viewport size differs,
+    // or the underlying image/window changes. Replacing `RenderTarget`
+    // via `insert` triggers none of those, so without this touch the
+    // viewable camera keeps a stale `target_info` from its previous
+    // RenderTarget (1x1 for the `RenderTarget::None` default), renders
+    // into a 1-pixel region, and the viewport appears empty. Marking
+    // Projection changed forces a recompute against the freshly-inserted
+    // Image target.
     if let Some(mut proj) = world.get_mut::<Projection>(target) {
         proj.set_changed();
     }
@@ -277,11 +277,11 @@ fn restore_editor_camera(world: &mut World) {
 
     if let Some(preview) = active {
         if let Ok(mut ec) = world.get_entity_mut(preview) {
-            // Replace the Image target with None rather than removing the
-            // component outright — Camera's required-components contract
-            // expects RenderTarget to exist, and leaving an Image target on
-            // an inactive camera can still trigger ambiguity warnings when
-            // the preview is re-entered.
+            // Replace the Image target with None rather than removing
+            // the component outright. `Camera`'s required-components
+            // contract expects `RenderTarget` to exist, and leaving an
+            // Image target on an inactive camera can still trigger
+            // ambiguity warnings when preview is re-entered.
             ec.insert(RenderTarget::None {
                 size: UVec2::splat(1),
             });
@@ -311,10 +311,10 @@ fn restore_editor_camera(world: &mut World) {
 /// Undoable placement of a viewable camera.
 ///
 /// `execute` spawns a fresh camera entity with the stored transform and
-/// caches the new id. `undo` despawns whatever was last spawned. A redo
-/// (re-executing after undo) spawns again with a new id — downstream
-/// references to the old id are invalid, but that's fine for the scene
-/// tree and inspector which both resolve by id on each frame.
+/// caches the new id. `undo` despawns whatever was last spawned. Redoing
+/// (re-executing after undo) spawns again with a new id. Downstream
+/// references to the old id become invalid, which is fine for the scene
+/// tree and inspector: both resolve entities by id on every frame.
 struct PlaceViewableCameraCommand {
     spawned: Option<Entity>,
     transform: Transform,
@@ -335,12 +335,13 @@ impl EditorCommand for PlaceViewableCameraCommand {
                     order: -1,
                     ..default()
                 },
-                // Explicit None target. Without this, `Camera`'s required
-                // components default to `RenderTarget::Window(Primary)`,
-                // which — if is_active ever flips true by accident — would
-                // render the scene on top of the editor UI. None keeps the
-                // camera inert until `enter_preview` swaps in the viewport
-                // image target.
+                // Explicit `None` target. Without this, `Camera`'s
+                // required components default to
+                // `RenderTarget::Window(Primary)`. If `is_active` ever
+                // flips true by accident, that would render the scene on
+                // top of the editor UI. `None` keeps the camera inert
+                // until `enter_preview` swaps in the viewport image
+                // target.
                 RenderTarget::None {
                     size: UVec2::splat(1),
                 },
@@ -352,10 +353,10 @@ impl EditorCommand for PlaceViewableCameraCommand {
     }
 
     fn undo(&mut self, world: &mut World) {
-        if let Some(entity) = self.spawned.take() {
-            if let Ok(ec) = world.get_entity_mut(entity) {
-                ec.despawn();
-            }
+        if let Some(entity) = self.spawned.take()
+            && let Ok(ec) = world.get_entity_mut(entity)
+        {
+            ec.despawn();
         }
     }
 

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -1,28 +1,10 @@
 //! Viewable Camera extension.
 //!
-//! Demonstrates a more substantial extension that integrates with the
-//! editor's viewport camera and the undo/redo system:
-//!
-//! - **F6** places a "viewable" camera entity at the current editor camera
-//!   position. The placement is undoable via a custom `EditorCommand`.
-//! - **F7** toggles between the editor view and looking *through* the
-//!   selected viewable camera (or the only one, if there's just one).
-//!   Preview is a view state, not scene data, so it is intentionally NOT
-//!   recorded in the undo history.
-//!
-//! Undo / redo flow:
-//!
-//! 1. Press F6. Camera spawned at P0; undo stack: `[Place Viewable Camera]`.
-//! 2. Select the camera in the hierarchy, drag it with the gizmo to P1.
-//!    Jackdaw's existing `SetTransform` command is pushed.
-//! 3. Drag to P2. Another `SetTransform` is pushed.
-//! 4. Press F7. The viewport now looks through the camera at P2. No
-//!    history entry is created.
-//! 5. Press F7 again. Back to the editor view.
-//! 6. Ctrl+Z twice. Camera returns to P0 (the two moves undo).
-//! 7. Ctrl+Z. Camera despawns (placement undoes). If preview was active,
-//!    the `Remove<ViewableCamera>` observer exits preview automatically so
-//!    the editor view snaps back on.
+//! - **F6**: place a viewable camera at the editor camera position.
+//!   Undoable via a custom `EditorCommand`.
+//! - **F7**: toggle between the editor view and looking through the
+//!   viewable camera. Preview is view state, not scene data, and is
+//!   not recorded in the undo history.
 
 use bevy::camera::RenderTarget;
 use bevy::ecs::system::SystemId;
@@ -30,10 +12,6 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 use jackdaw_commands::EditorCommand;
-
-// ============================================================================
-// Extension
-// ============================================================================
 
 pub struct ViewableCameraExtension;
 
@@ -52,17 +30,12 @@ impl JackdawExtension for ViewableCameraExtension {
         ctx.register_operator::<PlaceViewableCamera>();
         ctx.register_operator::<ToggleCameraPreview>();
 
-        // Contribute to the editor's Add menu. Menu entries dispatch
-        // through the same pipeline as keybinds, so clicking
-        // "Add > Viewable Camera" still produces exactly one undo entry.
         ctx.register_menu_entry(MenuEntryDescriptor {
             menu: "Add".into(),
             label: "Viewable Camera".into(),
             operator_id: PlaceViewableCamera::ID,
         });
 
-        // BEI context + action bindings. Spawned as a child of the
-        // extension entity so both are torn down on disable.
         ctx.spawn((
             ViewableCameraContext,
             actions!(ViewableCameraContext[
@@ -71,9 +44,9 @@ impl JackdawExtension for ViewableCameraExtension {
             ]),
         ));
 
-        // Observer: if the currently-previewed camera gets despawned
-        // (e.g. the user undoes the placement while preview is active),
-        // exit preview so the viewport falls back to the editor camera.
+        // Exit preview if the previewed camera gets despawned (e.g. the
+        // user undoes the placement while preview is active), so the
+        // viewport falls back to the editor camera.
         let ext_entity = ctx.entity();
         let observer = Observer::new(
             move |trigger: On<Remove, ViewableCamera>,
@@ -91,37 +64,26 @@ impl JackdawExtension for ViewableCameraExtension {
     }
 }
 
-// ============================================================================
-// Components, resources, markers
-// ============================================================================
-
-/// BEI context component. One per extension gives key-binding isolation.
+/// BEI context for this extension; gives key-binding isolation.
 #[derive(Component, Default)]
 pub struct ViewableCameraContext;
 
-/// Marker component on camera entities created by this extension. These
-/// are scene entities (serialized with the scene), not editor-local
-/// machinery.
+/// Marker on camera entities created by this extension. Scene data,
+/// not editor-local.
 #[derive(Component, Default, Reflect)]
 pub struct ViewableCamera;
 
-/// Editor-local state tracking the currently-previewed camera, if any.
-/// Not saved to the scene; reset on editor restart.
+/// Tracks the currently-previewed camera. Not saved to the scene.
 #[derive(Resource, Default)]
 struct CameraPreviewState {
-    /// The `ViewableCamera` entity currently being previewed.
     active: Option<Entity>,
-    /// Saved (editor-camera entity, render target) captured when entering
-    /// preview so it can be restored on exit.
+    /// `(editor_camera, its_render_target)` captured on enter so it can
+    /// be restored on exit.
     saved: Option<(Entity, RenderTarget)>,
 }
 
-// ============================================================================
-// Operators
-// ============================================================================
-
-/// Place a new viewable camera at the editor camera's current position.
-/// One-shot, undoable.
+/// Place a viewable camera at the editor camera's current position.
+/// Undoable.
 #[derive(Default, InputAction)]
 #[action_output(bool)]
 pub struct PlaceViewableCamera;
@@ -137,9 +99,8 @@ impl Operator for PlaceViewableCamera {
 }
 
 fn place_viewable_camera(world: &mut World) -> OperatorResult {
-    // Copy the editor camera's transform so the new camera starts where
-    // the user is already looking. That makes "look through" visually
-    // intuitive on the first toggle.
+    // Match the editor camera's transform so "look through" feels
+    // natural on the first toggle.
     let spawn_transform = find_editor_camera(world)
         .and_then(|e| world.get::<Transform>(e).copied())
         .unwrap_or_default();
@@ -153,8 +114,8 @@ fn place_viewable_camera(world: &mut World) -> OperatorResult {
     OperatorResult::Finished
 }
 
-/// Toggle "look through the viewable camera" vs. the editor view. Not
-/// undoable: preview is view state, not a scene edit.
+/// Toggle "look through the viewable camera" against the editor view.
+/// Preview is view state, not a scene edit, so it isn't undoable.
 #[derive(Default, InputAction)]
 #[action_output(bool)]
 pub struct ToggleCameraPreview;
@@ -187,13 +148,8 @@ fn toggle_preview(world: &mut World) -> OperatorResult {
     OperatorResult::Finished
 }
 
-// ============================================================================
-// Preview swap: RenderTarget handoff between editor cam and viewable cam
-// ============================================================================
-
-/// Walk the world looking for a camera that is currently acting as the
-/// editor viewport: one with a `Camera3d`, an `Image` render target, and
-/// `is_active = true`, that is NOT a viewable camera.
+/// Find the active editor-viewport camera: an active `Camera3d` with an
+/// `Image` render target that isn't one of ours.
 fn find_editor_camera(world: &mut World) -> Option<Entity> {
     let mut q = world.query_filtered::<
         (Entity, &Camera, &RenderTarget),
@@ -207,10 +163,10 @@ fn find_editor_camera(world: &mut World) -> Option<Entity> {
     None
 }
 
-/// Pick which viewable camera to preview. Preference order:
-/// 1. Primary selection if it's a viewable camera.
-/// 2. The only viewable camera in the scene, if there's exactly one.
-/// 3. None.
+/// Pick which viewable camera to preview: the only one if there is
+/// exactly one, otherwise the first one found. A richer rule honouring
+/// the editor's `Selection` resource would require depending on the
+/// main jackdaw crate.
 fn pick_preview_target(world: &mut World) -> Option<Entity> {
     let cams: Vec<Entity> = world
         .query_filtered::<Entity, With<ViewableCamera>>()
@@ -219,9 +175,6 @@ fn pick_preview_target(world: &mut World) -> Option<Entity> {
     if cams.len() == 1 {
         return Some(cams[0]);
     }
-    // Fall back to first matching entity. (Extending this to honour the
-    // editor's `Selection` resource would require depending on the main
-    // jackdaw crate; the simple rule above is enough for the demo.)
     cams.first().copied()
 }
 
@@ -246,15 +199,11 @@ fn enter_preview(world: &mut World, target: Entity) -> Result<(), &'static str> 
     if let Some(mut c) = world.get_mut::<Camera>(target) {
         c.is_active = true;
     }
-    // Bevy's `camera_system` only recomputes `camera.computed.target_info`
-    // when the Projection is marked changed, the viewport size differs,
-    // or the underlying image/window changes. Replacing `RenderTarget`
-    // via `insert` triggers none of those, so without this touch the
-    // viewable camera keeps a stale `target_info` from its previous
-    // RenderTarget (1x1 for the `RenderTarget::None` default), renders
-    // into a 1-pixel region, and the viewport appears empty. Marking
-    // Projection changed forces a recompute against the freshly-inserted
-    // Image target.
+    // Bevy's `camera_system` recomputes `target_info` only when
+    // Projection is marked changed, viewport size differs, or the
+    // underlying image/window changes. Replacing `RenderTarget` via
+    // `insert` triggers none of those, so without this the camera
+    // renders into the stale 1x1 target from spawn.
     if let Some(mut proj) = world.get_mut::<Projection>(target) {
         proj.set_changed();
     }
@@ -265,9 +214,8 @@ fn enter_preview(world: &mut World, target: Entity) -> Result<(), &'static str> 
     Ok(())
 }
 
-/// Exit preview: revoke the render target from the viewable camera and
-/// re-activate the editor camera. Safe to call even if we're not
-/// currently previewing.
+/// Hand the render target back to the editor camera. Safe to call when
+/// preview is already off.
 fn restore_editor_camera(world: &mut World) {
     let Some((editor_cam, _target)) = world.resource_mut::<CameraPreviewState>().saved.take()
     else {
@@ -277,11 +225,10 @@ fn restore_editor_camera(world: &mut World) {
 
     if let Some(preview) = active {
         if let Ok(mut ec) = world.get_entity_mut(preview) {
-            // Replace the Image target with None rather than removing
-            // the component outright. `Camera`'s required-components
-            // contract expects `RenderTarget` to exist, and leaving an
-            // Image target on an inactive camera can still trigger
-            // ambiguity warnings when preview is re-entered.
+            // `Camera` requires a `RenderTarget`, so swap to `None`
+            // rather than removing the component outright. Leaving the
+            // Image target on an inactive camera triggers ambiguity
+            // warnings when preview is re-entered.
             ec.insert(RenderTarget::None {
                 size: UVec2::splat(1),
             });
@@ -289,11 +236,8 @@ fn restore_editor_camera(world: &mut World) {
         if let Some(mut c) = world.get_mut::<Camera>(preview) {
             c.is_active = false;
         }
-        // Match the Projection poke in `enter_preview` so Bevy's
-        // `camera_system` notices the RenderTarget swap. Not strictly
-        // required while the camera is inactive, but keeps both swap
-        // directions symmetric and avoids stale `target_info` if another
-        // system activates the camera before the next preview toggle.
+        // Mirrors the Projection poke in `enter_preview`. See its
+        // comment for why.
         if let Some(mut proj) = world.get_mut::<Projection>(preview) {
             proj.set_changed();
         }
@@ -304,17 +248,9 @@ fn restore_editor_camera(world: &mut World) {
     }
 }
 
-// ============================================================================
-// Custom EditorCommand: spawn / despawn a viewable camera
-// ============================================================================
-
-/// Undoable placement of a viewable camera.
-///
-/// `execute` spawns a fresh camera entity with the stored transform and
-/// caches the new id. `undo` despawns whatever was last spawned. Redoing
-/// (re-executing after undo) spawns again with a new id. Downstream
-/// references to the old id become invalid, which is fine for the scene
-/// tree and inspector: both resolve entities by id on every frame.
+/// Undoable placement of a viewable camera. Redo re-executes, which
+/// spawns a new entity id; the scene tree and inspector resolve by id
+/// each frame so that's fine.
 struct PlaceViewableCameraCommand {
     spawned: Option<Entity>,
     transform: Transform,
@@ -328,20 +264,17 @@ impl EditorCommand for PlaceViewableCameraCommand {
                 ViewableCamera,
                 Camera3d::default(),
                 Camera {
-                    // is_active = false until we hand it the render target
-                    // via toggle preview. Keeps it from competing with the
-                    // editor viewport camera for rendering.
+                    // Stays off until `enter_preview` hands over the
+                    // viewport image target.
                     is_active: false,
                     order: -1,
                     ..default()
                 },
-                // Explicit `None` target. Without this, `Camera`'s
-                // required components default to
-                // `RenderTarget::Window(Primary)`. If `is_active` ever
-                // flips true by accident, that would render the scene on
-                // top of the editor UI. `None` keeps the camera inert
-                // until `enter_preview` swaps in the viewport image
-                // target.
+                // `Camera`'s required components default `RenderTarget`
+                // to the primary window, which would render over the
+                // editor UI if `is_active` ever flipped true. Keep the
+                // camera inert until `enter_preview` swaps in the
+                // viewport image target.
                 RenderTarget::None {
                     size: UVec2::splat(1),
                 },

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -1,0 +1,459 @@
+//! Unified "Add Entity" picker.
+//!
+//! A single list of entity templates fed from two sources:
+//!   1. Built-in shapes, lights, cameras, regions, prefabs — hardcoded in
+//!      [`collect_add_menu_items`].
+//!   2. Extension-contributed `RegisteredMenuEntry` rows with `menu == "Add"`.
+//!
+//! The same list backs:
+//!   * The toolbar's **Add** menu (via [`collect_add_menu_items`]).
+//!   * The scene-tree **Add Entity** button (opens this picker).
+//!
+//! This is what lets an extension make a single `register_menu_entry` call
+//! and have its entry appear in every "add" surface.
+
+use bevy::feathers::theme::ThemedText;
+use bevy::prelude::*;
+use bevy::ui_widgets::observe;
+use jackdaw_feathers::text_edit::{self, TextEditProps, TextEditValue};
+use jackdaw_feathers::tokens;
+
+use std::collections::HashSet;
+
+/// Marker for the scene-tree "Add Entity" button. Wired up in `layout.rs`.
+#[derive(Component)]
+pub struct AddEntityButton;
+
+/// Backdrop + panel root for the picker. Despawning it tears down the
+/// whole dialog.
+#[derive(Component)]
+pub struct AddEntityPicker;
+
+#[derive(Component)]
+pub struct AddEntityPickerSearch;
+
+#[derive(Component)]
+pub struct AddEntityPickerEntry {
+    pub label: String,
+    pub category: String,
+}
+
+#[derive(Component)]
+pub struct AddEntityPickerSectionHeader {
+    pub category: String,
+}
+
+/// Semantic grouping for the built-in Add items. Orders the sections in
+/// the picker and mirrors the separator groups of the toolbar Add menu.
+fn builtin_groups() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+    vec![
+        (
+            "Shapes",
+            vec![("add.cube", "Cube"), ("add.sphere", "Sphere")],
+        ),
+        (
+            "Lights",
+            vec![
+                ("add.point_light", "Point Light"),
+                ("add.directional_light", "Directional Light"),
+                ("add.spot_light", "Spot Light"),
+            ],
+        ),
+        (
+            "Cameras & Entities",
+            vec![("add.camera", "Camera"), ("add.empty", "Empty")],
+        ),
+        (
+            "Regions",
+            vec![
+                ("add.navmesh", "Navmesh Region"),
+                ("add.terrain", "Terrain"),
+            ],
+        ),
+        ("Prefabs", vec![("add.prefab", "Prefab...")]),
+    ]
+}
+
+/// Item surfaced by the Add menu / Add Entity picker / future surfaces.
+/// `action` is the id handled by `handle_menu_action` (e.g. `"add.cube"` or
+/// `"op:viewable_camera.place"`).
+#[derive(Clone)]
+pub struct AddMenuItem {
+    pub action: String,
+    pub label: String,
+    pub category: String,
+}
+
+/// Single source of truth for the Add menu contents. Used by both the
+/// toolbar's Add menu and the scene-tree Add Entity picker so a single
+/// extension registration surfaces in both.
+pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
+    let mut items: Vec<AddMenuItem> = builtin_groups()
+        .into_iter()
+        .flat_map(|(category, entries)| {
+            entries.into_iter().map(move |(action, label)| AddMenuItem {
+                action: action.to_string(),
+                label: label.to_string(),
+                category: category.to_string(),
+            })
+        })
+        .collect();
+
+    // Extension-contributed items. Grouped under the owning Extension's
+    // name so extension entries cluster by author in the picker.
+    let mut q = world
+        .query::<(&jackdaw_api::RegisteredMenuEntry, Option<&ChildOf>)>();
+    let mut ext_entries: Vec<(Entity, String, String)> = Vec::new();
+    for (entry, parent) in q.iter(world) {
+        if entry.menu != "Add" {
+            continue;
+        }
+        let ext_entity = parent.map(|c| c.parent()).unwrap_or(Entity::PLACEHOLDER);
+        ext_entries.push((
+            ext_entity,
+            format!("op:{}", entry.operator_id),
+            entry.label.clone(),
+        ));
+    }
+    for (ext_entity, action, label) in ext_entries {
+        let category = world
+            .get::<jackdaw_api::Extension>(ext_entity)
+            .map(|e| e.name.clone())
+            .unwrap_or_else(|| "Extensions".to_string());
+        items.push(AddMenuItem {
+            action,
+            label,
+            category,
+        });
+    }
+
+    items
+}
+
+/// Open the Add Entity picker as a blocking centered dialog. Matches the
+/// Add Component picker's styling so the two feel of-a-piece.
+pub fn open_add_entity_picker(world: &mut World) {
+    // Toggle: close existing picker if already open.
+    let existing: Vec<Entity> = world
+        .query_filtered::<Entity, With<AddEntityPicker>>()
+        .iter(world)
+        .collect();
+    if !existing.is_empty() {
+        for e in existing {
+            if let Ok(ec) = world.get_entity_mut(e) {
+                ec.despawn();
+            }
+        }
+        return;
+    }
+
+    let items = collect_add_menu_items(world);
+
+    // Preserve the insertion order of categories so the built-in groups
+    // (Shapes → Lights → Cameras → Regions → Prefabs) render before any
+    // alphabetical extension groups.
+    let mut grouped: Vec<(String, Vec<AddMenuItem>)> = Vec::new();
+    for item in items {
+        if let Some((_, entries)) = grouped.iter_mut().find(|(cat, _)| *cat == item.category) {
+            entries.push(item);
+        } else {
+            grouped.push((item.category.clone(), vec![item]));
+        }
+    }
+
+    let mut commands = world.commands();
+
+    let backdrop = commands
+        .spawn((
+            AddEntityPicker,
+            crate::EditorEntity,
+            Interaction::default(),
+            bevy::ui::FocusPolicy::Block,
+            Node {
+                position_type: PositionType::Absolute,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..Default::default()
+            },
+            BackgroundColor(tokens::DIALOG_BACKDROP),
+            GlobalZIndex(100),
+            crate::BlocksCameraInput,
+            observe(
+                |_: On<Pointer<Click>>,
+                 mut commands: Commands,
+                 pickers: Query<Entity, With<AddEntityPicker>>| {
+                    for picker in &pickers {
+                        commands.entity(picker).despawn();
+                    }
+                },
+            ),
+        ))
+        .id();
+
+    let picker = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Column,
+                width: Val::Px(tokens::DIALOG_WIDTH),
+                max_height: Val::Px(tokens::DIALOG_MAX_HEIGHT),
+                border: UiRect::all(Val::Px(1.0)),
+                border_radius: BorderRadius::all(Val::Px(tokens::BORDER_RADIUS_LG)),
+                ..Default::default()
+            },
+            BackgroundColor(tokens::PANEL_BG),
+            BorderColor::all(tokens::PANEL_BORDER),
+            BoxShadow(vec![ShadowStyle {
+                x_offset: Val::ZERO,
+                y_offset: Val::Px(4.0),
+                blur_radius: Val::Px(16.0),
+                spread_radius: Val::ZERO,
+                color: tokens::SHADOW_COLOR,
+            }]),
+            ChildOf(backdrop),
+            // Stop clicks inside the panel from closing the dialog.
+            observe(|mut click: On<Pointer<Click>>| {
+                click.propagate(false);
+            }),
+        ))
+        .id();
+
+    // Title bar.
+    commands.spawn((
+        Node {
+            flex_direction: FlexDirection::Row,
+            justify_content: JustifyContent::SpaceBetween,
+            align_items: AlignItems::Center,
+            width: Val::Percent(100.0),
+            padding: UiRect::axes(Val::Px(tokens::SPACING_MD), Val::Px(tokens::SPACING_SM)),
+            border_radius: BorderRadius::top(Val::Px(tokens::BORDER_RADIUS_LG)),
+            ..Default::default()
+        },
+        BackgroundColor(tokens::COMPONENT_CARD_HEADER_BG),
+        ChildOf(picker),
+        children![(
+            Text::new("Add Entity"),
+            TextFont {
+                font_size: tokens::FONT_MD,
+                weight: FontWeight::MEDIUM,
+                ..Default::default()
+            },
+            TextColor(tokens::TEXT_PRIMARY),
+        )],
+    ));
+
+    // Search.
+    commands.spawn((
+        AddEntityPickerSearch,
+        text_edit::text_edit(
+            TextEditProps::default()
+                .with_placeholder("Search entities...")
+                .auto_focus()
+                .allow_empty(),
+        ),
+        ChildOf(picker),
+    ));
+
+    // Scrollable list of sections + entries.
+    let list = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Column,
+                overflow: Overflow::scroll_y(),
+                flex_grow: 1.0,
+                min_height: Val::Px(0.0),
+                ..Default::default()
+            },
+            ChildOf(picker),
+        ))
+        .id();
+
+    for (category, entries) in &grouped {
+        let count = entries.len();
+
+        let header_id = commands
+            .spawn((
+                AddEntityPickerSectionHeader {
+                    category: category.clone(),
+                },
+                Node {
+                    padding: UiRect::new(
+                        Val::Px(tokens::SPACING_LG),
+                        Val::Px(tokens::SPACING_LG),
+                        Val::Px(tokens::SPACING_MD),
+                        Val::Px(tokens::SPACING_XS),
+                    ),
+                    width: Val::Percent(100.0),
+                    border: UiRect::bottom(Val::Px(1.0)),
+                    ..Default::default()
+                },
+                BorderColor::all(tokens::BORDER_SUBTLE),
+                ChildOf(list),
+            ))
+            .id();
+
+        commands.spawn((
+            Text::new(format!("{category} ({count})")),
+            TextFont {
+                font_size: tokens::FONT_SM,
+                ..Default::default()
+            },
+            TextColor(tokens::TEXT_SECONDARY),
+            ChildOf(header_id),
+        ));
+
+        for item in entries {
+            let label = item.label.clone();
+            let category = item.category.clone();
+            let action = item.action.clone();
+
+            let entry_id = commands
+                .spawn((
+                    AddEntityPickerEntry {
+                        label: label.clone(),
+                        category: category.clone(),
+                    },
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        padding: UiRect::axes(
+                            Val::Px(tokens::SPACING_LG),
+                            Val::Px(tokens::SPACING_SM),
+                        ),
+                        width: Val::Percent(100.0),
+                        ..Default::default()
+                    },
+                    BackgroundColor(Color::NONE),
+                    ChildOf(list),
+                    observe({
+                        let action = action.clone();
+                        move |mut click: On<Pointer<Click>>, mut commands: Commands| {
+                            click.propagate(false);
+                            // Reuse the menu-bar dispatch path so every
+                            // "add" action lands in the same place as the
+                            // toolbar's Add menu — no parallel code paths
+                            // to keep in sync.
+                            commands.trigger(jackdaw_widgets::menu_bar::MenuAction {
+                                action: action.clone(),
+                            });
+                            commands.queue(|world: &mut World| {
+                                let pickers: Vec<Entity> = world
+                                    .query_filtered::<Entity, With<AddEntityPicker>>()
+                                    .iter(world)
+                                    .collect();
+                                for picker in pickers {
+                                    if let Ok(ec) = world.get_entity_mut(picker) {
+                                        ec.despawn();
+                                    }
+                                }
+                            });
+                        }
+                    }),
+                    observe(
+                        move |hover: On<Pointer<Over>>, mut bg: Query<&mut BackgroundColor>| {
+                            if let Ok(mut bg) = bg.get_mut(hover.event_target()) {
+                                bg.0 = tokens::HOVER_BG;
+                            }
+                        },
+                    ),
+                    observe(
+                        move |out: On<Pointer<Out>>, mut bg: Query<&mut BackgroundColor>| {
+                            if let Ok(mut bg) = bg.get_mut(out.event_target()) {
+                                bg.0 = Color::NONE;
+                            }
+                        },
+                    ),
+                ))
+                .id();
+
+            // Row: label + category badge.
+            let row = commands
+                .spawn((
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        justify_content: JustifyContent::SpaceBetween,
+                        width: Val::Percent(100.0),
+                        ..Default::default()
+                    },
+                    ChildOf(entry_id),
+                ))
+                .id();
+
+            commands.spawn((
+                Text::new(label),
+                TextFont {
+                    font_size: tokens::FONT_MD,
+                    ..Default::default()
+                },
+                ThemedText,
+                ChildOf(row),
+            ));
+
+            commands.spawn((
+                Text::new(category),
+                TextFont {
+                    font_size: tokens::FONT_SM,
+                    ..Default::default()
+                },
+                TextColor(tokens::TEXT_SECONDARY),
+                ChildOf(row),
+            ));
+        }
+    }
+}
+
+/// Filter picker entries by the search input.
+pub fn filter_add_entity_picker(
+    search_query: Query<&TextEditValue, (With<AddEntityPickerSearch>, Changed<TextEditValue>)>,
+    entries: Query<(Entity, &AddEntityPickerEntry)>,
+    headers: Query<(Entity, &AddEntityPickerSectionHeader)>,
+    mut node_query: Query<&mut Node>,
+) {
+    let Ok(search) = search_query.single() else {
+        return;
+    };
+    let filter = search.0.trim().to_lowercase();
+
+    let mut visible_categories: HashSet<String> = HashSet::new();
+
+    for (entity, entry) in &entries {
+        let matches = filter.is_empty()
+            || entry.label.to_lowercase().contains(&filter)
+            || entry.category.to_lowercase().contains(&filter);
+
+        if let Ok(mut node) = node_query.get_mut(entity) {
+            node.display = if matches {
+                Display::Flex
+            } else {
+                Display::None
+            };
+        }
+
+        if matches {
+            visible_categories.insert(entry.category.clone());
+        }
+    }
+
+    for (entity, header) in &headers {
+        if let Ok(mut node) = node_query.get_mut(entity) {
+            node.display = if filter.is_empty() || visible_categories.contains(&header.category) {
+                Display::Flex
+            } else {
+                Display::None
+            };
+        }
+    }
+}
+
+/// Close on Escape.
+pub fn close_add_entity_picker_on_escape(
+    keys: Res<ButtonInput<KeyCode>>,
+    pickers: Query<Entity, With<AddEntityPicker>>,
+    mut commands: Commands,
+) {
+    if keys.just_pressed(KeyCode::Escape) && !pickers.is_empty() {
+        for picker in &pickers {
+            commands.entity(picker).despawn();
+        }
+    }
+}

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -1,16 +1,17 @@
 //! Unified "Add Entity" picker.
 //!
 //! A single list of entity templates fed from two sources:
-//!   1. Built-in shapes, lights, cameras, regions, prefabs — hardcoded in
-//!      [`collect_add_menu_items`].
-//!   2. Extension-contributed `RegisteredMenuEntry` rows with `menu == "Add"`.
+//!   1. Built-in shapes, lights, cameras, regions, and prefabs, declared
+//!      in [`collect_add_menu_items`].
+//!   2. Extension-contributed `RegisteredMenuEntry` rows with
+//!      `menu == "Add"`.
 //!
 //! The same list backs:
 //!   * The toolbar's **Add** menu (via [`collect_add_menu_items`]).
 //!   * The scene-tree **Add Entity** button (opens this picker).
 //!
-//! This is what lets an extension make a single `register_menu_entry` call
-//! and have its entry appear in every "add" surface.
+//! One `register_menu_entry` call from an extension surfaces its entry
+//! in every "add" surface.
 
 use bevy::feathers::theme::ThemedText;
 use bevy::prelude::*;
@@ -101,8 +102,7 @@ pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
 
     // Extension-contributed items. Grouped under the owning Extension's
     // name so extension entries cluster by author in the picker.
-    let mut q = world
-        .query::<(&jackdaw_api::RegisteredMenuEntry, Option<&ChildOf>)>();
+    let mut q = world.query::<(&jackdaw_api::RegisteredMenuEntry, Option<&ChildOf>)>();
     let mut ext_entries: Vec<(Entity, String, String)> = Vec::new();
     for (entry, parent) in q.iter(world) {
         if entry.menu != "Add" {
@@ -330,9 +330,9 @@ pub fn open_add_entity_picker(world: &mut World) {
                         move |mut click: On<Pointer<Click>>, mut commands: Commands| {
                             click.propagate(false);
                             // Reuse the menu-bar dispatch path so every
-                            // "add" action lands in the same place as the
-                            // toolbar's Add menu — no parallel code paths
-                            // to keep in sync.
+                            // "add" action lands in the same place as
+                            // the toolbar Add menu. Avoids keeping two
+                            // parallel code paths in sync.
                             commands.trigger(jackdaw_widgets::menu_bar::MenuAction {
                                 action: action.clone(),
                             });

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -1,17 +1,7 @@
-//! Unified "Add Entity" picker.
-//!
-//! A single list of entity templates fed from two sources:
-//!   1. Built-in shapes, lights, cameras, regions, and prefabs, declared
-//!      in [`collect_add_menu_items`].
-//!   2. Extension-contributed `RegisteredMenuEntry` rows with
-//!      `menu == "Add"`.
-//!
-//! The same list backs:
-//!   * The toolbar's **Add** menu (via [`collect_add_menu_items`]).
-//!   * The scene-tree **Add Entity** button (opens this picker).
-//!
-//! One `register_menu_entry` call from an extension surfaces its entry
-//! in every "add" surface.
+//! Unified Add Entity picker, shared by the toolbar Add menu and the
+//! scene-tree Add Entity button. Sources items from built-in templates
+//! plus extension-contributed `RegisteredMenuEntry` rows under
+//! `menu == "Add"`.
 
 use bevy::feathers::theme::ThemedText;
 use bevy::prelude::*;
@@ -21,12 +11,12 @@ use jackdaw_feathers::tokens;
 
 use std::collections::HashSet;
 
-/// Marker for the scene-tree "Add Entity" button. Wired up in `layout.rs`.
+/// Marker for the scene-tree Add Entity button.
 #[derive(Component)]
 pub struct AddEntityButton;
 
-/// Backdrop + panel root for the picker. Despawning it tears down the
-/// whole dialog.
+/// Backdrop and panel root for the picker. Despawning it tears down
+/// the whole dialog.
 #[derive(Component)]
 pub struct AddEntityPicker;
 
@@ -44,8 +34,8 @@ pub struct AddEntityPickerSectionHeader {
     pub category: String,
 }
 
-/// Semantic grouping for the built-in Add items. Orders the sections in
-/// the picker and mirrors the separator groups of the toolbar Add menu.
+/// Built-in Add items grouped by category. Order here is the order in
+/// the picker and in the toolbar Add menu.
 fn builtin_groups() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
     vec![
         (
@@ -75,8 +65,8 @@ fn builtin_groups() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
     ]
 }
 
-/// Item surfaced by the Add menu / Add Entity picker / future surfaces.
-/// `action` is the id handled by `handle_menu_action` (e.g. `"add.cube"` or
+/// One row in the Add menu or Add Entity picker. `action` is handled
+/// by `handle_menu_action` (e.g. `"add.cube"` or
 /// `"op:viewable_camera.place"`).
 #[derive(Clone)]
 pub struct AddMenuItem {
@@ -85,9 +75,8 @@ pub struct AddMenuItem {
     pub category: String,
 }
 
-/// Single source of truth for the Add menu contents. Used by both the
-/// toolbar's Add menu and the scene-tree Add Entity picker so a single
-/// extension registration surfaces in both.
+/// Shared source of truth for Add menu contents, consumed by both the
+/// toolbar Add menu and the scene-tree Add Entity picker.
 pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
     let mut items: Vec<AddMenuItem> = builtin_groups()
         .into_iter()
@@ -100,8 +89,8 @@ pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
         })
         .collect();
 
-    // Extension-contributed items. Grouped under the owning Extension's
-    // name so extension entries cluster by author in the picker.
+    // Extension items grouped by owning extension so entries cluster by
+    // author in the picker.
     let mut q = world.query::<(&jackdaw_api::RegisteredMenuEntry, Option<&ChildOf>)>();
     let mut ext_entries: Vec<(Entity, String, String)> = Vec::new();
     for (entry, parent) in q.iter(world) {
@@ -130,10 +119,9 @@ pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
     items
 }
 
-/// Open the Add Entity picker as a blocking centered dialog. Matches the
-/// Add Component picker's styling so the two feel of-a-piece.
+/// Open the Add Entity picker as a centered blocking dialog. Styled
+/// to match the Add Component dialog. Toggles off if already open.
 pub fn open_add_entity_picker(world: &mut World) {
-    // Toggle: close existing picker if already open.
     let existing: Vec<Entity> = world
         .query_filtered::<Entity, With<AddEntityPicker>>()
         .iter(world)
@@ -149,9 +137,8 @@ pub fn open_add_entity_picker(world: &mut World) {
 
     let items = collect_add_menu_items(world);
 
-    // Preserve the insertion order of categories so the built-in groups
-    // (Shapes → Lights → Cameras → Regions → Prefabs) render before any
-    // alphabetical extension groups.
+    // Group by category, preserving insertion order so built-in groups
+    // render before any extension groups.
     let mut grouped: Vec<(String, Vec<AddMenuItem>)> = Vec::new();
     for item in items {
         if let Some((_, entries)) = grouped.iter_mut().find(|(cat, _)| *cat == item.category) {
@@ -219,7 +206,6 @@ pub fn open_add_entity_picker(world: &mut World) {
         ))
         .id();
 
-    // Title bar.
     commands.spawn((
         Node {
             flex_direction: FlexDirection::Row,
@@ -243,7 +229,6 @@ pub fn open_add_entity_picker(world: &mut World) {
         )],
     ));
 
-    // Search.
     commands.spawn((
         AddEntityPickerSearch,
         text_edit::text_edit(
@@ -255,7 +240,6 @@ pub fn open_add_entity_picker(world: &mut World) {
         ChildOf(picker),
     ));
 
-    // Scrollable list of sections + entries.
     let list = commands
         .spawn((
             Node {
@@ -329,10 +313,9 @@ pub fn open_add_entity_picker(world: &mut World) {
                         let action = action.clone();
                         move |mut click: On<Pointer<Click>>, mut commands: Commands| {
                             click.propagate(false);
-                            // Reuse the menu-bar dispatch path so every
-                            // "add" action lands in the same place as
-                            // the toolbar Add menu. Avoids keeping two
-                            // parallel code paths in sync.
+                            // Route through the menu-bar dispatch path
+                            // so the toolbar Add menu and this picker
+                            // share one code path.
                             commands.trigger(jackdaw_widgets::menu_bar::MenuAction {
                                 action: action.clone(),
                             });
@@ -366,7 +349,6 @@ pub fn open_add_entity_picker(world: &mut World) {
                 ))
                 .id();
 
-            // Row: label + category badge.
             let row = commands
                 .spawn((
                     Node {

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -775,8 +775,7 @@ fn handle_apply_texture(
                     new: brush.clone(),
                     label: "Apply texture".into(),
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                history.push_executed(Box::new(cmd));
                 commands
                     .entity(entity)
                     .insert(crate::inspector::InspectorDirty);
@@ -798,6 +797,7 @@ fn handle_apply_texture(
                 }
             })
             .collect();
+        let mut group_commands: Vec<Box<dyn jackdaw_commands::EditorCommand>> = Vec::new();
         for entity in targets {
             if let Ok(mut brush) = brushes.get_mut(entity) {
                 let old = brush.clone();
@@ -810,12 +810,17 @@ fn handle_apply_texture(
                     new: brush.clone(),
                     label: "Apply texture".into(),
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                group_commands.push(Box::new(cmd));
                 commands
                     .entity(entity)
                     .insert(crate::inspector::InspectorDirty);
             }
+        }
+        if !group_commands.is_empty() {
+            history.push_executed(Box::new(jackdaw_commands::CommandGroup {
+                commands: group_commands,
+                label: "Apply texture".into(),
+            }));
         }
     }
 

--- a/src/brush/interaction.rs
+++ b/src/brush/interaction.rs
@@ -208,8 +208,7 @@ pub(super) fn brush_face_interact(
                                 new: brush.clone(),
                                 label: "Nudge brush face".to_string(),
                             };
-                            history.undo_stack.push(Box::new(cmd));
-                            history.redo_stack.clear();
+                            history.push_executed(Box::new(cmd));
                         }
                     }
                 }
@@ -299,8 +298,7 @@ pub(super) fn brush_face_interact(
                                     new: brush.clone(),
                                     label: "Move brush face".to_string(),
                                 };
-                                history.undo_stack.push(Box::new(cmd));
-                                history.redo_stack.clear();
+                                history.push_executed(Box::new(cmd));
                             }
                         }
                     }
@@ -658,8 +656,7 @@ fn spawn_extruded_brush(
             data: brush_data_from_entity(world, entity),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     });
 }
 
@@ -728,8 +725,7 @@ pub(super) fn brush_vertex_interact(
                             new: brush.clone(),
                             label: "Nudge brush vertex".to_string(),
                         };
-                        history.undo_stack.push(Box::new(cmd));
-                        history.redo_stack.clear();
+                        history.push_executed(Box::new(cmd));
                     }
                 }
             }
@@ -808,8 +804,7 @@ pub(super) fn brush_vertex_interact(
                         new: brush.clone(),
                         label: label.to_string(),
                     };
-                    history.undo_stack.push(Box::new(cmd));
-                    history.redo_stack.clear();
+                    history.push_executed(Box::new(cmd));
                 }
             }
             drag_state.active = false;
@@ -1083,8 +1078,7 @@ pub(super) fn brush_edge_interact(
                             new: brush.clone(),
                             label: "Nudge brush edge".to_string(),
                         };
-                        history.undo_stack.push(Box::new(cmd));
-                        history.redo_stack.clear();
+                        history.push_executed(Box::new(cmd));
                     }
                 }
             }
@@ -1157,8 +1151,7 @@ pub(super) fn brush_edge_interact(
                         new: brush.clone(),
                         label: "Move brush edge".to_string(),
                     };
-                    history.undo_stack.push(Box::new(cmd));
-                    history.redo_stack.clear();
+                    history.push_executed(Box::new(cmd));
                 }
             }
             drag_state.active = false;
@@ -1494,8 +1487,7 @@ pub(super) fn handle_brush_delete(
                     new: brush.clone(),
                     label: "Remove brush vertex".to_string(),
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                history.push_executed(Box::new(cmd));
                 brush_selection.vertices.clear();
             }
         }
@@ -1532,8 +1524,7 @@ pub(super) fn handle_brush_delete(
                     new: brush.clone(),
                     label: "Remove brush edge".to_string(),
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                history.push_executed(Box::new(cmd));
                 brush_selection.edges.clear();
             }
         }
@@ -1561,8 +1552,7 @@ pub(super) fn handle_brush_delete(
                 new: brush.clone(),
                 label: "Remove brush face".to_string(),
             };
-            history.undo_stack.push(Box::new(cmd));
-            history.redo_stack.clear();
+            history.push_executed(Box::new(cmd));
             brush_selection.faces.clear();
         }
         _ => {}
@@ -1781,8 +1771,7 @@ pub(super) fn handle_clip_mode(
                         new: brush.clone(),
                         label: "Clip brush (keep front)".to_string(),
                     };
-                    history.undo_stack.push(Box::new(cmd));
-                    history.redo_stack.clear();
+                    history.push_executed(Box::new(cmd));
                 }
                 ClipMode::KeepBack => {
                     let old = brush.clone();
@@ -1793,8 +1782,7 @@ pub(super) fn handle_clip_mode(
                         new: brush.clone(),
                         label: "Clip brush (keep back)".to_string(),
                     };
-                    history.undo_stack.push(Box::new(cmd));
-                    history.redo_stack.clear();
+                    history.push_executed(Box::new(cmd));
                 }
                 ClipMode::Split => {
                     let old = brush.clone();
@@ -1857,8 +1845,7 @@ pub(super) fn handle_clip_mode(
                             label: "Split brush".to_string(),
                         };
                         let mut history = world.resource_mut::<CommandHistory>();
-                        history.undo_stack.push(Box::new(group));
-                        history.redo_stack.clear();
+                        history.push_executed(Box::new(group));
                     });
                     clip_state.points.clear();
                     clip_state.preview_plane = None;

--- a/src/builtin_extensions.rs
+++ b/src/builtin_extensions.rs
@@ -1,0 +1,312 @@
+//! Built-in Jackdaw extensions.
+//!
+//! Each feature area of the editor exposes its dock windows through its
+//! own `JackdawExtension` so Jackdaw dogfoods the same API third-party
+//! authors use. The Extensions dialog (File > Extensions...) lists these
+//! alongside external extensions and lets the user disable a feature
+//! area entirely; for example, turning off `inspector` removes the
+//! Components, Materials, Resources, and Systems windows.
+//!
+//! The `default_area` field on each `WindowDescriptor` preserves the
+//! original dock layout: core navigation windows go into the left panel,
+//! the asset, timeline, and terminal windows into the bottom dock, and
+//! inspector windows into the right sidebar.
+//!
+//! All of these are registered into the `ExtensionCatalog` by
+//! `EditorPlugin::build` and loaded at startup by
+//! `apply_enabled_extensions_startup`.
+
+use std::sync::Arc;
+
+use bevy::prelude::*;
+use jackdaw_api::{ExtensionContext, ExtensionKind, JackdawExtension, WindowDescriptor};
+use jackdaw_feathers::icons::Icon;
+
+/// Scene Tree, Import, and Project Files; the essential navigation
+/// panels shown in the left dock area.
+pub struct CoreWindowsExtension;
+
+impl JackdawExtension for CoreWindowsExtension {
+    fn name(&self) -> &str {
+        "core_windows"
+    }
+
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Builtin
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.hierarchy".into(),
+            name: "Scene Tree".into(),
+            icon: None,
+            default_area: Some("left".into()),
+            priority: Some(0),
+            build: Arc::new(|world, parent| {
+                let icon_font = world
+                    .get_resource::<jackdaw_feathers::icons::IconFont>()
+                    .map(|f| f.0.clone())
+                    .unwrap_or_default();
+                world.spawn((ChildOf(parent), crate::layout::hierarchy_content(icon_font)));
+            }),
+        });
+
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.import".into(),
+            name: "Import".into(),
+            icon: None,
+            default_area: Some("left".into()),
+            priority: Some(1),
+            build: Arc::new(|world, parent| {
+                world.spawn((
+                    ChildOf(parent),
+                    Node {
+                        flex_grow: 1.0,
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![(
+                        Text::new("Import"),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
+                    )],
+                ));
+            }),
+        });
+
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.project_files".into(),
+            name: "Project Files".into(),
+            icon: None,
+            default_area: Some("left".into()),
+            priority: Some(10),
+            build: Arc::new(|world, parent| {
+                world.spawn((
+                    ChildOf(parent),
+                    crate::layout::project_files_panel_content(),
+                ));
+                world
+                    .resource_mut::<crate::project_files::ProjectFilesState>()
+                    .needs_refresh = true;
+            }),
+        });
+    }
+}
+
+/// Asset Browser: lives in the bottom dock.
+pub struct AssetBrowserExtension;
+
+impl JackdawExtension for AssetBrowserExtension {
+    fn name(&self) -> &str {
+        "asset_browser"
+    }
+
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Builtin
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.assets".into(),
+            name: "Assets".into(),
+            icon: Some(String::from(Icon::FolderOpen.unicode())),
+            default_area: Some("bottom_dock".into()),
+            priority: Some(0),
+            build: Arc::new(|world, parent| {
+                let icon_font = world
+                    .get_resource::<jackdaw_feathers::icons::IconFont>()
+                    .map(|f| f.0.clone())
+                    .unwrap_or_default();
+                world.spawn((
+                    ChildOf(parent),
+                    crate::asset_browser::asset_browser_panel(icon_font),
+                ));
+                world
+                    .resource_mut::<crate::asset_browser::AssetBrowserState>()
+                    .needs_refresh = true;
+            }),
+        });
+    }
+}
+
+/// Timeline: animation authoring panel in the bottom dock.
+pub struct TimelineExtension;
+
+impl JackdawExtension for TimelineExtension {
+    fn name(&self) -> &str {
+        "timeline"
+    }
+
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Builtin
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.timeline".into(),
+            name: "Timeline".into(),
+            icon: Some(String::from(Icon::Ruler.unicode())),
+            default_area: Some("bottom_dock".into()),
+            priority: Some(1),
+            build: Arc::new(|world, parent| {
+                world.spawn((ChildOf(parent), jackdaw_animation::timeline_panel()));
+            }),
+        });
+    }
+}
+
+/// Terminal: placeholder panel in the bottom dock.
+pub struct TerminalExtension;
+
+impl JackdawExtension for TerminalExtension {
+    fn name(&self) -> &str {
+        "terminal"
+    }
+
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Builtin
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.terminal".into(),
+            name: "Terminal".into(),
+            icon: Some(String::from(Icon::Terminal.unicode())),
+            default_area: Some("bottom_dock".into()),
+            priority: Some(2),
+            build: Arc::new(|world, parent| {
+                world.spawn((
+                    ChildOf(parent),
+                    Node {
+                        flex_grow: 1.0,
+                        width: Val::Percent(100.0),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![(
+                        Text::new("Terminal window (not implemented yet)"),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
+                    )],
+                ));
+            }),
+        });
+    }
+}
+
+/// Inspector: Components, Materials, Resources, and Systems windows
+/// for the right-sidebar stack.
+pub struct InspectorExtension;
+
+impl JackdawExtension for InspectorExtension {
+    fn name(&self) -> &str {
+        "inspector"
+    }
+
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Builtin
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.inspector.components".into(),
+            name: "Components".into(),
+            icon: None,
+            default_area: Some("right_sidebar".into()),
+            priority: Some(0),
+            build: Arc::new(|world, parent| {
+                let icon_font = world
+                    .get_resource::<jackdaw_feathers::icons::IconFont>()
+                    .map(|f| f.0.clone())
+                    .unwrap_or_default();
+                world.spawn((
+                    ChildOf(parent),
+                    crate::layout::inspector_components_content(icon_font),
+                ));
+            }),
+        });
+
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.inspector.materials".into(),
+            name: "Materials".into(),
+            icon: None,
+            default_area: Some("right_sidebar".into()),
+            priority: Some(1),
+            build: Arc::new(|world, parent| {
+                let icon_font = world
+                    .get_resource::<jackdaw_feathers::icons::IconFont>()
+                    .map(|f| f.0.clone())
+                    .unwrap_or_default();
+                world.spawn((
+                    ChildOf(parent),
+                    crate::material_browser::material_browser_panel(icon_font),
+                ));
+                world
+                    .resource_mut::<crate::material_browser::MaterialBrowserState>()
+                    .needs_rescan = true;
+            }),
+        });
+
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.inspector.resources".into(),
+            name: "Resources".into(),
+            icon: None,
+            default_area: Some("right_sidebar".into()),
+            priority: Some(2),
+            build: Arc::new(|world, parent| {
+                world.spawn((
+                    ChildOf(parent),
+                    Node {
+                        flex_grow: 1.0,
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![(
+                        Text::new("Resources"),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
+                    )],
+                ));
+            }),
+        });
+
+        ctx.register_window(WindowDescriptor {
+            id: "jackdaw.inspector.systems".into(),
+            name: "Systems".into(),
+            icon: None,
+            default_area: Some("right_sidebar".into()),
+            priority: Some(3),
+            build: Arc::new(|world, parent| {
+                world.spawn((
+                    ChildOf(parent),
+                    Node {
+                        flex_grow: 1.0,
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    children![(
+                        Text::new("Systems"),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
+                    )],
+                ));
+            }),
+        });
+    }
+}

--- a/src/builtin_extensions.rs
+++ b/src/builtin_extensions.rs
@@ -1,20 +1,7 @@
-//! Built-in Jackdaw extensions.
-//!
-//! Each feature area of the editor exposes its dock windows through its
-//! own `JackdawExtension` so Jackdaw dogfoods the same API third-party
-//! authors use. The Extensions dialog (File > Extensions...) lists these
-//! alongside external extensions and lets the user disable a feature
-//! area entirely; for example, turning off `inspector` removes the
-//! Components, Materials, Resources, and Systems windows.
-//!
-//! The `default_area` field on each `WindowDescriptor` preserves the
-//! original dock layout: core navigation windows go into the left panel,
-//! the asset, timeline, and terminal windows into the bottom dock, and
-//! inspector windows into the right sidebar.
-//!
-//! All of these are registered into the `ExtensionCatalog` by
-//! `EditorPlugin::build` and loaded at startup by
-//! `apply_enabled_extensions_startup`.
+//! Built-in Jackdaw extensions. Each feature area of the editor owns
+//! its dock windows through a `JackdawExtension`, so Jackdaw uses the
+//! same API third-party authors do. Disable one in File > Extensions
+//! to remove its windows from the layout.
 
 use std::sync::Arc;
 
@@ -22,8 +9,7 @@ use bevy::prelude::*;
 use jackdaw_api::{ExtensionContext, ExtensionKind, JackdawExtension, WindowDescriptor};
 use jackdaw_feathers::icons::Icon;
 
-/// Scene Tree, Import, and Project Files; the essential navigation
-/// panels shown in the left dock area.
+/// Scene Tree, Import, and Project Files in the left dock.
 pub struct CoreWindowsExtension;
 
 impl JackdawExtension for CoreWindowsExtension {
@@ -97,7 +83,7 @@ impl JackdawExtension for CoreWindowsExtension {
     }
 }
 
-/// Asset Browser: lives in the bottom dock.
+/// Assets window in the bottom dock.
 pub struct AssetBrowserExtension;
 
 impl JackdawExtension for AssetBrowserExtension {
@@ -133,7 +119,7 @@ impl JackdawExtension for AssetBrowserExtension {
     }
 }
 
-/// Timeline: animation authoring panel in the bottom dock.
+/// Animation timeline in the bottom dock.
 pub struct TimelineExtension;
 
 impl JackdawExtension for TimelineExtension {
@@ -159,7 +145,7 @@ impl JackdawExtension for TimelineExtension {
     }
 }
 
-/// Terminal: placeholder panel in the bottom dock.
+/// Terminal placeholder in the bottom dock.
 pub struct TerminalExtension;
 
 impl JackdawExtension for TerminalExtension {
@@ -202,8 +188,7 @@ impl JackdawExtension for TerminalExtension {
     }
 }
 
-/// Inspector: Components, Materials, Resources, and Systems windows
-/// for the right-sidebar stack.
+/// Right-sidebar stack: Components, Materials, Resources, Systems.
 pub struct InspectorExtension;
 
 impl JackdawExtension for InspectorExtension {

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -21,6 +21,10 @@ pub const FACE_GRID_UNSELECTED: Color = Color::srgba(0.294, 0.333, 0.388, 0.1);
 
 // ── Selection & bounding boxes ──
 pub const SELECTION_BBOX: Color = Color::srgba(1.0, 1.0, 0.0, 0.8);
+/// Dim variant for marker gizmos on unselected lights, cameras, and
+/// empty entities. Keeps invisible entities locatable in the viewport
+/// without overpowering selection highlights.
+pub const ENTITY_MARKER_UNSELECTED: Color = Color::srgba(0.55, 0.55, 0.6, 0.35);
 pub const SELECTION_MARQUEE_BG: Color = Color::srgba(0.3, 0.5, 1.0, 0.1);
 pub const SELECTION_MARQUEE_BORDER: Color = Color::srgba(0.3, 0.5, 1.0, 0.7);
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -149,6 +149,14 @@ impl EditorCommand for ReparentEntity {
 }
 
 fn set_parent(world: &mut World, entity: Entity, parent: Option<Entity>) {
+    // Preserve world position across reparent. Compute the entity's current
+    // world transform, then update its local Transform so that:
+    //   new_parent_global * new_local = current_world
+    // This prevents the brush from "jumping" (or disappearing off-screen)
+    // when parented under an entity at a non-origin position.
+    let current_world = world.get::<GlobalTransform>(entity).copied();
+    let new_parent_world = parent.and_then(|p| world.get::<GlobalTransform>(p).copied());
+
     match parent {
         Some(p) => {
             world.entity_mut(entity).insert(ChildOf(p));
@@ -157,11 +165,41 @@ fn set_parent(world: &mut World, entity: Entity, parent: Option<Entity>) {
             world.entity_mut(entity).remove::<ChildOf>();
         }
     }
-    // Update AST parent
-    let mut ast = world.resource_mut::<jackdaw_jsn::SceneJsnAst>();
-    let parent_idx = parent.and_then(|p| ast.ecs_to_jsn.get(&p).copied());
-    if let Some(node) = ast.node_for_entity_mut(entity) {
-        node.parent = parent_idx;
+
+    let new_transform =
+        if let (Some(world_tf), Some(parent_world)) = (current_world, new_parent_world) {
+            Some(Transform::from_matrix(
+                (parent_world.affine().inverse() * world_tf.affine()).into(),
+            ))
+        } else if parent.is_none() {
+            current_world.map(|w| Transform::from_matrix(w.affine().into()))
+        } else {
+            None
+        };
+    if let Some(new_tf) = new_transform {
+        if let Some(mut tf) = world.get_mut::<Transform>(entity) {
+            *tf = new_tf;
+        }
+    }
+
+    // Update AST parent and (if changed) Transform
+    let parent_idx = {
+        let ast = world.resource::<jackdaw_jsn::SceneJsnAst>();
+        parent.and_then(|p| ast.ecs_to_jsn.get(&p).copied())
+    };
+    {
+        let mut ast = world.resource_mut::<jackdaw_jsn::SceneJsnAst>();
+        if let Some(node) = ast.node_for_entity_mut(entity) {
+            node.parent = parent_idx;
+        }
+    }
+    if let Some(new_tf) = new_transform {
+        sync_component_to_ast(
+            world,
+            entity,
+            "bevy_transform::components::transform::Transform",
+            &new_tf,
+        );
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -237,8 +237,25 @@ impl EditorCommand for AddComponent {
     }
 
     fn undo(&mut self, world: &mut World) {
+        // Resolve promoted components' ComponentIds via the type registry
+        // so we can remove them from the ECS as well as the AST.
+        let registry = world.resource::<AppTypeRegistry>().clone();
+        let reg = registry.read();
+        let promoted_component_ids: Vec<bevy::ecs::component::ComponentId> = self
+            .promoted_components
+            .iter()
+            .filter_map(|type_path| {
+                let type_id = reg.get_with_type_path(type_path)?.type_id();
+                world.components().get_id(type_id)
+            })
+            .collect();
+        drop(reg);
+
         if let Ok(mut entity) = world.get_entity_mut(self.entity) {
             entity.remove_by_id(self.component_id);
+            for cid in &promoted_component_ids {
+                entity.remove_by_id(*cid);
+            }
         }
         // Remove the explicitly-added component + all promoted components from AST
         if let Some(node) = world
@@ -246,9 +263,15 @@ impl EditorCommand for AddComponent {
             .node_for_entity_mut(self.entity)
         {
             node.components.remove(&self.type_path);
+            node.derived_components.remove(&self.type_path);
             for promoted in &self.promoted_components {
                 node.components.remove(promoted);
+                node.derived_components.remove(promoted);
             }
+        }
+        // Trigger inspector rebuild so the UI reflects the removal immediately.
+        if let Ok(mut ec) = world.get_entity_mut(self.entity) {
+            ec.insert(crate::inspector::InspectorDirty);
         }
     }
 
@@ -328,11 +351,20 @@ pub struct SpawnEntity {
 
 impl EditorCommand for SpawnEntity {
     fn execute(&mut self, world: &mut World) {
-        let _entity = (self.spawn_fn)(world);
+        let entity = (self.spawn_fn)(world);
+        self.spawned = Some(entity);
     }
 
-    fn undo(&mut self, _world: &mut World) {
-        // TODO: Track spawned entity for despawn on undo
+    fn undo(&mut self, world: &mut World) {
+        if let Some(entity) = self.spawned.take() {
+            deselect_entities(world, &[entity]);
+            world
+                .resource_mut::<jackdaw_jsn::SceneJsnAst>()
+                .remove_node(entity);
+            if let Ok(entity_mut) = world.get_entity_mut(entity) {
+                entity_mut.despawn();
+            }
+        }
     }
 
     fn description(&self) -> &str {
@@ -424,9 +456,16 @@ pub(crate) fn collect_entity_ids(world: &World, entity: Entity, out: &mut Vec<En
     out.push(entity);
     if let Some(children) = world.get::<Children>(entity) {
         for child in children.iter() {
-            if world.get::<EditorEntity>(child).is_none() {
-                collect_entity_ids(world, child, out);
+            // Skip editor-only entities and runtime-generated children
+            // (e.g. BrushFaceEntity meshes). Including NonSerializable
+            // children causes them to be restored as orphans at origin
+            // after undo, while the parent regenerates its own.
+            if world.get::<EditorEntity>(child).is_some()
+                || world.get::<crate::NonSerializable>(child).is_some()
+            {
+                continue;
             }
+            collect_entity_ids(world, child, out);
         }
     }
 }
@@ -488,6 +527,9 @@ pub struct SetJsnField {
     pub field_path: String,
     pub old_value: serde_json::Value,
     pub new_value: serde_json::Value,
+    /// True if the component was in the `derived_components` set before this
+    /// command ran. Set on first execute so undo can demote the component back.
+    pub was_derived: bool,
 }
 
 impl EditorCommand for SetJsnField {
@@ -504,9 +546,11 @@ impl EditorCommand for SetJsnField {
                 &registry,
             );
             // If the user explicitly edits a derived component, promote it to
-            // "authored" so the change persists on save.
+            // "authored" so the change persists on save. Remember we did so,
+            // so undo can restore the derived state.
             if let Some(node) = ast.node_for_entity_mut(self.entity) {
                 if node.derived_components.remove(&self.type_path) {
+                    self.was_derived = true;
                     info!(
                         "Promoted derived component '{}' to authored (user edited it)",
                         self.type_path
@@ -527,15 +571,20 @@ impl EditorCommand for SetJsnField {
         {
             let registry = world.resource::<AppTypeRegistry>().clone();
             let registry = registry.read();
-            world
-                .resource_mut::<jackdaw_jsn::SceneJsnAst>()
-                .set_component_field(
-                    self.entity,
-                    &self.type_path,
-                    &self.field_path,
-                    self.old_value.clone(),
-                    &registry,
-                );
+            let mut ast = world.resource_mut::<jackdaw_jsn::SceneJsnAst>();
+            ast.set_component_field(
+                self.entity,
+                &self.type_path,
+                &self.field_path,
+                self.old_value.clone(),
+                &registry,
+            );
+            // Restore derived state if execute promoted it to authored.
+            if self.was_derived {
+                if let Some(node) = ast.node_for_entity_mut(self.entity) {
+                    node.derived_components.insert(self.type_path.clone());
+                }
+            }
         }
         apply_jsn_field_to_ecs(
             world,

--- a/src/draw_brush.rs
+++ b/src/draw_brush.rs
@@ -1104,8 +1104,7 @@ fn spawn_drawn_brush(active: &ActiveDraw, commands: &mut Commands) {
             data: brush_data_from_entity(world, entity),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     });
 }
 
@@ -1286,8 +1285,7 @@ fn append_to_brush(active: &ActiveDraw, commands: &mut Commands) {
             label: "Append brush geometry".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     });
 }
 
@@ -1531,8 +1529,7 @@ fn spawn_polygon_brush(active: &ActiveDraw, commands: &mut Commands) {
             data: brush_data_from_entity(world, entity),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     });
 }
 
@@ -2201,8 +2198,7 @@ fn subtract_drawn_brush(active: &ActiveDraw, commands: &mut Commands) {
             fragments,
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     });
 }
 
@@ -2496,11 +2492,10 @@ pub(crate) fn join_selected_brushes_impl(world: &mut World) {
 
         // Push grouped undo command
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(CommandGroup {
+        history.push_executed(Box::new(CommandGroup {
             commands: undo_commands,
             label: "Join brushes".to_string(),
         }));
-        history.redo_stack.clear();
     }
 }
 
@@ -2773,8 +2768,7 @@ pub(crate) fn csg_subtract_selected_impl(world: &mut World) {
         fragments,
     };
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }
 
 fn csg_intersect_selected(
@@ -2903,8 +2897,7 @@ pub(crate) fn csg_intersect_selected_impl(world: &mut World) {
         fragments: vec![BrushOrGroup::Single(brush_data)],
     };
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }
 
 fn extend_face_to_brush(
@@ -3181,6 +3174,5 @@ pub(crate) fn extend_face_to_brush_impl(
         label: "Extend face to brush".to_string(),
     };
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -174,8 +174,7 @@ fn apply_last_material(entity: Entity) -> impl FnOnce(&mut World) {
 pub fn create_entity_in_world(world: &mut World, template: EntityTemplate) {
     let label = format!("Add {}", template.label());
     let spawn_fn = Box::new(move |world: &mut World| -> Entity {
-        let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
-            SystemState::new(world);
+        let mut system_state: SystemState<(Commands, ResMut<Selection>)> = SystemState::new(world);
         let (mut commands, mut selection) = system_state.get_mut(world);
         let entity = create_entity(&mut commands, template, &mut selection);
         system_state.apply(world);

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -143,6 +143,17 @@ pub fn create_entity(
             .spawn((
                 Name::new("Camera"),
                 Camera3d::default(),
+                Camera {
+                    // Scene cameras are authored inactive so they don't
+                    // render over the editor viewport. They become active
+                    // at play time (or via a future "preview through this
+                    // camera" operator).
+                    is_active: false,
+                    ..default()
+                },
+                bevy::camera::RenderTarget::None {
+                    size: UVec2::splat(1),
+                },
                 Transform::from_xyz(0.0, 2.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ))
             .id(),

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -170,12 +170,26 @@ fn apply_last_material(entity: Entity) -> impl FnOnce(&mut World) {
 }
 
 /// World-access version of `create_entity`. Used from menu actions and other deferred contexts.
+/// Pushes a `SpawnEntity` command so the addition can be undone.
 pub fn create_entity_in_world(world: &mut World, template: EntityTemplate) {
-    let mut system_state: SystemState<(Commands, ResMut<Selection>)> = SystemState::new(world);
-    let (mut commands, mut selection) = system_state.get_mut(world);
-    let entity = create_entity(&mut commands, template, &mut selection);
-    system_state.apply(world);
-    crate::scene_io::register_entity_in_ast(world, entity);
+    let label = format!("Add {}", template.label());
+    let spawn_fn = Box::new(move |world: &mut World| -> Entity {
+        let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
+            SystemState::new(world);
+        let (mut commands, mut selection) = system_state.get_mut(world);
+        let entity = create_entity(&mut commands, template, &mut selection);
+        system_state.apply(world);
+        crate::scene_io::register_entity_in_ast(world, entity);
+        entity
+    });
+
+    let mut cmd: Box<dyn EditorCommand> = Box::new(crate::commands::SpawnEntity {
+        spawned: None,
+        spawn_fn,
+        label,
+    });
+    cmd.execute(world);
+    world.resource_mut::<CommandHistory>().push_executed(cmd);
 }
 
 pub fn spawn_gltf(
@@ -257,8 +271,7 @@ pub fn delete_selected(world: &mut World) {
             label: "Delete entities".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 
@@ -619,8 +632,7 @@ fn reset_transform_selected(world: &mut World, reset: TransformReset) {
             label: label.to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 
@@ -662,8 +674,7 @@ fn nudge_selected(world: &mut World, offset: Vec3) {
             label: "Nudge".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 
@@ -705,8 +716,7 @@ fn rotate_selected(world: &mut World, rotation: Quat) {
             label: "Rotate 90\u{00b0}".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 
@@ -844,6 +854,7 @@ fn hide_selected(world: &mut World) {
             field_path: String::new(),
             old_value: serde_json::Value::String(format!("{current:?}")),
             new_value: serde_json::Value::String(format!("{new_visibility:?}")),
+            was_derived: false,
         };
         cmd.execute(world);
         cmds.push(Box::new(cmd));
@@ -855,8 +866,7 @@ fn hide_selected(world: &mut World) {
             label: "Toggle visibility".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 
@@ -884,6 +894,7 @@ fn unhide_all_entities(world: &mut World) {
             field_path: String::new(),
             old_value: serde_json::Value::String("Hidden".to_string()),
             new_value: serde_json::Value::String("Inherited".to_string()),
+            was_derived: false,
         };
         cmd.execute(world);
         cmds.push(Box::new(cmd));
@@ -895,8 +906,7 @@ fn unhide_all_entities(world: &mut World) {
             label: "Unhide all".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 
@@ -924,6 +934,7 @@ fn hide_all_entities(world: &mut World) {
             field_path: String::new(),
             old_value: serde_json::Value::String(format!("{current:?}")),
             new_value: serde_json::Value::String("Hidden".to_string()),
+            was_derived: false,
         };
         cmd.execute(world);
         cmds.push(Box::new(cmd));
@@ -935,8 +946,7 @@ fn hide_all_entities(world: &mut World) {
             label: "Hide all".to_string(),
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(group));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(group));
     }
 }
 

--- a/src/entity_templates.rs
+++ b/src/entity_templates.rs
@@ -380,8 +380,7 @@ fn finalize_instantiation(world: &mut World, roots: &[Entity]) {
             snapshots: despawn_cmds,
         };
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     }
 }
 

--- a/src/extension_loader.rs
+++ b/src/extension_loader.rs
@@ -1,18 +1,24 @@
 //! Plugin that wires up the extension framework into the editor.
 //!
 //! Adds BEI, sets up the required resources (`OperatorCommandBuffer`,
-//! `OperatorIndex`, `PanelExtensionRegistry`, `ExtensionCatalog`), and
-//! registers the cleanup observers that keep non-ECS state in sync when
-//! extension entities are despawned.
+//! `OperatorIndex`, `PanelExtensionRegistry`, `ExtensionCatalog`,
+//! `ActiveModalOperator`), and registers the cleanup observers that keep
+//! non-ECS state in sync when extension entities are despawned.
+//!
+//! Also runs `tick_modal_operator` each frame in Update so modal
+//! operators (Blender-style grab/rotate/scale) re-run their invoke
+//! system until they return `Finished` or `Cancelled`.
 
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::EnhancedInputPlugin;
 use jackdaw_api::{
-    ExtensionCatalog, OperatorCommandBuffer, OperatorIndex, PanelExtensionRegistry,
+    ActiveModalOperator, ExtensionCatalog, OperatorCommandBuffer, OperatorIndex,
+    PanelExtensionRegistry,
     lifecycle::{
         cleanup_panel_extension_on_remove, cleanup_window_on_remove, cleanup_workspace_on_remove,
         deindex_and_cleanup_operator_on_remove, index_operator_on_add,
     },
+    tick_modal_operator,
 };
 
 pub struct ExtensionLoaderPlugin;
@@ -24,10 +30,12 @@ impl Plugin for ExtensionLoaderPlugin {
             .init_resource::<OperatorCommandBuffer>()
             .init_resource::<OperatorIndex>()
             .init_resource::<PanelExtensionRegistry>()
+            .init_resource::<ActiveModalOperator>()
             .add_observer(index_operator_on_add)
             .add_observer(deindex_and_cleanup_operator_on_remove)
             .add_observer(cleanup_window_on_remove)
             .add_observer(cleanup_workspace_on_remove)
-            .add_observer(cleanup_panel_extension_on_remove);
+            .add_observer(cleanup_panel_extension_on_remove)
+            .add_systems(Update, tick_modal_operator);
     }
 }

--- a/src/extension_loader.rs
+++ b/src/extension_loader.rs
@@ -1,75 +1,33 @@
+//! Plugin that wires up the extension framework into the editor.
+//!
+//! Adds BEI, sets up the required resources (`OperatorCommandBuffer`,
+//! `OperatorIndex`, `PanelExtensionRegistry`, `ExtensionCatalog`), and
+//! registers the cleanup observers that keep non-ECS state in sync when
+//! extension entities are despawned.
+
 use bevy::prelude::*;
+use bevy_enhanced_input::prelude::EnhancedInputPlugin;
 use jackdaw_api::{
-    KeyCombo, KeybindRegistry, Modifiers, OperatorContext, OperatorRegistry, PanelExtensionRegistry,
+    ExtensionCatalog, OperatorCommandBuffer, OperatorIndex, PanelExtensionRegistry,
+    lifecycle::{
+        cleanup_panel_extension_on_remove, cleanup_window_on_remove, cleanup_workspace_on_remove,
+        deindex_and_cleanup_operator_on_remove, index_operator_on_add,
+    },
 };
 
 pub struct ExtensionLoaderPlugin;
 
 impl Plugin for ExtensionLoaderPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<OperatorRegistry>()
-            .init_resource::<KeybindRegistry>()
+        app.add_plugins(EnhancedInputPlugin)
+            .init_resource::<ExtensionCatalog>()
+            .init_resource::<OperatorCommandBuffer>()
+            .init_resource::<OperatorIndex>()
             .init_resource::<PanelExtensionRegistry>()
-            .add_systems(
-                Update,
-                keybind_dispatch_system
-                    .run_if(in_state(crate::AppState::Editor))
-                    .run_if(crate::no_dialog_open),
-            );
-    }
-}
-
-fn keybind_dispatch_system(world: &mut World) {
-    let keyboard = world.resource::<ButtonInput<KeyCode>>();
-    let ctrl = keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight);
-    let shift = keyboard.pressed(KeyCode::ShiftLeft) || keyboard.pressed(KeyCode::ShiftRight);
-    let alt = keyboard.pressed(KeyCode::AltLeft) || keyboard.pressed(KeyCode::AltRight);
-    let modifiers = Modifiers { ctrl, shift, alt };
-
-    let just_pressed: Vec<KeyCode> = keyboard.get_just_pressed().copied().collect();
-    if just_pressed.is_empty() {
-        return;
-    }
-
-    let mut matched_operator_id = None;
-    let keybinds = world.resource::<KeybindRegistry>();
-    for key in &just_pressed {
-        let combo = KeyCombo {
-            key: *key,
-            modifiers,
-        };
-        if let Some(op_id) = keybinds.lookup(&combo) {
-            matched_operator_id = Some(op_id.to_string());
-            break;
-        }
-    }
-
-    let Some(operator_id) = matched_operator_id else {
-        return;
-    };
-
-    let operators = world.resource::<OperatorRegistry>();
-    let Some(mut operator) = operators.create(&operator_id) else {
-        warn!("Keybind references unknown operator: {operator_id}");
-        return;
-    };
-
-    let label = operator_id.clone();
-    let mut ctx = OperatorContext::new(world, true);
-
-    if !operator.poll(&ctx) {
-        return;
-    }
-
-    let result = operator.invoke(&mut ctx);
-    match result {
-        jackdaw_api::OperatorResult::Finished => {
-            ctx.finish(&label);
-        }
-        jackdaw_api::OperatorResult::Cancelled => {}
-        jackdaw_api::OperatorResult::Running => {
-            // TODO: modal operator support
-            ctx.finish(&label);
-        }
+            .add_observer(index_operator_on_add)
+            .add_observer(deindex_and_cleanup_operator_on_remove)
+            .add_observer(cleanup_window_on_remove)
+            .add_observer(cleanup_workspace_on_remove)
+            .add_observer(cleanup_panel_extension_on_remove);
     }
 }

--- a/src/extension_loader.rs
+++ b/src/extension_loader.rs
@@ -1,0 +1,75 @@
+use bevy::prelude::*;
+use jackdaw_api::{
+    KeyCombo, KeybindRegistry, Modifiers, OperatorContext, OperatorRegistry, PanelExtensionRegistry,
+};
+
+pub struct ExtensionLoaderPlugin;
+
+impl Plugin for ExtensionLoaderPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<OperatorRegistry>()
+            .init_resource::<KeybindRegistry>()
+            .init_resource::<PanelExtensionRegistry>()
+            .add_systems(
+                Update,
+                keybind_dispatch_system
+                    .run_if(in_state(crate::AppState::Editor))
+                    .run_if(crate::no_dialog_open),
+            );
+    }
+}
+
+fn keybind_dispatch_system(world: &mut World) {
+    let keyboard = world.resource::<ButtonInput<KeyCode>>();
+    let ctrl = keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight);
+    let shift = keyboard.pressed(KeyCode::ShiftLeft) || keyboard.pressed(KeyCode::ShiftRight);
+    let alt = keyboard.pressed(KeyCode::AltLeft) || keyboard.pressed(KeyCode::AltRight);
+    let modifiers = Modifiers { ctrl, shift, alt };
+
+    let just_pressed: Vec<KeyCode> = keyboard.get_just_pressed().copied().collect();
+    if just_pressed.is_empty() {
+        return;
+    }
+
+    let mut matched_operator_id = None;
+    let keybinds = world.resource::<KeybindRegistry>();
+    for key in &just_pressed {
+        let combo = KeyCombo {
+            key: *key,
+            modifiers,
+        };
+        if let Some(op_id) = keybinds.lookup(&combo) {
+            matched_operator_id = Some(op_id.to_string());
+            break;
+        }
+    }
+
+    let Some(operator_id) = matched_operator_id else {
+        return;
+    };
+
+    let operators = world.resource::<OperatorRegistry>();
+    let Some(mut operator) = operators.create(&operator_id) else {
+        warn!("Keybind references unknown operator: {operator_id}");
+        return;
+    };
+
+    let label = operator_id.clone();
+    let mut ctx = OperatorContext::new(world, true);
+
+    if !operator.poll(&ctx) {
+        return;
+    }
+
+    let result = operator.invoke(&mut ctx);
+    match result {
+        jackdaw_api::OperatorResult::Finished => {
+            ctx.finish(&label);
+        }
+        jackdaw_api::OperatorResult::Cancelled => {}
+        jackdaw_api::OperatorResult::Running => {
+            // TODO: modal operator support
+            ctx.finish(&label);
+        }
+    }
+}

--- a/src/extensions_config.rs
+++ b/src/extensions_config.rs
@@ -1,0 +1,89 @@
+//! Persistence for the "enabled extensions" list.
+//!
+//! Stores a JSON file at `~/.config/jackdaw/extensions.json`:
+//!
+//! ```json
+//! {
+//!   "enabled": [
+//!     "jackdaw.core_windows",
+//!     "jackdaw.inspector",
+//!     "sample"
+//!   ]
+//! }
+//! ```
+//!
+//! Read once on editor startup to decide which entries in the
+//! `ExtensionCatalog` to enable. Re-written whenever the user toggles an
+//! extension in the Plugins dialog.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use bevy::prelude::*;
+use jackdaw_api::{ExtensionCatalog, enable_extension};
+use serde::{Deserialize, Serialize};
+
+/// On-disk shape.
+#[derive(Serialize, Deserialize, Default)]
+pub struct ExtensionsConfig {
+    pub enabled: Vec<String>,
+}
+
+fn config_path() -> Option<PathBuf> {
+    crate::project::config_dir().map(|d| d.join("extensions.json"))
+}
+
+/// Read the enabled-list from disk. Returns `None` if the file doesn't
+/// exist — callers should interpret that as "enable everything".
+pub fn read_enabled_list() -> Option<Vec<String>> {
+    let path = config_path()?;
+    let data = std::fs::read_to_string(&path).ok()?;
+    let config: ExtensionsConfig = serde_json::from_str(&data).ok()?;
+    Some(config.enabled)
+}
+
+/// Write the currently-enabled list to disk.
+pub fn write_enabled_list(enabled: &[String]) {
+    let Some(path) = config_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let config = ExtensionsConfig {
+        enabled: enabled.to_vec(),
+    };
+    if let Ok(data) = serde_json::to_string_pretty(&config) {
+        let _ = std::fs::write(&path, data);
+    }
+}
+
+/// Enable every extension in the catalog whose name is in the persisted
+/// list. Falls back to "enable all" if the config file doesn't exist yet
+/// (first-run behavior).
+pub fn apply_enabled_from_disk(app: &mut App) {
+    let world = app.world_mut();
+    let to_enable: Vec<String> = {
+        let catalog = world.resource::<ExtensionCatalog>();
+        let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
+        match read_enabled_list() {
+            Some(list) => {
+                let set: HashSet<String> = list.into_iter().collect();
+                available.into_iter().filter(|n| set.contains(n)).collect()
+            }
+            None => available, // first run: enable everything
+        }
+    };
+
+    for name in &to_enable {
+        enable_extension(world, name);
+    }
+}
+
+/// Compute the current enabled list from the loaded `Extension` entities
+/// and write it to disk.
+pub fn persist_current_enabled(world: &mut World) {
+    let mut query = world.query::<&jackdaw_api::Extension>();
+    let enabled: Vec<String> = query.iter(world).map(|e| e.name.clone()).collect();
+    write_enabled_list(&enabled);
+}

--- a/src/extensions_config.rs
+++ b/src/extensions_config.rs
@@ -5,22 +5,22 @@
 //! ```json
 //! {
 //!   "enabled": [
-//!     "jackdaw.core_windows",
-//!     "jackdaw.inspector",
+//!     "core_windows",
+//!     "inspector",
 //!     "sample"
 //!   ]
 //! }
 //! ```
 //!
 //! Read once on editor startup to decide which entries in the
-//! `ExtensionCatalog` to enable. Re-written whenever the user toggles an
-//! extension in the Plugins dialog.
+//! [`ExtensionCatalog`] to enable. Rewritten whenever the user toggles
+//! an extension in the Extensions dialog.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
 
 use bevy::prelude::*;
-use jackdaw_api::{ExtensionCatalog, enable_extension};
+use jackdaw_api::{ExtensionCatalog, ExtensionKind};
 use serde::{Deserialize, Serialize};
 
 /// On-disk shape.
@@ -33,8 +33,8 @@ fn config_path() -> Option<PathBuf> {
     crate::project::config_dir().map(|d| d.join("extensions.json"))
 }
 
-/// Read the enabled-list from disk. Returns `None` if the file doesn't
-/// exist — callers should interpret that as "enable everything".
+/// Read the enabled list from disk. Returns `None` if the file doesn't
+/// exist; callers should interpret that as "enable everything".
 pub fn read_enabled_list() -> Option<Vec<String>> {
     let path = config_path()?;
     let data = std::fs::read_to_string(&path).ok()?;
@@ -58,25 +58,45 @@ pub fn write_enabled_list(enabled: &[String]) {
     }
 }
 
-/// Enable every extension in the catalog whose name is in the persisted
-/// list. Falls back to "enable all" if the config file doesn't exist yet
-/// (first-run behavior).
-pub fn apply_enabled_from_disk(app: &mut App) {
-    let world = app.world_mut();
-    let to_enable: Vec<String> = {
-        let catalog = world.resource::<ExtensionCatalog>();
-        let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
-        match read_enabled_list() {
-            Some(list) => {
-                let set: HashSet<String> = list.into_iter().collect();
-                available.into_iter().filter(|n| set.contains(n)).collect()
-            }
-            None => available, // first run: enable everything
-        }
-    };
+/// Resolve which catalog entries should be enabled on startup given the
+/// persisted list, if any. Called by the Startup system in `lib.rs`.
+///
+/// Includes a one-time upgrade migration: if the saved list predates the
+/// built-in feature-area extensions (none of its entries are built-ins),
+/// every catalog entry is enabled. The next toggle rewrites the file
+/// with the full list. Once the file records at least one built-in, the
+/// user's recorded preferences are trusted exactly as written, so an
+/// intentional disable of `inspector` stays disabled across restarts.
+///
+/// "Which names are built-ins" comes from the catalog itself: each
+/// extension declares its [`ExtensionKind`] on the `JackdawExtension`
+/// trait and registration captures it.
+pub fn resolve_enabled_list(world: &World) -> Vec<String> {
+    let catalog = world.resource::<ExtensionCatalog>();
+    let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
+    let builtins: HashSet<String> = catalog
+        .iter_with_kind()
+        .filter(|(_, kind)| *kind == ExtensionKind::Builtin)
+        .map(|(name, _)| name.to_string())
+        .collect();
 
-    for name in &to_enable {
-        enable_extension(world, name);
+    match read_enabled_list() {
+        Some(list) => {
+            let on_disk: HashSet<String> = list.into_iter().collect();
+            // Pre-dogfood files contain none of the built-in names.
+            // Treat those as legacy and fall back to "enable everything"
+            // so the editor stays usable. The next toggle rewrites the
+            // file with the complete list.
+            let has_any_builtin = builtins.iter().any(|name| on_disk.contains(name));
+            if !has_any_builtin {
+                return available;
+            }
+            available
+                .into_iter()
+                .filter(|n| on_disk.contains(n))
+                .collect()
+        }
+        None => available, // first run: enable everything
     }
 }
 

--- a/src/extensions_config.rs
+++ b/src/extensions_config.rs
@@ -1,20 +1,6 @@
-//! Persistence for the "enabled extensions" list.
-//!
-//! Stores a JSON file at `~/.config/jackdaw/extensions.json`:
-//!
-//! ```json
-//! {
-//!   "enabled": [
-//!     "core_windows",
-//!     "inspector",
-//!     "sample"
-//!   ]
-//! }
-//! ```
-//!
-//! Read once on editor startup to decide which entries in the
-//! [`ExtensionCatalog`] to enable. Rewritten whenever the user toggles
-//! an extension in the Extensions dialog.
+//! Persistence for the enabled-extensions list at
+//! `~/.config/jackdaw/extensions.json`. Read on startup, rewritten
+//! whenever the user toggles an extension.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -58,19 +44,12 @@ pub fn write_enabled_list(enabled: &[String]) {
     }
 }
 
-/// Resolve which catalog entries should be enabled on startup given the
-/// persisted list, if any. Called by the Startup system in `lib.rs`.
+/// Resolve which catalog entries to enable on startup.
 ///
-/// Includes a one-time upgrade migration: if the saved list predates the
-/// built-in feature-area extensions (none of its entries are built-ins),
-/// every catalog entry is enabled. The next toggle rewrites the file
-/// with the full list. Once the file records at least one built-in, the
-/// user's recorded preferences are trusted exactly as written, so an
-/// intentional disable of `inspector` stays disabled across restarts.
-///
-/// "Which names are built-ins" comes from the catalog itself: each
-/// extension declares its [`ExtensionKind`] on the `JackdawExtension`
-/// trait and registration captures it.
+/// Pre-dogfood files list none of the built-ins; fall back to enabling
+/// everything so the editor stays usable until the next toggle rewrites
+/// the file. Files that already record at least one built-in are
+/// trusted exactly as written.
 pub fn resolve_enabled_list(world: &World) -> Vec<String> {
     let catalog = world.resource::<ExtensionCatalog>();
     let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
@@ -83,10 +62,6 @@ pub fn resolve_enabled_list(world: &World) -> Vec<String> {
     match read_enabled_list() {
         Some(list) => {
             let on_disk: HashSet<String> = list.into_iter().collect();
-            // Pre-dogfood files contain none of the built-in names.
-            // Treat those as legacy and fall back to "enable everything"
-            // so the editor stays usable. The next toggle rewrites the
-            // file with the complete list.
             let has_any_builtin = builtins.iter().any(|name| on_disk.contains(name));
             if !has_any_builtin {
                 return available;
@@ -96,7 +71,7 @@ pub fn resolve_enabled_list(world: &World) -> Vec<String> {
                 .filter(|n| on_disk.contains(n))
                 .collect()
         }
-        None => available, // first run: enable everything
+        None => available,
     }
 }
 

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -1,4 +1,4 @@
-//! `File > Plugins...` dialog. Lets the user enable/disable compiled-in
+//! `File > Extensions...` dialog. Lets the user enable/disable compiled-in
 //! extensions at runtime. Changes are applied immediately via
 //! `enable_extension` / `disable_extension` and persisted to
 //! `~/.config/jackdaw/extensions.json`.
@@ -14,41 +14,41 @@ use jackdaw_feathers::{
 
 use crate::extensions_config;
 
-pub struct PluginsDialogPlugin;
+pub struct ExtensionsDialogPlugin;
 
-impl Plugin for PluginsDialogPlugin {
+impl Plugin for ExtensionsDialogPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<PluginsDialogOpen>()
-            .add_systems(Update, populate_plugins_dialog)
-            .add_observer(on_plugin_checkbox_commit)
+        app.init_resource::<ExtensionsDialogOpen>()
+            .add_systems(Update, populate_extensions_dialog)
+            .add_observer(on_extension_checkbox_commit)
             .add_observer(on_dialog_closed);
     }
 }
 
 /// Clear the open flag whenever any dialog closes. Safe because populate
-/// also checks for existing plugin checkboxes — it won't run again until
-/// the next open.
-fn on_dialog_closed(_: On<CloseDialogEvent>, mut open: ResMut<PluginsDialogOpen>) {
+/// also checks for existing extension checkboxes — it won't run again
+/// until the next open.
+fn on_dialog_closed(_: On<CloseDialogEvent>, mut open: ResMut<ExtensionsDialogOpen>) {
     open.0 = false;
 }
 
 /// Set to `true` while the dialog is being shown. Used by the populate
 /// system to know whether to fill the dialog's children slot.
 #[derive(Resource, Default)]
-struct PluginsDialogOpen(bool);
+struct ExtensionsDialogOpen(bool);
 
-/// Marks a checkbox as belonging to the plugins dialog. Stores the
+/// Marks a checkbox as belonging to the extensions dialog. Stores the
 /// extension name so the commit observer knows which one to toggle.
 #[derive(Component)]
-struct PluginCheckbox {
+struct ExtensionCheckbox {
     extension_name: String,
 }
 
-/// Opened from `File > Plugins...`. Called from the menu action handler.
-pub fn open_plugins_dialog(world: &mut World) {
-    world.resource_mut::<PluginsDialogOpen>().0 = true;
+/// Opened from `File > Extensions...`. Called from the menu action handler.
+pub fn open_extensions_dialog(world: &mut World) {
+    world.resource_mut::<ExtensionsDialogOpen>().0 = true;
     world.trigger(
-        OpenDialogEvent::new("Plugins", "Close")
+        OpenDialogEvent::new("Extensions", "Close")
             .without_cancel()
             .with_max_width(Val::Px(380.0)),
     );
@@ -60,17 +60,17 @@ pub fn open_plugins_dialog(world: &mut World) {
 ///
 /// Note: we do NOT filter on `&Children` because a freshly-spawned
 /// `DialogChildrenSlot` with no children doesn't have a `Children`
-/// component at all — the query would never match. Instead we rely on the
-/// `PluginCheckbox` existence check to avoid re-populating.
-fn populate_plugins_dialog(
+/// component at all — the query would never match. Instead we rely on
+/// the `ExtensionCheckbox` existence check to avoid re-populating.
+fn populate_extensions_dialog(
     mut commands: Commands,
     catalog: Res<ExtensionCatalog>,
-    open: Res<PluginsDialogOpen>,
+    open: Res<ExtensionsDialogOpen>,
     slots: Query<Entity, With<DialogChildrenSlot>>,
     loaded: Query<&Extension>,
     editor_font: Res<EditorFont>,
     icon_font: Res<IconFont>,
-    existing: Query<(), With<PluginCheckbox>>,
+    existing: Query<(), With<ExtensionCheckbox>>,
 ) {
     if !open.0 {
         return;
@@ -114,7 +114,7 @@ fn populate_plugins_dialog(
         let label = prettify(&name);
         commands.spawn((
             ChildOf(list),
-            PluginCheckbox {
+            ExtensionCheckbox {
                 extension_name: name.clone(),
             },
             checkbox(CheckboxProps::new(label).checked(checked), &font, &ifont),
@@ -122,11 +122,11 @@ fn populate_plugins_dialog(
     }
 }
 
-/// Observer: when a plugin checkbox commits, enable/disable the matching
-/// extension and rewrite the enabled list.
-fn on_plugin_checkbox_commit(
+/// Observer: when an extension checkbox commits, enable/disable the
+/// matching extension and rewrite the enabled list.
+fn on_extension_checkbox_commit(
     event: On<CheckboxCommitEvent>,
-    checkboxes: Query<&PluginCheckbox>,
+    checkboxes: Query<&ExtensionCheckbox>,
     mut commands: Commands,
 ) {
     let Ok(cb) = checkboxes.get(event.entity) else {

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -4,7 +4,7 @@
 //! `~/.config/jackdaw/extensions.json`.
 
 use bevy::prelude::*;
-use jackdaw_api::{Extension, ExtensionCatalog};
+use jackdaw_api::{Extension, ExtensionCatalog, ExtensionKind};
 use jackdaw_feathers::{
     checkbox::{CheckboxCommitEvent, CheckboxProps, checkbox},
     dialog::{CloseDialogEvent, DialogChildrenSlot, OpenDialogEvent},
@@ -25,9 +25,9 @@ impl Plugin for ExtensionsDialogPlugin {
     }
 }
 
-/// Clear the open flag whenever any dialog closes. Safe because populate
-/// also checks for existing extension checkboxes — it won't run again
-/// until the next open.
+/// Clear the open flag whenever any dialog closes. Safe because
+/// [`populate_extensions_dialog`] also checks for existing checkboxes
+/// before filling the slot, so it won't double-populate between closes.
 fn on_dialog_closed(_: On<CloseDialogEvent>, mut open: ResMut<ExtensionsDialogOpen>) {
     open.0 = false;
 }
@@ -55,13 +55,14 @@ pub fn open_extensions_dialog(world: &mut World) {
 }
 
 /// Populate the dialog's children slot with a row per catalog entry.
-/// Runs each frame but short-circuits unless the dialog is currently open
-/// and hasn't been populated yet.
+/// Runs each frame and short-circuits unless the dialog is open and
+/// hasn't been populated yet.
 ///
-/// Note: we do NOT filter on `&Children` because a freshly-spawned
-/// `DialogChildrenSlot` with no children doesn't have a `Children`
-/// component at all — the query would never match. Instead we rely on
-/// the `ExtensionCheckbox` existence check to avoid re-populating.
+/// The slot is detected by marker presence rather than by filtering on
+/// `&Children`. A freshly-spawned `DialogChildrenSlot` with no children
+/// has no `Children` component at all, which would cause the filter to
+/// never match. Checking for existing `ExtensionCheckbox` entities is
+/// how this system avoids re-populating the same dialog.
 fn populate_extensions_dialog(
     mut commands: Commands,
     catalog: Res<ExtensionCatalog>,
@@ -85,18 +86,25 @@ fn populate_extensions_dialog(
     let font = editor_font.0.clone();
     let ifont = icon_font.0.clone();
 
-    // Collect (name, is_enabled) for each catalog entry, sorted for
-    // stable ordering across runs.
+    // Collect (name, is_enabled) for each catalog entry, split into
+    // Built-in (Jackdaw feature areas) and Custom (example and
+    // third-party extensions). Group membership is taken from each
+    // extension's declared `ExtensionKind`, captured at
+    // `register_extension` time. Adding a new built-in is therefore a
+    // one-liner on the extension itself.
     let enabled_names: std::collections::HashSet<String> =
         loaded.iter().map(|e| e.name.clone()).collect();
-    let mut rows: Vec<(String, bool)> = catalog
-        .iter()
-        .map(|n| {
-            let is_enabled = enabled_names.contains(n);
-            (n.to_string(), is_enabled)
-        })
-        .collect();
-    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut builtin_rows: Vec<(String, bool)> = Vec::new();
+    let mut custom_rows: Vec<(String, bool)> = Vec::new();
+    for (name, kind) in catalog.iter_with_kind() {
+        let row = (name.to_string(), enabled_names.contains(name));
+        match kind {
+            ExtensionKind::Builtin => builtin_rows.push(row),
+            ExtensionKind::Custom => custom_rows.push(row),
+        }
+    }
+    builtin_rows.sort_by(|a, b| a.0.cmp(&b.0));
+    custom_rows.sort_by(|a, b| a.0.cmp(&b.0));
 
     let list = commands
         .spawn((
@@ -110,7 +118,8 @@ fn populate_extensions_dialog(
         ))
         .id();
 
-    for (name, checked) in rows {
+    spawn_section_header(&mut commands, list, "Built-in");
+    for (name, checked) in builtin_rows {
         let label = prettify(&name);
         commands.spawn((
             ChildOf(list),
@@ -120,6 +129,71 @@ fn populate_extensions_dialog(
             checkbox(CheckboxProps::new(label).checked(checked), &font, &ifont),
         ));
     }
+
+    spawn_section_header(&mut commands, list, "Custom");
+    if custom_rows.is_empty() {
+        // Empty-state hint so users learn where custom extensions will
+        // appear. Without it the section header sits alone and reads as
+        // broken UI.
+        commands.spawn((
+            ChildOf(list),
+            Node {
+                padding: UiRect::axes(Val::Px(tokens::SPACING_LG), Val::Px(tokens::SPACING_SM)),
+                ..default()
+            },
+            children![(
+                Text::new("No custom extensions installed"),
+                TextFont {
+                    font_size: tokens::FONT_SM,
+                    ..default()
+                },
+                TextColor(tokens::TEXT_SECONDARY),
+            )],
+        ));
+    } else {
+        for (name, checked) in custom_rows {
+            let label = prettify(&name);
+            commands.spawn((
+                ChildOf(list),
+                ExtensionCheckbox {
+                    extension_name: name.clone(),
+                },
+                checkbox(CheckboxProps::new(label).checked(checked), &font, &ifont),
+            ));
+        }
+    }
+}
+
+/// Small underlined heading matching the `ComponentPickerSectionHeader`
+/// look from the Add Component dialog, so the two modals feel uniform.
+fn spawn_section_header(commands: &mut Commands, list: Entity, label: &str) {
+    let header = commands
+        .spawn((
+            ChildOf(list),
+            Node {
+                padding: UiRect::new(
+                    Val::Px(tokens::SPACING_LG),
+                    Val::Px(tokens::SPACING_LG),
+                    Val::Px(tokens::SPACING_MD),
+                    Val::Px(tokens::SPACING_XS),
+                ),
+                width: Val::Percent(100.0),
+                border: UiRect::bottom(Val::Px(1.0)),
+                ..default()
+            },
+            BorderColor::all(tokens::BORDER_SUBTLE),
+        ))
+        .id();
+
+    commands.spawn((
+        ChildOf(header),
+        Text::new(label.to_string()),
+        TextFont {
+            font_size: tokens::FONT_SM,
+            ..default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+    ));
 }
 
 /// Observer: when an extension checkbox commits, enable/disable the

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -1,7 +1,5 @@
-//! `File > Extensions...` dialog. Lets the user enable/disable compiled-in
-//! extensions at runtime. Changes are applied immediately via
-//! `enable_extension` / `disable_extension` and persisted to
-//! `~/.config/jackdaw/extensions.json`.
+//! File > Extensions dialog. Toggles compiled-in extensions at runtime
+//! and persists the current state to `extensions.json`.
 
 use bevy::prelude::*;
 use jackdaw_api::{Extension, ExtensionCatalog, ExtensionKind};
@@ -25,26 +23,20 @@ impl Plugin for ExtensionsDialogPlugin {
     }
 }
 
-/// Clear the open flag whenever any dialog closes. Safe because
-/// [`populate_extensions_dialog`] also checks for existing checkboxes
-/// before filling the slot, so it won't double-populate between closes.
 fn on_dialog_closed(_: On<CloseDialogEvent>, mut open: ResMut<ExtensionsDialogOpen>) {
     open.0 = false;
 }
 
-/// Set to `true` while the dialog is being shown. Used by the populate
-/// system to know whether to fill the dialog's children slot.
 #[derive(Resource, Default)]
 struct ExtensionsDialogOpen(bool);
 
-/// Marks a checkbox as belonging to the extensions dialog. Stores the
-/// extension name so the commit observer knows which one to toggle.
+/// Records the extension name on each checkbox so the commit observer
+/// can look up which one to toggle.
 #[derive(Component)]
 struct ExtensionCheckbox {
     extension_name: String,
 }
 
-/// Opened from `File > Extensions...`. Called from the menu action handler.
 pub fn open_extensions_dialog(world: &mut World) {
     world.resource_mut::<ExtensionsDialogOpen>().0 = true;
     world.trigger(
@@ -54,15 +46,12 @@ pub fn open_extensions_dialog(world: &mut World) {
     );
 }
 
-/// Populate the dialog's children slot with a row per catalog entry.
-/// Runs each frame and short-circuits unless the dialog is open and
-/// hasn't been populated yet.
+/// Fill the dialog's children slot with a row per catalog entry.
 ///
-/// The slot is detected by marker presence rather than by filtering on
-/// `&Children`. A freshly-spawned `DialogChildrenSlot` with no children
-/// has no `Children` component at all, which would cause the filter to
-/// never match. Checking for existing `ExtensionCheckbox` entities is
-/// how this system avoids re-populating the same dialog.
+/// The slot is found by marker presence rather than `&Children` because
+/// a freshly-spawned `DialogChildrenSlot` has no `Children` component
+/// yet. Checking for existing `ExtensionCheckbox` entities prevents
+/// double-populating a re-opened dialog.
 fn populate_extensions_dialog(
     mut commands: Commands,
     catalog: Res<ExtensionCatalog>,
@@ -86,12 +75,8 @@ fn populate_extensions_dialog(
     let font = editor_font.0.clone();
     let ifont = icon_font.0.clone();
 
-    // Collect (name, is_enabled) for each catalog entry, split into
-    // Built-in (Jackdaw feature areas) and Custom (example and
-    // third-party extensions). Group membership is taken from each
-    // extension's declared `ExtensionKind`, captured at
-    // `register_extension` time. Adding a new built-in is therefore a
-    // one-liner on the extension itself.
+    // Split catalog entries into Built-in vs. Custom. Membership comes
+    // from each extension's declared `ExtensionKind`.
     let enabled_names: std::collections::HashSet<String> =
         loaded.iter().map(|e| e.name.clone()).collect();
     let mut builtin_rows: Vec<(String, bool)> = Vec::new();
@@ -132,9 +117,6 @@ fn populate_extensions_dialog(
 
     spawn_section_header(&mut commands, list, "Custom");
     if custom_rows.is_empty() {
-        // Empty-state hint so users learn where custom extensions will
-        // appear. Without it the section header sits alone and reads as
-        // broken UI.
         commands.spawn((
             ChildOf(list),
             Node {
@@ -164,8 +146,7 @@ fn populate_extensions_dialog(
     }
 }
 
-/// Small underlined heading matching the `ComponentPickerSectionHeader`
-/// look from the Add Component dialog, so the two modals feel uniform.
+/// Underlined heading matching the Add Component dialog's style.
 fn spawn_section_header(commands: &mut Commands, list: Entity, label: &str) {
     let header = commands
         .spawn((
@@ -196,8 +177,8 @@ fn spawn_section_header(commands: &mut Commands, list: Entity, label: &str) {
     ));
 }
 
-/// Observer: when an extension checkbox commits, enable/disable the
-/// matching extension and rewrite the enabled list.
+/// Enable or disable the matching extension when a checkbox commits,
+/// then persist the new enabled list.
 fn on_extension_checkbox_commit(
     event: On<CheckboxCommitEvent>,
     checkboxes: Query<&ExtensionCheckbox>,

--- a/src/gizmos.rs
+++ b/src/gizmos.rs
@@ -417,8 +417,7 @@ fn handle_gizmo_drag(
                     old_transform: drag_state.start_transform,
                     new_transform: *transform,
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                history.push_executed(Box::new(cmd));
             }
         }
         drag_state.active = false;

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -82,6 +82,7 @@ impl Plugin for HierarchyPlugin {
             .add_observer(handle_inline_rename_commit)
             .add_observer(on_root_entity_added)
             .add_observer(on_entity_reparented)
+            .add_observer(on_entity_deparented)
             .add_observer(on_tree_node_expanded)
             .add_observer(on_tree_row_clicked)
             .add_observer(on_entity_removed)
@@ -441,6 +442,30 @@ fn on_entity_reparented(
         }
         spawn_single_tree_row(world, entity, container);
     });
+}
+
+/// When ChildOf is removed (entity deparented back to root, e.g. via undo of
+/// a reparent), move its tree row back to the root container. Without this,
+/// the tree UI shows stale parent information after an undo.
+fn on_entity_deparented(
+    trigger: On<Remove, ChildOf>,
+    mut commands: Commands,
+    tree_index: Res<TreeIndex>,
+    container: Option<Single<Entity, With<HierarchyTreeContainer>>>,
+    editor_check: Query<(), Or<(With<EditorEntity>, With<EditorHidden>)>>,
+    tree_node_check: Query<(), With<TreeNode>>,
+) {
+    let entity = trigger.event_target();
+    if editor_check.contains(entity) || tree_node_check.contains(entity) {
+        return;
+    }
+    let Some(container) = container else {
+        return;
+    };
+    let root_container = *container;
+    if let Some(tree_entity) = tree_index.get(entity) {
+        commands.entity(tree_entity).insert(ChildOf(root_container));
+    }
 }
 
 /// When an entity's Name is removed, despawn its tree row.

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -782,6 +782,7 @@ fn handle_hierarchy_right_click(
     tree_row_contents: Query<(Entity, &ChildOf), With<TreeRowContent>>,
     tree_nodes: Query<&TreeNode>,
     computed_nodes: Query<(&ComputedNode, &UiGlobalTransform), With<TreeRowContent>>,
+    extension_add_entries: Query<&jackdaw_api::RegisteredMenuEntry>,
 ) {
     if !mouse.just_pressed(MouseButton::Right) {
         return;
@@ -845,25 +846,40 @@ fn handle_hierarchy_right_click(
         });
     }
 
-    let menu_items = &[
-        ("hierarchy.focus", "Focus                    F"),
-        ("hierarchy.rename", "Rename              F2"),
-        ("hierarchy.duplicate", "Duplicate        Ctrl+D"),
-        ("hierarchy.delete", "Delete             Del"),
-        ("---", ""),
-        ("hierarchy.save_template", "Save as Template..."),
-        ("---", ""),
-        ("hierarchy.add_cube", "Add Child Cube"),
-        ("hierarchy.add_sphere", "Add Child Sphere"),
-        ("hierarchy.add_light", "Add Child Light"),
-        ("hierarchy.add_empty", "Add Child Empty"),
+    // Built-in context menu items. The "Add Child ..." entries are the
+    // parent-aware variant: they spawn the entity and reparent it under
+    // the right-clicked target.
+    let mut owned_items: Vec<(String, String)> = vec![
+        ("hierarchy.focus".into(), "Focus                    F".into()),
+        ("hierarchy.rename".into(), "Rename              F2".into()),
+        ("hierarchy.duplicate".into(), "Duplicate        Ctrl+D".into()),
+        ("hierarchy.delete".into(), "Delete             Del".into()),
+        ("hierarchy.save_template".into(), "Save as Template...".into()),
+        ("hierarchy.add_cube".into(), "Add Child Cube".into()),
+        ("hierarchy.add_sphere".into(), "Add Child Sphere".into()),
+        ("hierarchy.add_light".into(), "Add Child Light".into()),
+        ("hierarchy.add_empty".into(), "Add Child Empty".into()),
     ];
 
-    // Filter out separators for spawn_context_menu (it doesn't handle them)
-    let items: Vec<(&str, &str)> = menu_items
+    // Append extension-contributed Add entries — same source the toolbar
+    // Add menu and the Add Entity picker use, so a single
+    // `register_menu_entry` call surfaces in all three places.
+    let mut ext_rows: Vec<(String, String)> = extension_add_entries
         .iter()
-        .filter(|(action, _)| *action != "---")
-        .copied()
+        .filter(|entry| entry.menu == "Add")
+        .map(|entry| {
+            (
+                format!("op:{}", entry.operator_id),
+                format!("Add {}", entry.label),
+            )
+        })
+        .collect();
+    ext_rows.sort_by(|a, b| a.1.cmp(&b.1));
+    owned_items.extend(ext_rows);
+
+    let items: Vec<(&str, &str)> = owned_items
+        .iter()
+        .map(|(a, l)| (a.as_str(), l.as_str()))
         .collect();
 
     let menu = spawn_context_menu(&mut commands, cursor_pos, Some(target), &items);
@@ -981,6 +997,16 @@ fn on_context_menu_action(
                     "Save",
                 ));
             }
+        }
+        action if action.starts_with("op:") => {
+            // Extension-contributed Add entry. Dispatch through the same
+            // path as the toolbar Add menu and the Add Entity picker so
+            // operators behave identically regardless of which surface
+            // invoked them.
+            let operator_id = action.strip_prefix("op:").unwrap().to_string();
+            commands.queue(move |world: &mut World| {
+                jackdaw_api::lifecycle::dispatch_operator_by_id(world, &operator_id, true);
+            });
         }
         _ => {}
     }

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -850,20 +850,29 @@ fn handle_hierarchy_right_click(
     // parent-aware variant: they spawn the entity and reparent it under
     // the right-clicked target.
     let mut owned_items: Vec<(String, String)> = vec![
-        ("hierarchy.focus".into(), "Focus                    F".into()),
+        (
+            "hierarchy.focus".into(),
+            "Focus                    F".into(),
+        ),
         ("hierarchy.rename".into(), "Rename              F2".into()),
-        ("hierarchy.duplicate".into(), "Duplicate        Ctrl+D".into()),
+        (
+            "hierarchy.duplicate".into(),
+            "Duplicate        Ctrl+D".into(),
+        ),
         ("hierarchy.delete".into(), "Delete             Del".into()),
-        ("hierarchy.save_template".into(), "Save as Template...".into()),
+        (
+            "hierarchy.save_template".into(),
+            "Save as Template...".into(),
+        ),
         ("hierarchy.add_cube".into(), "Add Child Cube".into()),
         ("hierarchy.add_sphere".into(), "Add Child Sphere".into()),
         ("hierarchy.add_light".into(), "Add Child Light".into()),
         ("hierarchy.add_empty".into(), "Add Child Empty".into()),
     ];
 
-    // Append extension-contributed Add entries — same source the toolbar
-    // Add menu and the Add Entity picker use, so a single
-    // `register_menu_entry` call surfaces in all three places.
+    // Append extension-contributed Add entries from the same source the
+    // toolbar Add menu and the Add Entity picker use. One
+    // `register_menu_entry` call therefore surfaces in all three places.
     let mut ext_rows: Vec<(String, String)> = extension_add_entries
         .iter()
         .filter(|entry| entry.menu == "Add")

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -988,14 +988,14 @@ fn on_visibility_toggled(
         field_path: String::new(),
         old_value: old_json,
         new_value: new_json,
+        was_derived: false,
     };
 
     commands.queue(move |world: &mut World| {
         let mut cmd = Box::new(cmd);
         cmd.execute(world);
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(cmd);
-        history.redo_stack.clear();
+        history.push_executed(cmd);
     });
 }
 
@@ -1227,12 +1227,12 @@ fn on_tree_row_renamed(event: On<TreeRowRenamed>, mut commands: Commands, names:
             field_path: String::new(),
             old_value: serde_json::Value::String(old_name),
             new_value: serde_json::Value::String(new_name),
+            was_derived: false,
         };
         let mut cmd = Box::new(cmd);
         cmd.execute(world);
         let mut history = world.resource_mut::<CommandHistory>();
-        history.undo_stack.push(cmd);
-        history.redo_stack.clear();
+        history.push_executed(cmd);
     });
 }
 

--- a/src/inspector/brush_display.rs
+++ b/src/inspector/brush_display.rs
@@ -760,8 +760,7 @@ fn apply_brush_face_field(
         new: brush.clone(),
         label: "Edit face UV".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }
 
 pub(crate) fn handle_clear_material(
@@ -798,8 +797,7 @@ pub(crate) fn handle_clear_material(
         new: brush.clone(),
         label: "Clear material".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
     commands.entity(brush_entity).insert(super::InspectorDirty);
 }
 
@@ -837,8 +835,7 @@ pub(crate) fn handle_clear_texture(
         new: brush.clone(),
         label: "Clear texture".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
     commands.entity(brush_entity).insert(super::InspectorDirty);
 }
 
@@ -883,8 +880,7 @@ pub(crate) fn handle_apply_texture_to_all(
         new: brush.clone(),
         label: "Apply material to all faces".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
     commands.entity(brush_entity).insert(super::InspectorDirty);
 }
 
@@ -922,8 +918,7 @@ pub(crate) fn handle_uv_scale_preset(
         new: brush.clone(),
         label: "Set UV scale preset".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }
 
 pub(crate) fn handle_clear_material_from_brush(
@@ -951,6 +946,7 @@ pub(crate) fn handle_clear_material_from_brush(
         })
         .collect();
 
+    let mut group_commands: Vec<Box<dyn jackdaw_commands::EditorCommand>> = Vec::new();
     for entity in targets {
         if let Ok(mut brush) = brushes.get_mut(entity) {
             let has_any_material = brush.faces.iter().any(|f| f.material != Handle::default());
@@ -967,9 +963,14 @@ pub(crate) fn handle_clear_material_from_brush(
                 new: brush.clone(),
                 label: "Clear all materials".to_string(),
             };
-            history.undo_stack.push(Box::new(cmd));
-            history.redo_stack.clear();
+            group_commands.push(Box::new(cmd));
             commands.entity(entity).insert(super::InspectorDirty);
         }
+    }
+    if !group_commands.is_empty() {
+        history.push_executed(Box::new(jackdaw_commands::CommandGroup {
+            commands: group_commands,
+            label: "Clear all materials".to_string(),
+        }));
     }
 }

--- a/src/inspector/component_picker.rs
+++ b/src/inspector/component_picker.rs
@@ -348,8 +348,7 @@ pub(crate) fn on_add_component_button_click(
                                 cmd.execute(world);
                                 let mut history =
                                     world.resource_mut::<crate::commands::CommandHistory>();
-                                history.undo_stack.push(cmd);
-                                history.redo_stack.clear();
+                                history.push_executed(cmd);
 
                                 // Signal the inspector to rebuild
                                 world.entity_mut(source_entity).insert(InspectorDirty);

--- a/src/inspector/custom_props_display.rs
+++ b/src/inspector/custom_props_display.rs
@@ -412,8 +412,7 @@ fn add_custom_property_from_ui(world: &mut World, source_entity: Entity) {
     cmd.execute(world);
 
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 
     // Rebuild inspector
     rebuild_inspector(world, source_entity);
@@ -436,8 +435,7 @@ fn remove_custom_property(world: &mut World, source_entity: Entity, property_nam
     cmd.execute(world);
 
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 
     rebuild_inspector(world, source_entity);
 }
@@ -464,8 +462,7 @@ fn apply_custom_property_with_undo(
     cmd.execute(world);
 
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }
 
 /// Handle TextEditCommitEvent for custom property numeric/string fields + axis bindings.

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -140,10 +140,76 @@ impl Plugin for InspectorPlugin {
                     component_display::filter_inspector_components,
                     anim_diamond::decorate_animatable_fields,
                     anim_diamond::update_anim_diamond_highlights,
+                    refresh_name_field,
                 )
                     .run_if(in_state(crate::AppState::Editor)),
             );
     }
+}
+
+/// Keep the Name field's text input in sync with the underlying Name component.
+/// Needed so that undo/redo and external edits are reflected in the UI without
+/// having to deselect and reselect the entity.
+fn refresh_name_field(world: &mut World) {
+    use bevy::input_focus::InputFocus;
+    use jackdaw_feathers::text_edit::{
+        TextEditDragging, TextEditValue, TextInputQueue, set_text_input_value,
+    };
+
+    // Gather (outer, source_entity, current_value) tuples.
+    let mut targets: Vec<(Entity, Entity, String)> = Vec::new();
+    let mut query = world.query::<(Entity, &NameFieldInput, &TextEditValue)>();
+    for (outer, input, value) in query.iter(world) {
+        targets.push((outer, input.0, value.0.clone()));
+    }
+    if targets.is_empty() {
+        return;
+    }
+
+    let input_focus = world.resource::<InputFocus>().0;
+
+    for (outer, source, current) in targets {
+        let Some(name) = world.get::<Name>(source) else {
+            continue;
+        };
+        let expected = name.as_str().to_string();
+        if current == expected {
+            continue;
+        }
+        // Walk outer -> children (and grandchildren) to find the wrapper.
+        let Some((wrapper_entity, inner_entity)) = find_text_edit_entities_local(world, outer)
+        else {
+            continue;
+        };
+        // Skip if the user is currently dragging or typing in this field.
+        if world.get::<TextEditDragging>(wrapper_entity).is_some() {
+            continue;
+        }
+        if input_focus == Some(inner_entity) {
+            continue;
+        }
+        if let Some(mut queue) = world.get_mut::<TextInputQueue>(inner_entity) {
+            set_text_input_value(&mut queue, expected);
+        }
+    }
+}
+
+fn find_text_edit_entities_local(world: &World, outer_entity: Entity) -> Option<(Entity, Entity)> {
+    use jackdaw_feathers::text_edit::TextEditWrapper;
+    let children = world.get::<Children>(outer_entity)?;
+    for child in children.iter() {
+        if let Some(wrapper) = world.get::<TextEditWrapper>(child) {
+            return Some((child, wrapper.0));
+        }
+        if let Some(grandchildren) = world.get::<Children>(child) {
+            for gc in grandchildren.iter() {
+                if let Some(wrapper) = world.get::<TextEditWrapper>(gc) {
+                    return Some((gc, wrapper.0));
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Handle TextEditCommitEvent for Name field inputs.

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -147,11 +147,13 @@ impl Plugin for InspectorPlugin {
 }
 
 /// Handle TextEditCommitEvent for Name field inputs.
+/// Pushes a `SetJsnField` command so the rename can be undone.
 fn on_name_field_commit(
     event: On<jackdaw_feathers::text_edit::TextEditCommitEvent>,
     name_inputs: Query<&NameFieldInput>,
     child_of_query: Query<&ChildOf>,
-    mut names: Query<&mut Name>,
+    names: Query<&Name>,
+    mut commands: Commands,
 ) {
     // Walk up from the committed entity to find a NameFieldInput
     let mut current = event.entity;
@@ -171,9 +173,31 @@ fn on_name_field_commit(
         return;
     };
 
-    if let Ok(mut name) = names.get_mut(source_entity) {
-        *name = Name::new(event.text.clone());
+    let old_name = names
+        .get(source_entity)
+        .map(|n| n.as_str().to_string())
+        .unwrap_or_default();
+    let new_name = event.text.clone();
+
+    if old_name == new_name {
+        return;
     }
+
+    commands.queue(move |world: &mut World| {
+        let cmd = crate::commands::SetJsnField {
+            entity: source_entity,
+            type_path: "bevy_ecs::name::Name".to_string(),
+            field_path: String::new(),
+            old_value: serde_json::Value::String(old_name),
+            new_value: serde_json::Value::String(new_name),
+            was_derived: false,
+        };
+        let mut cmd: Box<dyn jackdaw_commands::EditorCommand> = Box::new(cmd);
+        cmd.execute(world);
+        world
+            .resource_mut::<crate::commands::CommandHistory>()
+            .push_executed(cmd);
+    });
 }
 
 #[derive(Component)]

--- a/src/inspector/physics_display.rs
+++ b/src/inspector/physics_display.rs
@@ -527,9 +527,7 @@ pub(super) fn on_physics_enable_toggle(
             let cmd = DisablePhysics::from_world(world, source_entity);
             let mut cmd: Box<dyn EditorCommand> = Box::new(cmd);
             cmd.execute(world);
-            world
-                .resource_mut::<CommandHistory>()
-                .push_executed(cmd);
+            world.resource_mut::<CommandHistory>().push_executed(cmd);
         }
         // Rebuild inspector
         if let Ok(mut ec) = world.get_entity_mut(source_entity) {
@@ -553,7 +551,10 @@ impl DisablePhysics {
     fn from_world(world: &World, entity: Entity) -> Self {
         let mut removed_components = std::collections::HashMap::new();
         let mut removed_derived = std::collections::HashSet::new();
-        if let Some(node) = world.resource::<jackdaw_jsn::SceneJsnAst>().node_for_entity(entity) {
+        if let Some(node) = world
+            .resource::<jackdaw_jsn::SceneJsnAst>()
+            .node_for_entity(entity)
+        {
             for (type_path, value) in &node.components {
                 if type_path == RIGID_BODY_TYPE_PATH
                     || type_path == AVIAN_COLLIDER_TYPE_PATH
@@ -607,7 +608,9 @@ impl EditorCommand for DisablePhysics {
             let Some(registration) = reg.get_with_type_path(type_path) else {
                 continue;
             };
-            let Some(reflect_component) = registration.data::<bevy::ecs::reflect::ReflectComponent>() else {
+            let Some(reflect_component) =
+                registration.data::<bevy::ecs::reflect::ReflectComponent>()
+            else {
                 continue;
             };
             // Deserialize JSON -> reflected value -> insert into ECS
@@ -709,4 +712,3 @@ fn enable_physics(world: &mut World, entity: Entity) {
     let mut history = world.resource_mut::<CommandHistory>();
     history.push_executed(cmd);
 }
-

--- a/src/inspector/physics_display.rs
+++ b/src/inspector/physics_display.rs
@@ -201,6 +201,7 @@ pub(super) fn spawn_physics_section(
                         field_path: String::new(),
                         old_value: old_json,
                         new_value: new_json.clone(),
+                        was_derived: false,
                     }));
                 }
                 drop(reg);
@@ -218,8 +219,7 @@ pub(super) fn spawn_physics_section(
                 };
                 cmd.execute(world);
                 let mut history = world.resource_mut::<CommandHistory>();
-                history.undo_stack.push(cmd);
-                history.redo_stack.clear();
+                history.push_executed(cmd);
 
                 // Rebuild inspector to reflect the change
                 for &t in &targets {
@@ -522,13 +522,128 @@ pub(super) fn on_physics_enable_toggle(
         if checked {
             enable_physics(world, source_entity);
         } else {
-            disable_physics(world, source_entity);
+            // Wrap disable in an undoable command. Captures the full
+            // physics-related AST state as a snapshot and restores it on undo.
+            let cmd = DisablePhysics::from_world(world, source_entity);
+            let mut cmd: Box<dyn EditorCommand> = Box::new(cmd);
+            cmd.execute(world);
+            world
+                .resource_mut::<CommandHistory>()
+                .push_executed(cmd);
         }
         // Rebuild inspector
         if let Ok(mut ec) = world.get_entity_mut(source_entity) {
             ec.insert(super::InspectorDirty);
         }
     });
+}
+
+/// Command that disables physics on an entity. Captures the full pre-disable
+/// state (RigidBody, AvianCollider, and all derived avian components in the
+/// AST) so undo restores them.
+struct DisablePhysics {
+    entity: Entity,
+    /// Snapshot of AST components that were removed, keyed by type_path.
+    removed_components: std::collections::HashMap<String, serde_json::Value>,
+    /// Derived components that were cleared on execute, for re-adding on undo.
+    removed_derived: std::collections::HashSet<String>,
+}
+
+impl DisablePhysics {
+    fn from_world(world: &World, entity: Entity) -> Self {
+        let mut removed_components = std::collections::HashMap::new();
+        let mut removed_derived = std::collections::HashSet::new();
+        if let Some(node) = world.resource::<jackdaw_jsn::SceneJsnAst>().node_for_entity(entity) {
+            for (type_path, value) in &node.components {
+                if type_path == RIGID_BODY_TYPE_PATH
+                    || type_path == AVIAN_COLLIDER_TYPE_PATH
+                    || type_path.starts_with("avian3d::")
+                {
+                    removed_components.insert(type_path.clone(), value.clone());
+                }
+            }
+            for type_path in &node.derived_components {
+                if type_path == RIGID_BODY_TYPE_PATH
+                    || type_path == AVIAN_COLLIDER_TYPE_PATH
+                    || type_path.starts_with("avian3d::")
+                {
+                    removed_derived.insert(type_path.clone());
+                }
+            }
+        }
+        Self {
+            entity,
+            removed_components,
+            removed_derived,
+        }
+    }
+}
+
+impl EditorCommand for DisablePhysics {
+    fn execute(&mut self, world: &mut World) {
+        // Remove ECS components
+        if let Ok(mut ec) = world.get_entity_mut(self.entity) {
+            ec.remove::<RigidBody>();
+            ec.remove::<AvianCollider>();
+            ec.remove::<Collider>();
+        }
+        // Clean up AST (matches previous behavior)
+        if let Some(node) = world
+            .resource_mut::<jackdaw_jsn::SceneJsnAst>()
+            .node_for_entity_mut(self.entity)
+        {
+            node.components.remove(RIGID_BODY_TYPE_PATH);
+            node.components.remove(AVIAN_COLLIDER_TYPE_PATH);
+            node.derived_components.clear();
+            node.components.retain(|k, _| !k.starts_with("avian3d::"));
+        }
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        // Restore each component via AST set_component + reflection insert into ECS
+        let registry = world.resource::<AppTypeRegistry>().clone();
+        let reg = registry.read();
+        for (type_path, value) in &self.removed_components {
+            let Some(registration) = reg.get_with_type_path(type_path) else {
+                continue;
+            };
+            let Some(reflect_component) = registration.data::<bevy::ecs::reflect::ReflectComponent>() else {
+                continue;
+            };
+            // Deserialize JSON -> reflected value -> insert into ECS
+            let deserializer =
+                bevy::reflect::serde::TypedReflectDeserializer::new(registration, &reg);
+            use serde::de::DeserializeSeed;
+            let Ok(reflected) = deserializer.deserialize(value) else {
+                continue;
+            };
+            let Ok(mut entity_mut) = world.get_entity_mut(self.entity) else {
+                continue;
+            };
+            reflect_component.insert(&mut entity_mut, reflected.as_ref(), &reg);
+        }
+        drop(reg);
+        // Restore AST entries
+        if let Some(node) = world
+            .resource_mut::<jackdaw_jsn::SceneJsnAst>()
+            .node_for_entity_mut(self.entity)
+        {
+            for (type_path, value) in &self.removed_components {
+                node.components.insert(type_path.clone(), value.clone());
+            }
+            for type_path in &self.removed_derived {
+                node.derived_components.insert(type_path.clone());
+            }
+        }
+        // Rebuild inspector to reflect restored state
+        if let Ok(mut ec) = world.get_entity_mut(self.entity) {
+            ec.insert(super::InspectorDirty);
+        }
+    }
+
+    fn description(&self) -> &str {
+        "Disable physics"
+    }
 }
 
 fn enable_physics(world: &mut World, entity: Entity) {
@@ -592,25 +707,6 @@ fn enable_physics(world: &mut World, entity: Entity) {
     };
     cmd.execute(world);
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(cmd);
-    history.redo_stack.clear();
+    history.push_executed(cmd);
 }
 
-fn disable_physics(world: &mut World, entity: Entity) {
-    // Remove both components + clean up AST
-    if let Ok(mut ec) = world.get_entity_mut(entity) {
-        ec.remove::<RigidBody>();
-        ec.remove::<AvianCollider>();
-        ec.remove::<Collider>();
-    }
-    if let Some(node) = world
-        .resource_mut::<jackdaw_jsn::SceneJsnAst>()
-        .node_for_entity_mut(entity)
-    {
-        node.components.remove(RIGID_BODY_TYPE_PATH);
-        node.components.remove(AVIAN_COLLIDER_TYPE_PATH);
-        // Also remove derived components that came with them
-        node.derived_components.clear();
-        node.components.retain(|k, _| !k.starts_with("avian3d::"));
-    }
-}

--- a/src/inspector/reflect_fields.rs
+++ b/src/inspector/reflect_fields.rs
@@ -1318,6 +1318,7 @@ fn apply_color_with_undo(
             field_path: field_path.to_string(),
             old_value: old_json,
             new_value: new_json.clone(),
+            was_derived: false,
         }));
     }
     drop(reg);
@@ -1336,8 +1337,7 @@ fn apply_color_with_undo(
     };
     cmd.execute(world);
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(cmd);
-    history.redo_stack.clear();
+    history.push_executed(cmd);
 }
 
 fn spawn_numeric_field(
@@ -1482,6 +1482,7 @@ fn apply_field_value_with_undo(
             field_path: field_path.to_string(),
             old_value: old_json,
             new_value: new_json.clone(),
+            was_derived: false,
         }));
     }
     drop(reg);
@@ -1500,8 +1501,7 @@ fn apply_field_value_with_undo(
     };
     cmd.execute(world);
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(cmd);
-    history.redo_stack.clear();
+    history.push_executed(cmd);
 }
 
 /// Parse a text field string to the most appropriate JSON value.
@@ -2384,6 +2384,7 @@ fn apply_enum_variant_with_undo(
             field_path: field_path.to_string(),
             old_value: old_json,
             new_value: new_json.clone(),
+            was_derived: false,
         }));
     }
     drop(reg);
@@ -2402,8 +2403,7 @@ fn apply_enum_variant_with_undo(
     };
     cmd.execute(world);
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(cmd);
-    history.redo_stack.clear();
+    history.push_executed(cmd);
     // No need to flag anything  -- `refresh_enum_variants` detects the ECS
     // variant change and rebuilds the affected subtree automatically. Same
     // goes for undo/redo since the command framework mutates the ECS too.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1100,6 +1100,7 @@ pub fn hierarchy_content(icon_font: Handle<Font>) -> impl Bundle {
                 ],
             ),
             (
+                crate::add_entity_picker::AddEntityButton,
                 Interaction::default(),
                 Hovered::default(),
                 Node {
@@ -1127,6 +1128,14 @@ pub fn hierarchy_content(icon_font: Handle<Font>) -> impl Bundle {
                         if let Ok(mut bg) = bg.get_mut(out.event_target()) {
                             bg.0 = tokens::ELEVATED_BG;
                         }
+                    },
+                ),
+                observe(
+                    |mut click: On<Pointer<Click>>, mut commands: Commands| {
+                        click.propagate(false);
+                        commands.queue(|world: &mut World| {
+                            crate::add_entity_picker::open_add_entity_picker(world);
+                        });
                     },
                 ),
                 children![

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1130,14 +1130,12 @@ pub fn hierarchy_content(icon_font: Handle<Font>) -> impl Bundle {
                         }
                     },
                 ),
-                observe(
-                    |mut click: On<Pointer<Click>>, mut commands: Commands| {
-                        click.propagate(false);
-                        commands.queue(|world: &mut World| {
-                            crate::add_entity_picker::open_add_entity_picker(world);
-                        });
-                    },
-                ),
+                observe(|mut click: On<Pointer<Click>>, mut commands: Commands| {
+                    click.propagate(false);
+                    commands.queue(|world: &mut World| {
+                        crate::add_entity_picker::open_add_entity_picker(world);
+                    });
+                },),
                 children![
                     (
                         Text::new(String::from(Icon::PackagePlus.unicode())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod add_entity_picker;
 pub mod alignment_guides;
 pub mod asset_browser;
 pub mod asset_catalog;
@@ -17,6 +18,7 @@ pub mod keybinds;
 pub use inspector::{EditorMeta, ReflectEditorMeta};
 pub mod extension_loader;
 pub mod extensions_config;
+pub mod extensions_dialog;
 pub mod layout;
 pub mod material_browser;
 pub mod material_preview;
@@ -24,7 +26,6 @@ pub mod modal_transform;
 pub mod navmesh;
 pub mod physics_brush_bridge;
 pub mod physics_tool;
-pub mod plugins_dialog;
 pub mod prefab_picker;
 pub mod project;
 pub mod project_files;
@@ -151,7 +152,7 @@ impl Plugin for EditorPlugin {
             .add_plugins(jackdaw_animation::AnimationPlugin)
             .add_plugins(jackdaw_panels::DockPlugin)
             .add_plugins(extension_loader::ExtensionLoaderPlugin)
-            .add_plugins(plugins_dialog::PluginsDialogPlugin)
+            .add_plugins(extensions_dialog::ExtensionsDialogPlugin)
             .add_systems(
                 Startup,
                 (
@@ -175,6 +176,8 @@ impl Plugin for EditorPlugin {
             .init_resource::<MenuBarDirty>()
             .add_observer(flag_menu_dirty_on_window_add)
             .add_observer(flag_menu_dirty_on_window_remove)
+            .add_observer(flag_menu_dirty_on_menu_entry_add)
+            .add_observer(flag_menu_dirty_on_menu_entry_remove)
             .add_systems(
                 OnEnter(AppState::Editor),
                 (spawn_layout, init_layout, populate_menu).chain(),
@@ -203,6 +206,8 @@ impl Plugin for EditorPlugin {
                     handle_keyframe_delete_intercept.before(entity_ops::handle_entity_keys),
                     handle_timeline_shortcuts.before(entity_ops::handle_entity_keys),
                     auto_save_layout_on_change,
+                    add_entity_picker::filter_add_entity_picker,
+                    add_entity_picker::close_add_entity_picker_on_escape,
                 )
                     .run_if(in_state(AppState::Editor)),
             )
@@ -225,6 +230,9 @@ impl Plugin for EditorPlugin {
         // `ContextInstances` resource.
         jackdaw_api::register_extension(app, "sample", || {
             Box::new(sample_extension::SampleExtension)
+        });
+        jackdaw_api::register_extension(app, "viewable_camera", || {
+            Box::new(viewable_camera_extension::ViewableCameraExtension)
         });
 
         // Enable extensions. Has to run AFTER all plugins finish() — BEI
@@ -262,6 +270,20 @@ fn flag_menu_dirty_on_window_add(
 
 fn flag_menu_dirty_on_window_remove(
     _: On<Remove, jackdaw_api::RegisteredWindow>,
+    mut dirty: ResMut<MenuBarDirty>,
+) {
+    dirty.0 = true;
+}
+
+fn flag_menu_dirty_on_menu_entry_add(
+    _: On<Add, jackdaw_api::RegisteredMenuEntry>,
+    mut dirty: ResMut<MenuBarDirty>,
+) {
+    dirty.0 = true;
+}
+
+fn flag_menu_dirty_on_menu_entry_remove(
+    _: On<Remove, jackdaw_api::RegisteredMenuEntry>,
     mut dirty: ResMut<MenuBarDirty>,
 ) {
     dirty.0 = true;
@@ -1653,6 +1675,28 @@ fn populate_menu(world: &mut World) {
         }
     }
 
+    // Collect extension-contributed menu entries for menus OTHER than
+    // "Add". The "Add" menu goes through the shared
+    // `collect_add_menu_items` helper below so the toolbar and the
+    // scene-tree picker present identical content.
+    let mut ext_menu_entries: std::collections::BTreeMap<String, Vec<(String, String)>> =
+        std::collections::BTreeMap::new();
+    {
+        let mut q = world.query::<&jackdaw_api::RegisteredMenuEntry>();
+        for entry in q.iter(world) {
+            if entry.menu == "Add" {
+                continue;
+            }
+            ext_menu_entries
+                .entry(entry.menu.clone())
+                .or_default()
+                .push((format!("op:{}", entry.operator_id), entry.label.clone()));
+        }
+        for entries in ext_menu_entries.values_mut() {
+            entries.sort_by(|a, b| a.1.cmp(&b.1));
+        }
+    }
+
     // Collect window entries from WindowRegistry grouped by default_area.
     // Built-in windows have a default_area, extension windows don't (empty string).
     let window_registry = world.resource::<jackdaw_panels::WindowRegistry>();
@@ -1697,6 +1741,26 @@ fn populate_menu(world: &mut World) {
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
+
+    // Build the Add menu from the shared helper so the toolbar and the
+    // scene-tree Add Entity picker stay in lockstep. Separators are
+    // inserted between categories.
+    let add_items = add_entity_picker::collect_add_menu_items(world);
+    let mut add_menu: Vec<(String, String)> = Vec::with_capacity(add_items.len() + 8);
+    let mut last_category: Option<String> = None;
+    for item in add_items {
+        if last_category.as_deref() != Some(item.category.as_str()) {
+            if last_category.is_some() {
+                add_menu.push(("---".into(), String::new()));
+            }
+            last_category = Some(item.category.clone());
+        }
+        add_menu.push((item.action, item.label));
+    }
+    let add_menu_refs: Vec<(&str, &str)> = add_menu
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
     jackdaw_feathers::menu_bar::populate_menu_bar(
         world,
         menu_bar_entity,
@@ -1713,7 +1777,7 @@ fn populate_menu(world: &mut World) {
                     ("file.save_template", "Save Selection as Template"),
                     ("---", ""),
                     ("file.keybinds", "Keybinds..."),
-                    ("file.plugins", "Plugins..."),
+                    ("file.extensions", "Extensions..."),
                     ("---", ""),
                     ("file.open_recent", "Open Recent..."),
                     ("file.home", "Home"),
@@ -1747,25 +1811,7 @@ fn populate_menu(world: &mut World) {
                     ("view.hierarchy_arrows", "Toggle Hierarchy Arrows"),
                 ],
             ),
-            (
-                "Add",
-                vec![
-                    ("add.cube", "Cube"),
-                    ("add.sphere", "Sphere"),
-                    ("---", ""),
-                    ("add.point_light", "Point Light"),
-                    ("add.directional_light", "Directional Light"),
-                    ("add.spot_light", "Spot Light"),
-                    ("---", ""),
-                    ("add.camera", "Camera"),
-                    ("add.empty", "Empty"),
-                    ("---", ""),
-                    ("add.navmesh", "Navmesh Region"),
-                    ("add.terrain", "Terrain"),
-                    ("---", ""),
-                    ("add.prefab", "Prefab..."),
-                ],
-            ),
+            ("Add", add_menu_refs),
             ("Window", window_entries_refs),
         ],
     );
@@ -1900,9 +1946,9 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
         "file.keybinds" => {
             commands.trigger(keybind_settings::OpenKeybindSettingsEvent);
         }
-        "file.plugins" => {
+        "file.extensions" => {
             commands.queue(|world: &mut World| {
-                plugins_dialog::open_plugins_dialog(world);
+                extensions_dialog::open_extensions_dialog(world);
             });
         }
         "file.home" => {
@@ -2041,6 +2087,16 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
         "add.prefab" => {
             commands.queue(|world: &mut World| {
                 crate::prefab_picker::open_prefab_picker(world);
+            });
+        }
+        action if action.starts_with("op:") => {
+            // Extension-contributed menu entry. The action id is the
+            // operator id with an "op:" prefix — dispatch it through the
+            // same path as keybind-triggered operators so behavior
+            // (history entry, poll, modal) is identical.
+            let operator_id = action.strip_prefix("op:").unwrap().to_string();
+            commands.queue(move |world: &mut World| {
+                jackdaw_api::lifecycle::dispatch_operator_by_id(world, &operator_id, true);
             });
         }
         action if action.starts_with("window.") => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod keybind_settings;
 pub mod keybinds;
 pub use inspector::{EditorMeta, ReflectEditorMeta};
 pub mod extension_loader;
+pub mod extensions_config;
 pub mod layout;
 pub mod material_browser;
 pub mod material_preview;
@@ -23,6 +24,7 @@ pub mod modal_transform;
 pub mod navmesh;
 pub mod physics_brush_bridge;
 pub mod physics_tool;
+pub mod plugins_dialog;
 pub mod prefab_picker;
 pub mod project;
 pub mod project_files;
@@ -149,6 +151,7 @@ impl Plugin for EditorPlugin {
             .add_plugins(jackdaw_animation::AnimationPlugin)
             .add_plugins(jackdaw_panels::DockPlugin)
             .add_plugins(extension_loader::ExtensionLoaderPlugin)
+            .add_plugins(plugins_dialog::PluginsDialogPlugin)
             .add_systems(
                 Startup,
                 (
@@ -169,9 +172,16 @@ impl Plugin for EditorPlugin {
             .init_resource::<layout::KeybindHelpPopover>()
             .init_resource::<asset_catalog::AssetCatalog>()
             .init_resource::<jackdaw_jsn::SceneJsnAst>()
+            .init_resource::<MenuBarDirty>()
+            .add_observer(flag_menu_dirty_on_window_add)
+            .add_observer(flag_menu_dirty_on_window_remove)
             .add_systems(
                 OnEnter(AppState::Editor),
                 (spawn_layout, init_layout, populate_menu).chain(),
+            )
+            .add_systems(
+                Update,
+                rebuild_menu_if_dirty.run_if(in_state(AppState::Editor)),
             )
             .add_systems(OnExit(AppState::Editor), cleanup_editor)
             .add_systems(
@@ -208,7 +218,73 @@ impl Plugin for EditorPlugin {
             .add_observer(on_duration_input_commit)
             .add_observer(on_timeline_keyframe_click);
 
-        jackdaw_api::load_static_extension(app, &sample_extension::SampleExtension);
+        // Register all built-in + example extensions into the catalog.
+        // `register_extension` runs each extension's one-time BEI context
+        // registration; this has to happen during build() so BEI's
+        // `finish()` sees all context types and initializes their
+        // `ContextInstances` resource.
+        jackdaw_api::register_extension(app, "sample", || {
+            Box::new(sample_extension::SampleExtension)
+        });
+
+        // Enable extensions. Has to run AFTER all plugins finish() — BEI
+        // initializes `ContextInstances<PreUpdate>` in finish(), and
+        // spawning a context entity before that triggers a panic. We
+        // queue the work as a Startup system that runs once before the
+        // editor enters its main loop.
+        app.add_systems(Startup, apply_enabled_extensions_startup);
+    }
+}
+
+/// Set when an extension's windows change. A system in Update drains it
+/// and rebuilds the menu bar once per frame so multiple registrations
+/// coalesce into a single rebuild.
+#[derive(Resource, Default)]
+pub struct MenuBarDirty(pub bool);
+
+/// Watches `RegisteredWindow` add/remove in observers (see
+/// `flag_menu_dirty_on_window_change`). When set, rebuilds the menu bar
+/// from the current `WindowRegistry`.
+fn rebuild_menu_if_dirty(world: &mut World) {
+    if !world.resource::<MenuBarDirty>().0 {
+        return;
+    }
+    world.resource_mut::<MenuBarDirty>().0 = false;
+    populate_menu(world);
+}
+
+fn flag_menu_dirty_on_window_add(
+    _: On<Add, jackdaw_api::RegisteredWindow>,
+    mut dirty: ResMut<MenuBarDirty>,
+) {
+    dirty.0 = true;
+}
+
+fn flag_menu_dirty_on_window_remove(
+    _: On<Remove, jackdaw_api::RegisteredWindow>,
+    mut dirty: ResMut<MenuBarDirty>,
+) {
+    dirty.0 = true;
+}
+
+fn apply_enabled_extensions_startup(world: &mut World) {
+    // Build up the list of names to enable, then run enable_extension
+    // for each. Mirrors `apply_enabled_from_disk` but operates on World
+    // directly (Startup systems have world access).
+    use jackdaw_api::{ExtensionCatalog, enable_extension};
+    let to_enable: Vec<String> = {
+        let catalog = world.resource::<ExtensionCatalog>();
+        let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
+        match extensions_config::read_enabled_list() {
+            Some(list) => {
+                let set: std::collections::HashSet<String> = list.into_iter().collect();
+                available.into_iter().filter(|n| set.contains(n)).collect()
+            }
+            None => available, // first run: enable everything
+        }
+    };
+    for name in &to_enable {
+        enable_extension(world, name);
     }
 }
 
@@ -1564,6 +1640,19 @@ fn populate_menu(world: &mut World) {
         return;
     };
 
+    // Despawn existing menu-bar items before re-populating. Idempotent on
+    // first call (nothing to remove), necessary for rebuilds when the
+    // window registry changes (extensions toggled on/off).
+    let existing: Vec<Entity> = world
+        .query_filtered::<Entity, With<jackdaw_widgets::menu_bar::MenuBarItem>>()
+        .iter(world)
+        .collect();
+    for entity in existing {
+        if let Ok(ec) = world.get_entity_mut(entity) {
+            ec.despawn();
+        }
+    }
+
     // Collect window entries from WindowRegistry grouped by default_area.
     // Built-in windows have a default_area, extension windows don't (empty string).
     let window_registry = world.resource::<jackdaw_panels::WindowRegistry>();
@@ -1624,6 +1713,7 @@ fn populate_menu(world: &mut World) {
                     ("file.save_template", "Save Selection as Template"),
                     ("---", ""),
                     ("file.keybinds", "Keybinds..."),
+                    ("file.plugins", "Plugins..."),
                     ("---", ""),
                     ("file.open_recent", "Open Recent..."),
                     ("file.home", "Home"),
@@ -1810,6 +1900,11 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
         "file.keybinds" => {
             commands.trigger(keybind_settings::OpenKeybindSettingsEvent);
         }
+        "file.plugins" => {
+            commands.queue(|world: &mut World| {
+                plugins_dialog::open_plugins_dialog(world);
+            });
+        }
         "file.home" => {
             commands.queue(|world: &mut World| {
                 world
@@ -1972,12 +2067,11 @@ fn spawn_undoable<F>(world: &mut World, label: &str, spawn: F)
 where
     F: Fn(&mut World) -> Entity + Send + Sync + 'static,
 {
-    let mut cmd: Box<dyn jackdaw_commands::EditorCommand> =
-        Box::new(commands::SpawnEntity {
-            spawned: None,
-            spawn_fn: Box::new(spawn),
-            label: label.to_string(),
-        });
+    let mut cmd: Box<dyn jackdaw_commands::EditorCommand> = Box::new(commands::SpawnEntity {
+        spawned: None,
+        spawn_fn: Box::new(spawn),
+        label: label.to_string(),
+    });
     cmd.execute(world);
     world
         .resource_mut::<commands::CommandHistory>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod alignment_guides;
 pub mod asset_browser;
 pub mod asset_catalog;
 pub mod brush;
+pub mod builtin_extensions;
 pub mod colors;
 pub mod commands;
 pub mod custom_properties;
@@ -153,14 +154,7 @@ impl Plugin for EditorPlugin {
             .add_plugins(jackdaw_panels::DockPlugin)
             .add_plugins(extension_loader::ExtensionLoaderPlugin)
             .add_plugins(extensions_dialog::ExtensionsDialogPlugin)
-            .add_systems(
-                Startup,
-                (
-                    register_all_dock_windows,
-                    register_workspaces,
-                    sync_icon_font,
-                ),
-            )
+            .add_systems(Startup, (register_workspaces, sync_icon_font))
             .configure_sets(
                 Update,
                 EditorInteraction
@@ -223,11 +217,29 @@ impl Plugin for EditorPlugin {
             .add_observer(on_duration_input_commit)
             .add_observer(on_timeline_keyframe_click);
 
-        // Register all built-in + example extensions into the catalog.
-        // `register_extension` runs each extension's one-time BEI context
-        // registration; this has to happen during build() so BEI's
-        // `finish()` sees all context types and initializes their
-        // `ContextInstances` resource.
+        // Register all built-in and example extensions into the
+        // catalog. `register_extension` runs each extension's one-time
+        // BEI context registration, which must happen during `build()`
+        // so BEI's `finish()` hook sees every context type and
+        // initializes the matching `ContextInstances` resource. Each
+        // extension self-classifies via `JackdawExtension::kind`:
+        // built-ins override it to `ExtensionKind::Builtin`, while
+        // examples and third-party extensions keep the default `Custom`.
+        jackdaw_api::register_extension(app, "core_windows", || {
+            Box::new(builtin_extensions::CoreWindowsExtension)
+        });
+        jackdaw_api::register_extension(app, "asset_browser", || {
+            Box::new(builtin_extensions::AssetBrowserExtension)
+        });
+        jackdaw_api::register_extension(app, "timeline", || {
+            Box::new(builtin_extensions::TimelineExtension)
+        });
+        jackdaw_api::register_extension(app, "terminal", || {
+            Box::new(builtin_extensions::TerminalExtension)
+        });
+        jackdaw_api::register_extension(app, "inspector", || {
+            Box::new(builtin_extensions::InspectorExtension)
+        });
         jackdaw_api::register_extension(app, "sample", || {
             Box::new(sample_extension::SampleExtension)
         });
@@ -235,11 +247,12 @@ impl Plugin for EditorPlugin {
             Box::new(viewable_camera_extension::ViewableCameraExtension)
         });
 
-        // Enable extensions. Has to run AFTER all plugins finish() — BEI
-        // initializes `ContextInstances<PreUpdate>` in finish(), and
-        // spawning a context entity before that triggers a panic. We
-        // queue the work as a Startup system that runs once before the
-        // editor enters its main loop.
+        // Enable extensions on startup. Has to run AFTER every plugin's
+        // `finish()` hook: BEI initializes `ContextInstances<PreUpdate>`
+        // in `finish`, and spawning a context entity before that
+        // resource exists panics. Running this as a Startup system
+        // guarantees it fires once before the editor enters its main
+        // loop.
         app.add_systems(Startup, apply_enabled_extensions_startup);
     }
 }
@@ -289,24 +302,15 @@ fn flag_menu_dirty_on_menu_entry_remove(
     dirty.0 = true;
 }
 
+/// Enable every catalog entry that `resolve_enabled_list` reports as on.
+///
+/// Runs in `Startup` because Startup systems have world access, which is
+/// what `enable_extension` needs. The resolution helper handles the
+/// upgrade migration for pre-dogfood config files.
 fn apply_enabled_extensions_startup(world: &mut World) {
-    // Build up the list of names to enable, then run enable_extension
-    // for each. Mirrors `apply_enabled_from_disk` but operates on World
-    // directly (Startup systems have world access).
-    use jackdaw_api::{ExtensionCatalog, enable_extension};
-    let to_enable: Vec<String> = {
-        let catalog = world.resource::<ExtensionCatalog>();
-        let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
-        match extensions_config::read_enabled_list() {
-            Some(list) => {
-                let set: std::collections::HashSet<String> = list.into_iter().collect();
-                available.into_iter().filter(|n| set.contains(n)).collect()
-            }
-            None => available, // first run: enable everything
-        }
-    };
+    let to_enable = extensions_config::resolve_enabled_list(world);
     for name in &to_enable {
-        enable_extension(world, name);
+        jackdaw_api::enable_extension(world, name);
     }
 }
 
@@ -2091,9 +2095,10 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
         }
         action if action.starts_with("op:") => {
             // Extension-contributed menu entry. The action id is the
-            // operator id with an "op:" prefix — dispatch it through the
-            // same path as keybind-triggered operators so behavior
-            // (history entry, poll, modal) is identical.
+            // operator id with an "op:" prefix. Dispatching through the
+            // operator system rather than a parallel path keeps
+            // behaviour (history entry, poll, modal) identical to
+            // keybind-triggered operators.
             let operator_id = action.strip_prefix("op:").unwrap().to_string();
             commands.queue(move |world: &mut World| {
                 jackdaw_api::lifecycle::dispatch_operator_by_id(world, &operator_id, true);
@@ -2636,220 +2641,4 @@ fn sync_icon_font(
     if let Some(font) = icon_font {
         commands.insert_resource(jackdaw_panels::IconFontHandle(font.0.clone()));
     }
-}
-
-fn register_all_dock_windows(mut registry: ResMut<jackdaw_panels::WindowRegistry>) {
-    use jackdaw_feathers::icons::Icon;
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.assets".into(),
-        name: "Assets".into(),
-        icon: Some(String::from(Icon::FolderOpen.unicode())),
-        default_area: "bottom_dock".into(),
-        priority: 0,
-        build: std::sync::Arc::new(|world, parent| {
-            let icon_font = world
-                .get_resource::<jackdaw_feathers::icons::IconFont>()
-                .map(|f| f.0.clone())
-                .unwrap_or_default();
-            world.spawn((
-                ChildOf(parent),
-                asset_browser::asset_browser_panel(icon_font),
-            ));
-            world
-                .resource_mut::<asset_browser::AssetBrowserState>()
-                .needs_refresh = true;
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.timeline".into(),
-        name: "Timeline".into(),
-        icon: Some(String::from(Icon::Ruler.unicode())),
-        default_area: "bottom_dock".into(),
-        priority: 1,
-        build: std::sync::Arc::new(|world, parent| {
-            world.spawn((ChildOf(parent), jackdaw_animation::timeline_panel()));
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.terminal".into(),
-        name: "Terminal".into(),
-        icon: Some(String::from(Icon::Terminal.unicode())),
-        default_area: "bottom_dock".into(),
-        priority: 2,
-        build: std::sync::Arc::new(|world, parent| {
-            world.spawn((
-                ChildOf(parent),
-                Node {
-                    flex_grow: 1.0,
-                    width: Val::Percent(100.0),
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                children![(
-                    Text::new("Terminal window (not implemented yet)"),
-                    TextFont {
-                        font_size: 11.0,
-                        ..default()
-                    },
-                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
-                )],
-            ));
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.hierarchy".into(),
-        name: "Scene Tree".into(),
-        icon: None,
-        default_area: "left".into(),
-        priority: 0,
-        build: std::sync::Arc::new(|world, parent| {
-            let icon_font = world
-                .get_resource::<jackdaw_feathers::icons::IconFont>()
-                .map(|f| f.0.clone())
-                .unwrap_or_default();
-            world.spawn((ChildOf(parent), crate::layout::hierarchy_content(icon_font)));
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.import".into(),
-        name: "Import".into(),
-        icon: None,
-        default_area: "left".into(),
-        priority: 1,
-        build: std::sync::Arc::new(|world, parent| {
-            world.spawn((
-                ChildOf(parent),
-                Node {
-                    flex_grow: 1.0,
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                children![(
-                    Text::new("Import"),
-                    TextFont {
-                        font_size: 11.0,
-                        ..default()
-                    },
-                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
-                )],
-            ));
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.project_files".into(),
-        name: "Project Files".into(),
-        icon: None,
-        default_area: "left".into(),
-        priority: 10,
-        build: std::sync::Arc::new(|world, parent| {
-            world.spawn((
-                ChildOf(parent),
-                crate::layout::project_files_panel_content(),
-            ));
-            world
-                .resource_mut::<project_files::ProjectFilesState>()
-                .needs_refresh = true;
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.inspector.components".into(),
-        name: "Components".into(),
-        icon: None,
-        default_area: "right_sidebar".into(),
-        priority: 0,
-        build: std::sync::Arc::new(|world, parent| {
-            let icon_font = world
-                .get_resource::<jackdaw_feathers::icons::IconFont>()
-                .map(|f| f.0.clone())
-                .unwrap_or_default();
-            world.spawn((
-                ChildOf(parent),
-                crate::layout::inspector_components_content(icon_font),
-            ));
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.inspector.materials".into(),
-        name: "Materials".into(),
-        icon: None,
-        default_area: "right_sidebar".into(),
-        priority: 1,
-        build: std::sync::Arc::new(|world, parent| {
-            let icon_font = world
-                .get_resource::<jackdaw_feathers::icons::IconFont>()
-                .map(|f| f.0.clone())
-                .unwrap_or_default();
-            world.spawn((
-                ChildOf(parent),
-                material_browser::material_browser_panel(icon_font),
-            ));
-            world
-                .resource_mut::<material_browser::MaterialBrowserState>()
-                .needs_rescan = true;
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.inspector.resources".into(),
-        name: "Resources".into(),
-        icon: None,
-        default_area: "right_sidebar".into(),
-        priority: 2,
-        build: std::sync::Arc::new(|world, parent| {
-            world.spawn((
-                ChildOf(parent),
-                Node {
-                    flex_grow: 1.0,
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                children![(
-                    Text::new("Resources"),
-                    TextFont {
-                        font_size: 11.0,
-                        ..default()
-                    },
-                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
-                )],
-            ));
-        }),
-    });
-
-    registry.register(jackdaw_panels::DockWindowDescriptor {
-        id: "jackdaw.inspector.systems".into(),
-        name: "Systems".into(),
-        icon: None,
-        default_area: "right_sidebar".into(),
-        priority: 3,
-        build: std::sync::Arc::new(|world, parent| {
-            world.spawn((
-                ChildOf(parent),
-                Node {
-                    flex_grow: 1.0,
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                children![(
-                    Text::new("Systems"),
-                    TextFont {
-                        font_size: 11.0,
-                        ..default()
-                    },
-                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.3)),
-                )],
-            ));
-        }),
-    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod inspector;
 pub mod keybind_settings;
 pub mod keybinds;
 pub use inspector::{EditorMeta, ReflectEditorMeta};
+pub mod extension_loader;
 pub mod layout;
 pub mod material_browser;
 pub mod material_preview;
@@ -147,6 +148,7 @@ impl Plugin for EditorPlugin {
             .add_plugins(jackdaw_node_graph::NodeGraphPlugin)
             .add_plugins(jackdaw_animation::AnimationPlugin)
             .add_plugins(jackdaw_panels::DockPlugin)
+            .add_plugins(extension_loader::ExtensionLoaderPlugin)
             .add_systems(
                 Startup,
                 (
@@ -205,6 +207,8 @@ impl Plugin for EditorPlugin {
             .add_observer(on_clip_name_commit)
             .add_observer(on_duration_input_commit)
             .add_observer(on_timeline_keyframe_click);
+
+        jackdaw_api::load_static_extension(app, &sample_extension::SampleExtension);
     }
 }
 
@@ -896,8 +900,7 @@ fn handle_keyframe_delete_intercept(world: &mut World) {
         label: "Delete keyframes".to_string(),
     };
     let mut history = world.resource_mut::<jackdaw_commands::CommandHistory>();
-    history.undo_stack.push(Box::new(group));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(group));
 }
 
 /// Typed, undo-aware spawn command for animation keyframes. Mirror of
@@ -1336,8 +1339,7 @@ fn handle_keyframe_paste(world: &mut World) {
         label: "Paste keyframes".to_string(),
     };
     let mut history = world.resource_mut::<jackdaw_commands::CommandHistory>();
-    history.undo_stack.push(Box::new(group));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(group));
     world
         .resource_mut::<ButtonInput<KeyCode>>()
         .clear_just_pressed(KeyCode::KeyV);
@@ -1462,6 +1464,7 @@ fn on_duration_input_commit(
                 field_path: "duration".to_string(),
                 old_value: old_json,
                 new_value: new_json,
+                was_derived: false,
             }),
             world,
         );
@@ -1560,6 +1563,51 @@ fn populate_menu(world: &mut World) {
     let Some(menu_bar_entity) = menu_bar_entity else {
         return;
     };
+
+    // Collect window entries from WindowRegistry grouped by default_area.
+    // Built-in windows have a default_area, extension windows don't (empty string).
+    let window_registry = world.resource::<jackdaw_panels::WindowRegistry>();
+    let mut by_area: std::collections::BTreeMap<String, Vec<(String, String)>> =
+        std::collections::BTreeMap::new();
+    for descriptor in window_registry.iter() {
+        let area_key = if descriptor.default_area.is_empty() {
+            "zz_extensions".to_string()
+        } else {
+            descriptor.default_area.clone()
+        };
+        by_area.entry(area_key).or_default().push((
+            format!("window.open:{}", descriptor.id),
+            descriptor.name.clone(),
+        ));
+    }
+    // Build the Window menu with separators between area groups, followed
+    // by Reset Layout at the bottom.
+    let mut window_entries: Vec<(String, String)> = Vec::new();
+    let area_order = ["left", "bottom_dock", "right_sidebar", "zz_extensions"];
+    let mut first = true;
+    for area in area_order {
+        let Some(entries) = by_area.get(area) else {
+            continue;
+        };
+        if !first {
+            window_entries.push(("---".to_string(), String::new()));
+        }
+        first = false;
+        for (id, name) in entries {
+            window_entries.push((id.clone(), name.clone()));
+        }
+    }
+    if !window_entries.is_empty() {
+        window_entries.push(("---".to_string(), String::new()));
+    }
+    window_entries.push((
+        "window.reset_layout".to_string(),
+        "Reset Layout".to_string(),
+    ));
+    let window_entries_refs: Vec<(&str, &str)> = window_entries
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
     jackdaw_feathers::menu_bar::populate_menu_bar(
         world,
         menu_bar_entity,
@@ -1628,25 +1676,7 @@ fn populate_menu(world: &mut World) {
                     ("add.prefab", "Prefab..."),
                 ],
             ),
-            (
-                "Window",
-                vec![
-                    ("window.hierarchy", "Scene Tree"),
-                    ("window.import", "Import"),
-                    ("window.project_files", "Project Files"),
-                    ("---", ""),
-                    ("window.assets", "Assets"),
-                    ("window.timeline", "Timeline"),
-                    ("window.terminal", "Terminal"),
-                    ("---", ""),
-                    ("window.components", "Components"),
-                    ("window.materials", "Materials"),
-                    ("window.resources", "Resources"),
-                    ("window.systems", "Systems"),
-                    ("---", ""),
-                    ("window.reset_layout", "Reset Layout"),
-                ],
-            ),
+            ("Window", window_entries_refs),
         ],
     );
 }
@@ -1887,23 +1917,30 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
         }
         "add.navmesh" => {
             commands.queue(|world: &mut World| {
-                let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
-                    SystemState::new(world);
-                let (mut commands, mut selection) = system_state.get_mut(world);
-                let entity = navmesh::spawn_navmesh_entity(&mut commands);
-                selection.select_single(&mut commands, entity);
-                system_state.apply(world);
+                spawn_undoable(world, "Add Navmesh Region", |world| {
+                    let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
+                        SystemState::new(world);
+                    let (mut commands, mut selection) = system_state.get_mut(world);
+                    let entity = navmesh::spawn_navmesh_entity(&mut commands);
+                    selection.select_single(&mut commands, entity);
+                    system_state.apply(world);
+                    scene_io::register_entity_in_ast(world, entity);
+                    entity
+                });
             });
         }
         "add.terrain" => {
             commands.queue(|world: &mut World| {
-                let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
-                    SystemState::new(world);
-                let (mut commands, mut selection) = system_state.get_mut(world);
-                let entity = terrain::spawn_terrain_entity(&mut commands);
-                selection.select_single(&mut commands, entity);
-                system_state.apply(world);
-                scene_io::register_entity_in_ast(world, entity);
+                spawn_undoable(world, "Add Terrain", |world| {
+                    let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
+                        SystemState::new(world);
+                    let (mut commands, mut selection) = system_state.get_mut(world);
+                    let entity = terrain::spawn_terrain_entity(&mut commands);
+                    selection.select_single(&mut commands, entity);
+                    system_state.apply(world);
+                    scene_io::register_entity_in_ast(world, entity);
+                    entity
+                });
             });
         }
         "add.prefab" => {
@@ -1919,21 +1956,8 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
                 return;
             }
 
-            let window_id = match action {
-                "window.hierarchy" => Some("jackdaw.hierarchy"),
-                "window.import" => Some("jackdaw.import"),
-                "window.project_files" => Some("jackdaw.project_files"),
-                "window.assets" => Some("jackdaw.assets"),
-                "window.timeline" => Some("jackdaw.timeline"),
-                "window.terminal" => Some("jackdaw.terminal"),
-                "window.components" => Some("jackdaw.inspector.components"),
-                "window.materials" => Some("jackdaw.inspector.materials"),
-                "window.resources" => Some("jackdaw.inspector.resources"),
-                "window.systems" => Some("jackdaw.inspector.systems"),
-                _ => None,
-            };
-            if let Some(id) = window_id {
-                let id = id.to_string();
+            if let Some(window_id) = action.strip_prefix("window.open:") {
+                let id = window_id.to_string();
                 commands.queue(move |world: &mut World| {
                     open_window_in_default_area(world, &id);
                 });
@@ -1941,6 +1965,23 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
         }
         _ => {}
     }
+}
+
+/// Wrap an entity-spawning closure in a `SpawnEntity` command so Ctrl+Z can undo it.
+fn spawn_undoable<F>(world: &mut World, label: &str, spawn: F)
+where
+    F: Fn(&mut World) -> Entity + Send + Sync + 'static,
+{
+    let mut cmd: Box<dyn jackdaw_commands::EditorCommand> =
+        Box::new(commands::SpawnEntity {
+            spawned: None,
+            spawn_fn: Box::new(spawn),
+            label: label.to_string(),
+        });
+    cmd.execute(world);
+    world
+        .resource_mut::<commands::CommandHistory>()
+        .push_executed(cmd);
 }
 
 fn cleanup_editor(world: &mut World) {
@@ -2327,7 +2368,15 @@ fn open_window_in_default_area(world: &mut World, window_id: &str) {
 
     let target_leaf = {
         let tree = world.resource::<DockTree>();
-        let Some(root) = tree.anchor(&default_area) else {
+        // If window has a default_area, place it there. Otherwise (extension
+        // windows have no default), fall back to the first available anchor
+        // so the user can reposition it from there.
+        let root = if default_area.is_empty() {
+            tree.iter_anchors().next().map(|(_, id)| id)
+        } else {
+            tree.anchor(&default_area)
+        };
+        let Some(root) = root else {
             return;
         };
         tree.leaves_under(root).first().map(|(id, _)| *id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,14 +217,10 @@ impl Plugin for EditorPlugin {
             .add_observer(on_duration_input_commit)
             .add_observer(on_timeline_keyframe_click);
 
-        // Register all built-in and example extensions into the
-        // catalog. `register_extension` runs each extension's one-time
-        // BEI context registration, which must happen during `build()`
-        // so BEI's `finish()` hook sees every context type and
-        // initializes the matching `ContextInstances` resource. Each
-        // extension self-classifies via `JackdawExtension::kind`:
-        // built-ins override it to `ExtensionKind::Builtin`, while
-        // examples and third-party extensions keep the default `Custom`.
+        // Register built-in and example extensions into the catalog.
+        // Runs during `build()` so BEI's `finish()` hook sees every
+        // context type. Built-ins override `kind()` to `Builtin`; the
+        // rest default to `Custom`.
         jackdaw_api::register_extension(app, "core_windows", || {
             Box::new(builtin_extensions::CoreWindowsExtension)
         });
@@ -247,25 +243,18 @@ impl Plugin for EditorPlugin {
             Box::new(viewable_camera_extension::ViewableCameraExtension)
         });
 
-        // Enable extensions on startup. Has to run AFTER every plugin's
-        // `finish()` hook: BEI initializes `ContextInstances<PreUpdate>`
-        // in `finish`, and spawning a context entity before that
-        // resource exists panics. Running this as a Startup system
-        // guarantees it fires once before the editor enters its main
-        // loop.
+        // Must run after every plugin's `finish()`: BEI initializes
+        // `ContextInstances<PreUpdate>` there, and spawning a context
+        // entity before that resource exists panics.
         app.add_systems(Startup, apply_enabled_extensions_startup);
     }
 }
 
-/// Set when an extension's windows change. A system in Update drains it
-/// and rebuilds the menu bar once per frame so multiple registrations
-/// coalesce into a single rebuild.
+/// Drained once per frame so multiple registrations coalesce into a
+/// single menu-bar rebuild.
 #[derive(Resource, Default)]
 pub struct MenuBarDirty(pub bool);
 
-/// Watches `RegisteredWindow` add/remove in observers (see
-/// `flag_menu_dirty_on_window_change`). When set, rebuilds the menu bar
-/// from the current `WindowRegistry`.
 fn rebuild_menu_if_dirty(world: &mut World) {
     if !world.resource::<MenuBarDirty>().0 {
         return;
@@ -302,11 +291,7 @@ fn flag_menu_dirty_on_menu_entry_remove(
     dirty.0 = true;
 }
 
-/// Enable every catalog entry that `resolve_enabled_list` reports as on.
-///
-/// Runs in `Startup` because Startup systems have world access, which is
-/// what `enable_extension` needs. The resolution helper handles the
-/// upgrade migration for pre-dogfood config files.
+/// Enable every catalog entry `resolve_enabled_list` reports as on.
 fn apply_enabled_extensions_startup(world: &mut World) {
     let to_enable = extensions_config::resolve_enabled_list(world);
     for name in &to_enable {

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -24,6 +24,7 @@ use crate::{
     material_preview::MaterialPreviewState,
     selection::Selection,
 };
+use jackdaw_commands::{CommandGroup, EditorCommand};
 
 pub struct MaterialBrowserPlugin;
 
@@ -658,8 +659,7 @@ fn handle_apply_material(
                     new: new_brush.clone(),
                     label: "Apply material".into(),
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                history.push_executed(Box::new(cmd));
                 // Deferred AST sync (SetBrush was pushed without execute)
                 commands.queue(move |world: &mut World| {
                     crate::brush::sync_brush_to_ast(world, entity, &new_brush);
@@ -685,6 +685,7 @@ fn handle_apply_material(
                 }
             })
             .collect();
+        let mut group_commands: Vec<Box<dyn EditorCommand>> = Vec::new();
         for entity in targets {
             if let Ok(mut brush) = brushes.get_mut(entity) {
                 let old = brush.clone();
@@ -698,8 +699,7 @@ fn handle_apply_material(
                     new: new_brush.clone(),
                     label: "Apply material".into(),
                 };
-                history.undo_stack.push(Box::new(cmd));
-                history.redo_stack.clear();
+                group_commands.push(Box::new(cmd));
                 // Deferred AST sync (SetBrush was pushed without execute)
                 commands.queue(move |world: &mut World| {
                     crate::brush::sync_brush_to_ast(world, entity, &new_brush);
@@ -708,6 +708,12 @@ fn handle_apply_material(
                     .entity(entity)
                     .insert(crate::inspector::InspectorDirty);
             }
+        }
+        if !group_commands.is_empty() {
+            history.push_executed(Box::new(CommandGroup {
+                commands: group_commands,
+                label: "Apply material".into(),
+            }));
         }
     }
 }

--- a/src/modal_transform.rs
+++ b/src/modal_transform.rs
@@ -408,8 +408,7 @@ fn modal_confirm(
             old_transform: active.start_transform,
             new_transform: *transform,
         };
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     }
 
     modal.active = None;
@@ -716,8 +715,7 @@ fn viewport_drag_finish(
             old_transform: active.start_transform,
             new_transform: *transform,
         };
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     }
 
     // Release cursor confinement

--- a/src/physics_brush_bridge.rs
+++ b/src/physics_brush_bridge.rs
@@ -20,7 +20,21 @@ impl Plugin for PhysicsBrushBridgePlugin {
         app.add_systems(
             PreUpdate,
             sync_editor_collider_config.run_if(in_state(crate::AppState::Editor)),
-        );
+        )
+        .add_observer(remove_collider_when_avian_collider_removed);
+    }
+}
+
+/// When the user-facing `AvianCollider` is removed (e.g. physics toggle off,
+/// or undo of enable-physics), also remove the runtime `Collider` we built
+/// from it. Without this, the collider gizmo keeps being drawn after undo.
+fn remove_collider_when_avian_collider_removed(
+    trigger: On<Remove, AvianCollider>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event_target();
+    if let Ok(mut ec) = commands.get_entity(entity) {
+        ec.try_remove::<Collider>();
     }
 }
 

--- a/src/physics_tool.rs
+++ b/src/physics_tool.rs
@@ -389,6 +389,7 @@ fn commit_physics_transforms(world: &mut World) {
             field_path: String::new(),
             old_value: old_json,
             new_value: new_json,
+            was_derived: false,
         }));
     }
 
@@ -406,6 +407,5 @@ fn commit_physics_transforms(world: &mut World) {
     };
     cmd.execute(world);
     let mut history = world.resource_mut::<CommandHistory>();
-    history.undo_stack.push(cmd);
-    history.redo_stack.clear();
+    history.push_executed(cmd);
 }

--- a/src/plugins_dialog.rs
+++ b/src/plugins_dialog.rs
@@ -1,0 +1,163 @@
+//! `File > Plugins...` dialog. Lets the user enable/disable compiled-in
+//! extensions at runtime. Changes are applied immediately via
+//! `enable_extension` / `disable_extension` and persisted to
+//! `~/.config/jackdaw/extensions.json`.
+
+use bevy::prelude::*;
+use jackdaw_api::{Extension, ExtensionCatalog};
+use jackdaw_feathers::{
+    checkbox::{CheckboxCommitEvent, CheckboxProps, checkbox},
+    dialog::{CloseDialogEvent, DialogChildrenSlot, OpenDialogEvent},
+    icons::{EditorFont, IconFont},
+    tokens,
+};
+
+use crate::extensions_config;
+
+pub struct PluginsDialogPlugin;
+
+impl Plugin for PluginsDialogPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PluginsDialogOpen>()
+            .add_systems(Update, populate_plugins_dialog)
+            .add_observer(on_plugin_checkbox_commit)
+            .add_observer(on_dialog_closed);
+    }
+}
+
+/// Clear the open flag whenever any dialog closes. Safe because populate
+/// also checks for existing plugin checkboxes — it won't run again until
+/// the next open.
+fn on_dialog_closed(_: On<CloseDialogEvent>, mut open: ResMut<PluginsDialogOpen>) {
+    open.0 = false;
+}
+
+/// Set to `true` while the dialog is being shown. Used by the populate
+/// system to know whether to fill the dialog's children slot.
+#[derive(Resource, Default)]
+struct PluginsDialogOpen(bool);
+
+/// Marks a checkbox as belonging to the plugins dialog. Stores the
+/// extension name so the commit observer knows which one to toggle.
+#[derive(Component)]
+struct PluginCheckbox {
+    extension_name: String,
+}
+
+/// Opened from `File > Plugins...`. Called from the menu action handler.
+pub fn open_plugins_dialog(world: &mut World) {
+    world.resource_mut::<PluginsDialogOpen>().0 = true;
+    world.trigger(
+        OpenDialogEvent::new("Plugins", "Close")
+            .without_cancel()
+            .with_max_width(Val::Px(380.0)),
+    );
+}
+
+/// Populate the dialog's children slot with a row per catalog entry.
+/// Runs each frame but short-circuits unless the dialog is currently open
+/// and hasn't been populated yet.
+///
+/// Note: we do NOT filter on `&Children` because a freshly-spawned
+/// `DialogChildrenSlot` with no children doesn't have a `Children`
+/// component at all — the query would never match. Instead we rely on the
+/// `PluginCheckbox` existence check to avoid re-populating.
+fn populate_plugins_dialog(
+    mut commands: Commands,
+    catalog: Res<ExtensionCatalog>,
+    open: Res<PluginsDialogOpen>,
+    slots: Query<Entity, With<DialogChildrenSlot>>,
+    loaded: Query<&Extension>,
+    editor_font: Res<EditorFont>,
+    icon_font: Res<IconFont>,
+    existing: Query<(), With<PluginCheckbox>>,
+) {
+    if !open.0 {
+        return;
+    }
+    if !existing.is_empty() {
+        return;
+    }
+    let Some(slot_entity) = slots.iter().next() else {
+        return;
+    };
+
+    let font = editor_font.0.clone();
+    let ifont = icon_font.0.clone();
+
+    // Collect (name, is_enabled) for each catalog entry, sorted for
+    // stable ordering across runs.
+    let enabled_names: std::collections::HashSet<String> =
+        loaded.iter().map(|e| e.name.clone()).collect();
+    let mut rows: Vec<(String, bool)> = catalog
+        .iter()
+        .map(|n| {
+            let is_enabled = enabled_names.contains(n);
+            (n.to_string(), is_enabled)
+        })
+        .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let list = commands
+        .spawn((
+            ChildOf(slot_entity),
+            Node {
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(tokens::SPACING_XS),
+                min_width: Val::Px(280.0),
+                ..default()
+            },
+        ))
+        .id();
+
+    for (name, checked) in rows {
+        let label = prettify(&name);
+        commands.spawn((
+            ChildOf(list),
+            PluginCheckbox {
+                extension_name: name.clone(),
+            },
+            checkbox(CheckboxProps::new(label).checked(checked), &font, &ifont),
+        ));
+    }
+}
+
+/// Observer: when a plugin checkbox commits, enable/disable the matching
+/// extension and rewrite the enabled list.
+fn on_plugin_checkbox_commit(
+    event: On<CheckboxCommitEvent>,
+    checkboxes: Query<&PluginCheckbox>,
+    mut commands: Commands,
+) {
+    let Ok(cb) = checkboxes.get(event.entity) else {
+        return;
+    };
+    let name = cb.extension_name.clone();
+    let checked = event.checked;
+
+    commands.queue(move |world: &mut World| {
+        if checked {
+            jackdaw_api::enable_extension(world, &name);
+        } else {
+            jackdaw_api::disable_extension(world, &name);
+        }
+        extensions_config::persist_current_enabled(world);
+    });
+}
+
+/// Convert `"jackdaw.asset_browser"` → `"Asset Browser"`.
+fn prettify(name: &str) -> String {
+    let stripped = name.strip_prefix("jackdaw.").unwrap_or(name);
+    let mut out = String::new();
+    for (i, part) in stripped.split(&['_', '.'][..]).enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        let mut chars = part.chars();
+        if let Some(c) = chars.next() {
+            out.extend(c.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -680,8 +680,7 @@ fn on_generate_clicked(
         new_heights,
         label: "Generate Terrain".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }
 
 fn on_erode_clicked(
@@ -711,6 +710,5 @@ fn on_erode_clicked(
         new_heights: heights,
         label: "Erode Terrain".to_string(),
     };
-    history.undo_stack.push(Box::new(cmd));
-    history.redo_stack.clear();
+    history.push_executed(Box::new(cmd));
 }

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -232,8 +232,7 @@ fn terrain_sculpt_interaction(
             new_heights: terrain.heights.clone(),
             label: format!("Terrain {:?}", tool),
         };
-        history.undo_stack.push(Box::new(cmd));
-        history.redo_stack.clear();
+        history.push_executed(Box::new(cmd));
     }
 }
 

--- a/src/viewport_overlays.rs
+++ b/src/viewport_overlays.rs
@@ -38,6 +38,7 @@ impl Plugin for ViewportOverlaysPlugin {
                     draw_spot_light_gizmo,
                     draw_dir_light_gizmo,
                     draw_camera_gizmo,
+                    draw_empty_entity_marker,
                 )
                     .after(bevy::camera::visibility::VisibilitySystems::VisibilityPropagate)
                     .run_if(in_state(crate::AppState::Editor)),
@@ -275,20 +276,47 @@ pub(crate) fn collect_descendant_mesh_world_vertices(
     }
 }
 
-/// Point light: 3 axis-aligned circles at range radius.
+/// Color for an entity marker gizmo.
+///
+/// Selected entities use the bright bounding-box color; unselected
+/// entities use a dim variant that stays visible without overpowering
+/// the active selection.
+fn marker_color(is_selected: bool) -> Color {
+    if is_selected {
+        colors::SELECTION_BBOX
+    } else {
+        colors::ENTITY_MARKER_UNSELECTED
+    }
+}
+
+/// Point light: three axis-aligned circles at range radius. Drawn for
+/// every scene-visible point light so invisible lights are still
+/// findable in the viewport (bright when selected, dim otherwise).
+///
+/// The `Without<EditorEntity>` filter keeps editor-local lights, such as
+/// the material-preview scene's lights, out of the main viewport.
 fn draw_point_light_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
-    query: Query<(&PointLight, &GlobalTransform, &InheritedVisibility), With<Selected>>,
+    query: Query<
+        (
+            Entity,
+            &PointLight,
+            &GlobalTransform,
+            &InheritedVisibility,
+            Has<Selected>,
+        ),
+        Without<crate::EditorEntity>,
+    >,
 ) {
     if !settings.show_bounding_boxes {
         return;
     }
-    let color = colors::SELECTION_BBOX;
-    for (light, tf, inherited_vis) in &query {
+    for (_entity, light, tf, inherited_vis, selected) in &query {
         if !inherited_vis.get() {
             continue;
         }
+        let color = marker_color(selected);
         let pos = tf.translation();
         gizmos.circle(
             Isometry3d::new(pos, Quat::from_rotation_x(FRAC_PI_2)),
@@ -304,20 +332,29 @@ fn draw_point_light_gizmo(
     }
 }
 
-/// Spot light: cone from outer_angle + range.
+/// Spot light: cone from outer_angle + range. Drawn for all scene-visible
+/// spot lights.
 fn draw_spot_light_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
-    query: Query<(&SpotLight, &GlobalTransform, &InheritedVisibility), With<Selected>>,
+    query: Query<
+        (
+            &SpotLight,
+            &GlobalTransform,
+            &InheritedVisibility,
+            Has<Selected>,
+        ),
+        Without<crate::EditorEntity>,
+    >,
 ) {
     if !settings.show_bounding_boxes {
         return;
     }
-    let color = colors::SELECTION_BBOX;
-    for (light, tf, inherited_vis) in &query {
+    for (light, tf, inherited_vis, selected) in &query {
         if !inherited_vis.get() {
             continue;
         }
+        let color = marker_color(selected);
         let pos = tf.translation();
         let fwd = tf.forward().as_vec3();
         let right = tf.right().as_vec3();
@@ -338,46 +375,59 @@ fn draw_spot_light_gizmo(
     }
 }
 
-/// Directional light: arrow along forward direction.
+/// Directional light: arrow along forward direction. Drawn for every
+/// scene-visible directional light.
 fn draw_dir_light_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
     query: Query<
-        (&GlobalTransform, &InheritedVisibility),
-        (With<DirectionalLight>, With<Selected>),
+        (&GlobalTransform, &InheritedVisibility, Has<Selected>),
+        (With<DirectionalLight>, Without<crate::EditorEntity>),
     >,
 ) {
     if !settings.show_bounding_boxes {
         return;
     }
-    let color = colors::SELECTION_BBOX;
-    for (tf, inherited_vis) in &query {
+    for (tf, inherited_vis, selected) in &query {
         if !inherited_vis.get() {
             continue;
         }
+        let color = marker_color(selected);
         let pos = tf.translation();
         let dir = tf.forward().as_vec3();
         gizmos.arrow(pos, pos + dir * 2.0, color);
     }
 }
 
-/// Camera: frustum wireframe from Projection.
+/// Camera frustum. Drawn for every scene-authored camera.
+///
+/// The `Without<EditorEntity>` filter excludes the main viewport camera
+/// and the material-preview camera; those are editor-local and should
+/// not surface as selectable scene content.
 fn draw_camera_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
-    query: Query<(&Projection, &GlobalTransform, &InheritedVisibility), With<Selected>>,
+    query: Query<
+        (
+            &Projection,
+            &GlobalTransform,
+            &InheritedVisibility,
+            Has<Selected>,
+        ),
+        (With<Camera>, Without<crate::EditorEntity>),
+    >,
 ) {
     if !settings.show_bounding_boxes {
         return;
     }
-    let color = colors::SELECTION_BBOX;
-    for (projection, tf, inherited_vis) in &query {
+    for (projection, tf, inherited_vis, selected) in &query {
         if !inherited_vis.get() {
             continue;
         }
         let Projection::Perspective(proj) = projection else {
             continue;
         };
+        let color = marker_color(selected);
         let depth = 2.0;
         let half_v = depth * (proj.fov / 2.0).tan();
         let half_h = half_v * proj.aspect_ratio;
@@ -400,6 +450,57 @@ fn draw_camera_gizmo(
         for i in 0..4 {
             gizmos.line(corners[i], corners[(i + 1) % 4], color);
         }
+    }
+}
+
+/// Fallback marker for entities with a `Transform` but no visible
+/// geometry and no specialised gizmo (empty entities, tag entities, and
+/// the like). Draws a small wireframe cube around the origin so the
+/// entity is findable in the viewport and selectable from the scene
+/// tree.
+fn draw_empty_entity_marker(
+    mut gizmos: Gizmos,
+    settings: Res<OverlaySettings>,
+    query: Query<
+        (
+            Entity,
+            &GlobalTransform,
+            &InheritedVisibility,
+            Has<Selected>,
+        ),
+        (
+            With<Transform>,
+            Without<crate::EditorEntity>,
+            Without<crate::EditorHidden>,
+            Without<Mesh3d>,
+            Without<BrushGroup>,
+            Without<PointLight>,
+            Without<SpotLight>,
+            Without<DirectionalLight>,
+            Without<Camera>,
+            Without<ChildOf>,
+        ),
+    >,
+) {
+    if !settings.show_bounding_boxes {
+        return;
+    }
+    // Fixed 0.5-unit cube so the marker stays visible regardless of
+    // camera distance. This is not the world AABB of the entity: there
+    // is no geometry to compute a bound from.
+    const SIZE: f32 = 0.25;
+    for (_entity, tf, inherited_vis, selected) in &query {
+        if !inherited_vis.get() {
+            continue;
+        }
+        let color = marker_color(selected);
+        let pos = tf.translation();
+        draw_aabb_wireframe(
+            &mut gizmos,
+            pos - Vec3::splat(SIZE),
+            pos + Vec3::splat(SIZE),
+            color,
+        );
     }
 }
 

--- a/src/viewport_overlays.rs
+++ b/src/viewport_overlays.rs
@@ -276,11 +276,7 @@ pub(crate) fn collect_descendant_mesh_world_vertices(
     }
 }
 
-/// Color for an entity marker gizmo.
-///
-/// Selected entities use the bright bounding-box color; unselected
-/// entities use a dim variant that stays visible without overpowering
-/// the active selection.
+/// Bright bounding-box color when selected, dim marker color otherwise.
 fn marker_color(is_selected: bool) -> Color {
     if is_selected {
         colors::SELECTION_BBOX
@@ -289,12 +285,9 @@ fn marker_color(is_selected: bool) -> Color {
     }
 }
 
-/// Point light: three axis-aligned circles at range radius. Drawn for
-/// every scene-visible point light so invisible lights are still
-/// findable in the viewport (bright when selected, dim otherwise).
-///
-/// The `Without<EditorEntity>` filter keeps editor-local lights, such as
-/// the material-preview scene's lights, out of the main viewport.
+/// Point light: three axis-aligned circles at range radius. The
+/// `Without<EditorEntity>` filter keeps editor-local lights (e.g. the
+/// material-preview scene) out of the main viewport.
 fn draw_point_light_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
@@ -332,8 +325,7 @@ fn draw_point_light_gizmo(
     }
 }
 
-/// Spot light: cone from outer_angle + range. Drawn for all scene-visible
-/// spot lights.
+/// Spot light cone: `outer_angle` and `range`.
 fn draw_spot_light_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
@@ -375,8 +367,7 @@ fn draw_spot_light_gizmo(
     }
 }
 
-/// Directional light: arrow along forward direction. Drawn for every
-/// scene-visible directional light.
+/// Directional light: arrow along the forward direction.
 fn draw_dir_light_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
@@ -399,11 +390,8 @@ fn draw_dir_light_gizmo(
     }
 }
 
-/// Camera frustum. Drawn for every scene-authored camera.
-///
-/// The `Without<EditorEntity>` filter excludes the main viewport camera
-/// and the material-preview camera; those are editor-local and should
-/// not surface as selectable scene content.
+/// Camera frustum. `Without<EditorEntity>` excludes the main viewport
+/// camera and the material-preview camera.
 fn draw_camera_gizmo(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
@@ -453,11 +441,8 @@ fn draw_camera_gizmo(
     }
 }
 
-/// Fallback marker for entities with a `Transform` but no visible
-/// geometry and no specialised gizmo (empty entities, tag entities, and
-/// the like). Draws a small wireframe cube around the origin so the
-/// entity is findable in the viewport and selectable from the scene
-/// tree.
+/// Fallback marker for empty / tag entities: small wireframe cube at
+/// the origin so the entity is findable and selectable.
 fn draw_empty_entity_marker(
     mut gizmos: Gizmos,
     settings: Res<OverlaySettings>,
@@ -485,9 +470,8 @@ fn draw_empty_entity_marker(
     if !settings.show_bounding_boxes {
         return;
     }
-    // Fixed 0.5-unit cube so the marker stays visible regardless of
-    // camera distance. This is not the world AABB of the entity: there
-    // is no geometry to compute a bound from.
+    // Fixed 0.5-unit cube so the marker is visible at any camera
+    // distance. Not the world AABB: nothing to compute one from.
     const SIZE: f32 = 0.25;
     for (_entity, tf, inherited_vis, selected) in &query {
         if !inherited_vis.get() {


### PR DESCRIPTION
## Summary

- Extension API rebuilt on bevy_enhanced_input. Operators are BEI actions.
- Trigger modes (`Start` / `Fire` / `Complete` / `Manual`) and modal
  operators for Blender-style grab / rotate / scale.
- One `RegisteredMenuEntry` powers the toolbar Add menu, scene-tree
  Add Entity picker, and right-click context menu.
- Jackdaw's own feature areas (scene tree, asset browser, timeline,
  terminal, inspector) are now `JackdawExtension` impls.
- Dim marker gizmos for unselected lights, cameras, and empties.
- Undo / redo fixes (see Closes below).

## Writing an extension

```rust
use bevy::ecs::system::SystemId;
use bevy::prelude::*;
use bevy_enhanced_input::prelude::*;
use jackdaw_api::prelude::*;

pub struct SampleExtension;

impl JackdawExtension for SampleExtension {
    fn name(&self) -> &str { "sample" }

    fn register_input_contexts(&self, app: &mut App) {
        app.add_input_context::<SampleContext>();
    }

    fn register(&self, ctx: &mut ExtensionContext) {
        ctx.register_window(WindowDescriptor {
            id: "sample.hello".into(),
            name: "Hello Extension".into(),
            build: std::sync::Arc::new(|world, parent| {
                world.spawn((ChildOf(parent), Text::new("Hello!")));
            }),
            ..default()
        });

        ctx.register_operator::<HelloOp>();

        ctx.spawn((
            SampleContext,
            actions!(SampleContext[
                (Action::<HelloOp>::new(), bindings![KeyCode::F9]),
            ]),
        ));
    }
}

#[derive(Component, Default)]
pub struct SampleContext;

#[derive(Default, InputAction)]
#[action_output(bool)]
pub struct HelloOp;

impl Operator for HelloOp {
    const ID: &'static str = "sample.hello";
    const LABEL: &'static str = "Hello";

    fn register_execute(cmds: &mut Commands) -> SystemId<(), OperatorResult> {
        cmds.register_system(|| {
            info!("hello");
            OperatorResult::Finished
        })
    }
}
```

Register it:

```rust
jackdaw_api::register_extension(app, "sample", || Box::new(SampleExtension));
```

Unload is `world.entity_mut(ext).despawn()`.

## Triggers

```rust
impl Operator for PlaceCube {
    const ID: &'static str = "sample.place_cube";
    const LABEL: &'static str = "Place Cube";
    const TRIGGER: Trigger = Trigger::Start;   // default

    fn register_execute(c: &mut Commands) -> SystemId<(), OperatorResult> {
        c.register_system(place_cube)
    }
}
```

| Trigger           | Fires on                | Use                    |
|-------------------|-------------------------|------------------------|
| `Start` (default) | key down                | one-shot               |
| `Fire`            | every frame while held  | modal sessions         |
| `Complete`        | key up                  | arm-then-release       |
| `Manual`          | never (no observer)     | menu / button invokes  |

## Modal operators

```rust
impl Operator for Grab {
    const ID: &'static str = "transform.grab";
    const LABEL: &'static str = "Grab";
    const MODAL: bool = true;

    fn register_execute(c: &mut Commands) -> SystemId<(), OperatorResult> {
        c.register_system(grab_tick)
    }
}

fn grab_tick(/* bevy params */) -> OperatorResult {
    if cancel { return OperatorResult::Cancelled; }
    if commit { return OperatorResult::Finished; }
    OperatorResult::Running
}
```

Every command recorded across the session commits as a single undo
entry.

## Menu entries

```rust
ctx.register_menu_entry(MenuEntryDescriptor {
    menu: "Add".into(),
    label: "Viewable Camera".into(),
    operator_id: PlaceViewableCamera::ID,
});
```

Appears in:
- **Add** in the toolbar menu bar
- the **Add Entity** picker (scene-tree button)
- the scene-tree right-click context menu

## Built-in vs. Custom

```rust
impl JackdawExtension for InspectorExtension {
    fn name(&self) -> &str { "inspector" }
    fn kind(&self) -> ExtensionKind { ExtensionKind::Builtin }
    fn register(&self, ctx: &mut ExtensionContext) { /* ... */ }
}
```

`kind()` defaults to `Custom`. `File > Extensions` splits its list on
this value.

## Dogfooded built-ins

| Extension       | Windows                                        |
|-----------------|------------------------------------------------|
| `core_windows`  | Scene Tree, Import, Project Files              |
| `asset_browser` | Assets                                         |
| `timeline`      | Timeline                                       |
| `terminal`      | Terminal (placeholder)                         |
| `inspector`     | Components, Materials, Resources, Systems      |

Disabling a built-in removes its windows from the live dock tree and
every stored workspace. `register_all_dock_windows` is gone.

Enabled / disabled extensions are persisted to `extensions.json`.

Closes #85, 
Closes #112, 
Closes #117, 
Closes #128, 
Closes #129,
Closes #134,