### PR TITLE
feat: automatic snapshot-based undo + #[operator] macro

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
             jackdaw_avian_integration
             jackdaw_remote
             jackdaw_panels
+            jackdaw_api_macros
             jackdaw_api
             jackdaw_jsn
             jackdaw_camera

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7556,7 +7556,6 @@ dependencies = [
  "bevy",
  "bevy_enhanced_input",
  "jackdaw_api",
- "jackdaw_commands",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,8 +4504,18 @@ version = "0.4.0"
 dependencies = [
  "bevy",
  "bevy_enhanced_input",
+ "jackdaw_api_macros",
  "jackdaw_commands",
  "jackdaw_panels",
+]
+
+[[package]]
+name = "jackdaw_api_macros"
+version = "0.4.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ jackdaw_avian_integration = { version = "0.4.0", path = "crates/jackdaw_avian_in
 jackdaw_runtime = { version = "0.4.0", path = "crates/jackdaw_runtime" }
 jackdaw_panels = { version = "0.4.0", path = "crates/jackdaw_panels" }
 jackdaw_api = { version = "0.4.0", path = "crates/jackdaw_api" }
+jackdaw_api_macros = { version = "0.4.0", path = "crates/jackdaw_api_macros" }
 bevy_enhanced_input = "0.24"
 rfd = "0.15"
 bevy_rerecast = { version = "0.4", default-features = true }

--- a/crates/jackdaw_api/Cargo.toml
+++ b/crates/jackdaw_api/Cargo.toml
@@ -11,6 +11,7 @@ bevy.workspace = true
 bevy_enhanced_input.workspace = true
 jackdaw_panels.workspace = true
 jackdaw_commands.workspace = true
+jackdaw_api_macros.workspace = true
 
 [lints]
 workspace = true

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -68,6 +68,7 @@ use jackdaw_panels::{
     DockWindowDescriptor, WindowRegistry, WorkspaceDescriptor, WorkspaceRegistry,
 };
 
+pub use jackdaw_api_macros::operator;
 pub use lifecycle::{
     ActiveModalOperator, CallOperatorError, CallOperatorSettings, Extension, ExtensionCatalog,
     ExtensionCtor, ExtensionKind, OperatorEntity, OperatorIndex, OperatorSession, OperatorWorldExt,
@@ -87,7 +88,7 @@ pub mod prelude {
     pub use crate::operator::{Operator, OperatorResult};
     pub use crate::{
         ExtensionContext, ExtensionPoint, JackdawExtension, MenuEntryDescriptor, PanelContext,
-        SectionBuildFn, WindowDescriptor,
+        SectionBuildFn, WindowDescriptor, operator,
     };
     // BEI types extension authors need for `actions!` / `bindings!` / observers.
     pub use bevy_enhanced_input::prelude::*;

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -26,7 +26,11 @@
 //!     }
 //! }
 //!
-//! fn place_cube(mut _buffer: ResMut<OperatorCommandBuffer>) -> OperatorResult {
+//! // Operators are plain Bevy systems. Mutate the world however you
+//! // like; the dispatcher snapshots the scene before invoke and diffs
+//! // after, so a single Ctrl+Z reverses the entire call.
+//! fn place_cube(mut commands: Commands) -> OperatorResult {
+//!     commands.spawn((Name::new("Cube"), Transform::default()));
 //!     OperatorResult::Finished
 //! }
 //!
@@ -54,6 +58,7 @@
 pub mod lifecycle;
 mod operator;
 mod registries;
+pub mod snapshot;
 
 use std::sync::Arc;
 
@@ -64,20 +69,22 @@ use jackdaw_panels::{
 };
 
 pub use lifecycle::{
-    ActiveModalOperator, Extension, ExtensionCatalog, ExtensionCtor, ExtensionKind, OperatorEntity,
-    OperatorIndex, RegisteredMenuEntry, RegisteredPanelExtension, RegisteredWindow,
-    RegisteredWorkspace, disable_extension, enable_extension, register_extension,
-    tick_modal_operator, unload_extension,
+    ActiveModalOperator, CallOperatorError, CallOperatorSettings, Extension, ExtensionCatalog,
+    ExtensionCtor, ExtensionKind, OperatorEntity, OperatorIndex, OperatorSession, OperatorWorldExt,
+    RegisteredMenuEntry, RegisteredPanelExtension, RegisteredWindow, RegisteredWorkspace,
+    disable_extension, enable_extension, register_extension, tick_modal_operator, unload_extension,
 };
-pub use operator::{Operator, OperatorCommandBuffer, OperatorResult, Trigger};
+pub use operator::{Operator, OperatorResult};
 pub use registries::PanelExtensionRegistry;
+pub use snapshot::{ActiveSnapshotter, SceneSnapshot, SceneSnapshotter};
 
 /// Re-exports plugin authors will want in one import.
 pub mod prelude {
     pub use crate::lifecycle::{
-        Extension, ExtensionCatalog, ExtensionKind, OperatorEntity, OperatorIndex,
+        CallOperatorError, CallOperatorSettings, Extension, ExtensionCatalog, ExtensionKind,
+        OperatorEntity, OperatorIndex, OperatorWorldExt,
     };
-    pub use crate::operator::{Operator, OperatorCommandBuffer, OperatorResult, Trigger};
+    pub use crate::operator::{Operator, OperatorResult};
     pub use crate::{
         ExtensionContext, ExtensionPoint, JackdawExtension, MenuEntryDescriptor, PanelContext,
         SectionBuildFn, WindowDescriptor,
@@ -205,27 +212,24 @@ impl<'a> ExtensionContext<'a> {
         ec
     }
 
-    /// Register an operator. Spawns an [`OperatorEntity`] as a child of
-    /// the extension entity and, based on the operator's
-    /// [`Operator::TRIGGER`], an observer that dispatches the operator
-    /// on `Start`, `Fire`, or `Complete`. `Trigger::Manual` skips the
-    /// observer; the caller is expected to invoke the operator through
-    /// [`crate::lifecycle::dispatch_operator_by_id`].
+    /// Register an operator. Spawns an [`OperatorEntity`] as a child
+    /// of the extension entity and, unless [`Operator::MANUAL`] is
+    /// `true`, a `Fire<O>` observer that dispatches the operator
+    /// through [`crate::OperatorWorldExt::call_operator`]. BEI binding
+    /// modifiers on the actions shape timing (press / release / hold).
     pub fn register_operator<O: Operator>(&mut self) {
         let ext = self.extension_entity;
 
-        // Register execute/invoke/poll as real Bevy systems.
-        let (execute, invoke, poll) = {
+        let (execute, invoke, availability_check) = {
             let mut queue = bevy::ecs::world::CommandQueue::default();
             let mut commands = Commands::new(&mut queue, self.world);
             let execute = O::register_execute(&mut commands);
             let invoke = O::register_invoke(&mut commands);
-            let poll = O::register_poll(&mut commands);
+            let availability_check = O::register_availability_check(&mut commands);
             queue.apply(self.world);
-            (execute, invoke, poll)
+            (execute, invoke, availability_check)
         };
 
-        // Spawn the operator entity as a child of the extension.
         let op_entity = self
             .world
             .spawn((
@@ -235,47 +239,25 @@ impl<'a> ExtensionContext<'a> {
                     description: O::DESCRIPTION,
                     execute,
                     invoke,
-                    poll,
+                    availability_check,
                     modal: O::MODAL,
                 },
                 ChildOf(ext),
             ))
             .id();
 
-        // Spawn the BEI observer for the configured trigger. The
-        // observer is parented to the operator entity so despawning the
-        // operator drops it automatically. `Trigger::Manual` skips the
-        // observer; callers dispatch through `dispatch_operator_by_id`.
-        use bevy_enhanced_input::prelude::{Complete, Fire, Start};
-        match O::TRIGGER {
-            crate::operator::Trigger::Start => {
-                self.spawn_trigger_observer::<O, Start<O>>(op_entity);
-            }
-            crate::operator::Trigger::Fire => {
-                self.spawn_trigger_observer::<O, Fire<O>>(op_entity);
-            }
-            crate::operator::Trigger::Complete => {
-                self.spawn_trigger_observer::<O, Complete<O>>(op_entity);
-            }
-            crate::operator::Trigger::Manual => {}
+        if !O::MANUAL {
+            let observer = Observer::new(
+                move |_: bevy::prelude::On<bevy_enhanced_input::prelude::Fire<O>>,
+                      mut commands: Commands| {
+                    commands.queue(move |world: &mut World| {
+                        use crate::OperatorWorldExt;
+                        let _ = world.call_operator(O::ID);
+                    });
+                },
+            );
+            self.world.spawn((observer, ChildOf(op_entity)));
         }
-    }
-
-    /// Helper used by [`Self::register_operator`] to spawn a BEI observer
-    /// that dispatches the operator through
-    /// [`crate::lifecycle::dispatch_operator_by_id`]. Generic over the
-    /// event type so one body covers `Start<O>`, `Fire<O>`, and
-    /// `Complete<O>`.
-    fn spawn_trigger_observer<O: Operator, E: bevy::ecs::event::EntityEvent>(
-        &mut self,
-        op_entity: Entity,
-    ) {
-        let observer = Observer::new(move |_: bevy::prelude::On<E>, mut commands: Commands| {
-            commands.queue(move |world: &mut World| {
-                crate::lifecycle::dispatch_operator_by_id(world, O::ID, true);
-            });
-        });
-        self.world.spawn((observer, ChildOf(op_entity)));
     }
 
     /// Inject a section into an existing panel (e.g. add a sub-section to

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -9,13 +9,16 @@
 //! unregistering stored `SystemId`s, removing entries from the dock
 //! `WindowRegistry`, and so on.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
+use jackdaw_commands::{CommandHistory, EditorCommand};
 
 use crate::operator::OperatorResult;
+use crate::snapshot::{ActiveSnapshotter, SceneSnapshot};
 
 /// Root component for an extension.
 ///
@@ -41,7 +44,9 @@ pub struct OperatorEntity {
     pub description: &'static str,
     pub execute: SystemId<(), OperatorResult>,
     pub invoke: SystemId<(), OperatorResult>,
-    pub poll: Option<SystemId<(), bool>>,
+    /// Optional system that returns whether the operator can run in
+    /// the current editor state. Equivalent to Blender's `poll`.
+    pub availability_check: Option<SystemId<(), bool>>,
     /// Mirrors [`crate::Operator::MODAL`]. Set at registration so the
     /// dispatcher can enter modal mode without re-resolving the generic
     /// operator type.
@@ -52,15 +57,16 @@ pub struct OperatorEntity {
 /// active at any time; starting a second modal while one is running is
 /// refused.
 ///
-/// While set, `tick_modal_operator` re-runs the invoke system every frame
-/// and the [`crate::OperatorCommandBuffer`] stays prepared across frames
-/// so every `record` call lands in the same `CommandGroup`.
+/// The `before_snapshot` is captured when the modal begins; on commit
+/// the dispatcher diffs it against a fresh snapshot and pushes a single
+/// undo entry, so the entire modal session rolls up into one Ctrl+Z.
 #[derive(Resource, Default)]
 pub struct ActiveModalOperator {
     pub(crate) id: Option<&'static str>,
     pub(crate) operator_entity: Option<Entity>,
     pub(crate) invoke_system: Option<SystemId<(), OperatorResult>>,
     pub(crate) label: Option<String>,
+    pub(crate) before_snapshot: Option<Box<dyn SceneSnapshot>>,
 }
 
 impl ActiveModalOperator {
@@ -70,6 +76,20 @@ impl ActiveModalOperator {
 
     pub fn id(&self) -> Option<&'static str> {
         self.id
+    }
+}
+
+/// Counts how deeply operators are nested. The outermost operator in
+/// a call chain takes the snapshot; inner operators' mutations roll
+/// into that outer diff.
+#[derive(Resource, Default)]
+pub struct OperatorSession {
+    depth: u32,
+}
+
+impl OperatorSession {
+    pub fn is_outermost(&self) -> bool {
+        self.depth == 0
     }
 }
 
@@ -242,97 +262,229 @@ where
         .register(name, kind, ctor);
 }
 
-use crate::operator::OperatorCommandBuffer;
-use jackdaw_commands::{CommandGroup, CommandHistory};
+/// Extension trait on [`World`] for calling operators by id.
+///
+/// Usage:
+///
+/// ```ignore
+/// use jackdaw_api::prelude::*;
+///
+/// fn my_button(mut commands: Commands) {
+///     commands.queue(|world: &mut World| {
+///         let _ = world.call_operator("avian.add_rigid_body");
+///     });
+/// }
+/// ```
+pub trait OperatorWorldExt {
+    /// Call an operator by id. The availability check runs before the
+    /// invoke system, so validation logic lives only on the operator
+    /// itself. Equivalent to
+    /// `call_operator_with(id, &CallOperatorSettings::default())`.
+    fn call_operator(
+        &mut self,
+        id: impl Into<Cow<'static, str>>,
+    ) -> Result<OperatorResult, CallOperatorError>;
 
-/// Dispatch an operator by id. Used by the BEI trigger observers spawned
-/// in `ExtensionContext::register_operator`, and callable directly for
-/// `Trigger::Manual` operators (UI buttons, F3 search, etc.).
-///
-/// - Non-modal operators: runs once and pushes a history entry immediately.
-/// - Modal operators: if the invoke returns `Running`, enters modal mode.
-///   The tick system takes over from the next frame.
-///
-/// If another modal operator is already active, the dispatch is refused
-/// with a warn log (matches Blender's "one modal at a time" rule).
-pub fn dispatch_operator_by_id(world: &mut World, id: &str, creates_history_entry: bool) {
-    // Refuse if another modal operator is active.
-    if let Some(active_id) = world.resource::<ActiveModalOperator>().id {
-        warn!("Ignoring operator '{id}': modal operator '{active_id}' is currently active");
-        return;
+    /// Call an operator with explicit settings.
+    fn call_operator_with(
+        &mut self,
+        id: impl Into<Cow<'static, str>>,
+        settings: &CallOperatorSettings,
+    ) -> Result<OperatorResult, CallOperatorError>;
+
+    /// Whether the operator would run in the current editor state.
+    /// `Ok(true)` if it's ready, `Ok(false)` if not, `Err` for unknown
+    /// ids.
+    fn is_operator_available(
+        &mut self,
+        id: impl Into<Cow<'static, str>>,
+    ) -> Result<bool, CallOperatorError>;
+}
+
+/// Knobs passed to [`OperatorWorldExt::call_operator_with`].
+#[derive(Clone, Debug)]
+pub struct CallOperatorSettings {
+    /// Whether a successful call should push an undo entry. Default
+    /// `true`. Set `false` for view-local effects (camera moves,
+    /// preview toggles) that should not be undoable.
+    pub creates_history_entry: bool,
+}
+
+impl Default for CallOperatorSettings {
+    fn default() -> Self {
+        Self {
+            creates_history_entry: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum CallOperatorError {
+    UnknownId(Cow<'static, str>),
+    ModalAlreadyActive(&'static str),
+    AvailabilityCheckFailed,
+    ExecuteFailed,
+}
+
+impl std::fmt::Display for CallOperatorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownId(id) => write!(f, "unknown operator: {id}"),
+            Self::ModalAlreadyActive(id) => {
+                write!(f, "modal operator '{id}' is currently active")
+            }
+            Self::AvailabilityCheckFailed => f.write_str("operator's availability check failed"),
+            Self::ExecuteFailed => f.write_str("operator's execute system failed"),
+        }
+    }
+}
+
+impl std::error::Error for CallOperatorError {}
+
+impl OperatorWorldExt for World {
+    fn call_operator(
+        &mut self,
+        id: impl Into<Cow<'static, str>>,
+    ) -> Result<OperatorResult, CallOperatorError> {
+        self.call_operator_with(id, &CallOperatorSettings::default())
     }
 
-    // Resolve operator via the reactive index. The index keys are
-    // `&'static str` from each operator's trait, but `HashMap` lookup
-    // hashes by string content, so a plain `&str` works.
-    let Some(op_entity) = world.resource::<OperatorIndex>().by_id.get(id).copied() else {
-        warn!("Tried to dispatch unknown operator: {}", id);
-        return;
+    fn call_operator_with(
+        &mut self,
+        id: impl Into<Cow<'static, str>>,
+        settings: &CallOperatorSettings,
+    ) -> Result<OperatorResult, CallOperatorError> {
+        let id = id.into();
+        dispatch_operator(self, id, settings.creates_history_entry)
+    }
+
+    fn is_operator_available(
+        &mut self,
+        id: impl Into<Cow<'static, str>>,
+    ) -> Result<bool, CallOperatorError> {
+        let id = id.into();
+        let Some(op_entity) = self
+            .resource::<OperatorIndex>()
+            .by_id
+            .get(id.as_ref())
+            .copied()
+        else {
+            return Err(CallOperatorError::UnknownId(id));
+        };
+        let Some(op) = self.get::<OperatorEntity>(op_entity).cloned() else {
+            return Err(CallOperatorError::UnknownId(id));
+        };
+        let Some(check) = op.availability_check else {
+            return Ok(true);
+        };
+        self.run_system(check)
+            .map_err(|_| CallOperatorError::AvailabilityCheckFailed)
+    }
+}
+
+fn dispatch_operator(
+    world: &mut World,
+    id: Cow<'static, str>,
+    creates_history_entry: bool,
+) -> Result<OperatorResult, CallOperatorError> {
+    if let Some(active_id) = world.resource::<ActiveModalOperator>().id {
+        return Err(CallOperatorError::ModalAlreadyActive(active_id));
+    }
+
+    let Some(op_entity) = world
+        .resource::<OperatorIndex>()
+        .by_id
+        .get(id.as_ref())
+        .copied()
+    else {
+        return Err(CallOperatorError::UnknownId(id));
     };
     let Some(op) = world.get::<OperatorEntity>(op_entity).cloned() else {
-        return;
+        return Err(CallOperatorError::UnknownId(id));
     };
 
-    // Poll (optional).
-    if let Some(poll) = op.poll {
-        if !world.run_system(poll).unwrap_or(false) {
-            return;
+    if let Some(check) = op.availability_check {
+        let available = world
+            .run_system(check)
+            .map_err(|_| CallOperatorError::AvailabilityCheckFailed)?;
+        if !available {
+            return Ok(OperatorResult::Cancelled);
         }
     }
 
-    // Prep the command buffer, run the invoke system.
-    world
-        .resource_mut::<OperatorCommandBuffer>()
-        .prepare(creates_history_entry);
+    // Only the outermost operator in a nesting chain captures the
+    // snapshot. Inner `call_operator` calls mutate inside the outer's
+    // span and their changes roll into the outer's diff.
+    let is_outermost = world.resource::<OperatorSession>().depth == 0;
+    let before = (is_outermost && creates_history_entry)
+        .then(|| world.resource::<ActiveSnapshotter>().0.capture(world));
 
-    let result = match world.run_system(op.invoke) {
-        Ok(r) => r,
-        Err(err) => {
-            error!("Failed to run operator {}: {:?}", op.id, err);
-            world.resource_mut::<OperatorCommandBuffer>().take();
-            return;
-        }
-    };
+    world.resource_mut::<OperatorSession>().depth += 1;
+    let result = world.run_system(op.invoke);
+    world.resource_mut::<OperatorSession>().depth -= 1;
+
+    let result = result.map_err(|_| CallOperatorError::ExecuteFailed)?;
 
     match result {
         OperatorResult::Running if op.modal => {
-            // Enter modal mode. The tick system picks up from next frame;
-            // the command buffer stays prepared across frames.
             let mut active = world.resource_mut::<ActiveModalOperator>();
             active.id = Some(op.id);
             active.operator_entity = Some(op_entity);
             active.invoke_system = Some(op.invoke);
             active.label = Some(op.label.to_string());
+            active.before_snapshot = before;
         }
         OperatorResult::Running | OperatorResult::Finished => {
-            // Non-modal `Running` collapses to `Finished` for one-shot behavior.
-            finalize_operator_session(world, op.label, true);
+            finalize(world, op.label, before);
         }
         OperatorResult::Cancelled => {
-            finalize_operator_session(world, op.label, false);
+            // Drop the snapshot without pushing history.
+            drop(before);
         }
     }
+
+    Ok(result)
 }
 
-/// Drain the command buffer and, if committing and history-tracked, push a
-/// `CommandGroup` to `CommandHistory`.
-fn finalize_operator_session(world: &mut World, label: &str, commit: bool) {
-    let (recorded, creates_history) = world.resource_mut::<OperatorCommandBuffer>().take();
-    if !commit {
+/// Capture the current state, diff against `before`, and push a
+/// `SnapshotDiff` onto [`CommandHistory`] if the scene changed.
+fn finalize(world: &mut World, label: &str, before: Option<Box<dyn SceneSnapshot>>) {
+    let Some(before) = before else { return };
+    let after = world.resource::<ActiveSnapshotter>().0.capture(world);
+    if before.equals(&*after) {
         return;
     }
-    if creates_history && !recorded.is_empty() {
-        let group = Box::new(CommandGroup {
-            commands: recorded,
+    world
+        .resource_mut::<CommandHistory>()
+        .push_executed(Box::new(SnapshotDiff {
+            before,
+            after,
             label: label.to_string(),
-        });
-        world.resource_mut::<CommandHistory>().push_executed(group);
+        }));
+}
+
+/// One undo entry. Swaps the active scene snapshot on execute / undo.
+struct SnapshotDiff {
+    before: Box<dyn SceneSnapshot>,
+    after: Box<dyn SceneSnapshot>,
+    label: String,
+}
+
+impl EditorCommand for SnapshotDiff {
+    fn execute(&mut self, world: &mut World) {
+        self.after.apply(world);
+    }
+    fn undo(&mut self, world: &mut World) {
+        self.before.apply(world);
+    }
+    fn description(&self) -> &str {
+        &self.label
     }
 }
 
-/// Tick system added to Update by `ExtensionLoaderPlugin`. If a modal
-/// operator is active, re-runs its invoke system once per frame and
-/// transitions out of modal on `Finished` or `Cancelled`.
+/// Tick system added to Update by `ExtensionLoaderPlugin`. Re-runs the
+/// active modal operator's invoke system each frame; exits modal on
+/// `Finished` (committing) or `Cancelled` (discarding).
 pub fn tick_modal_operator(world: &mut World) {
     let Some(invoke) = world.resource::<ActiveModalOperator>().invoke_system else {
         return;
@@ -340,33 +492,33 @@ pub fn tick_modal_operator(world: &mut World) {
     let result = match world.run_system(invoke) {
         Ok(r) => r,
         Err(err) => {
-            error!(
-                "Modal operator's invoke system failed: {:?}; cancelling",
-                err
-            );
+            error!("Modal operator's invoke system failed: {err:?}; cancelling");
             finalize_modal(world, false);
             return;
         }
     };
     match result {
-        OperatorResult::Running => { /* stay modal */ }
+        OperatorResult::Running => {}
         OperatorResult::Finished => finalize_modal(world, true),
         OperatorResult::Cancelled => finalize_modal(world, false),
     }
 }
 
-/// Exit modal mode. Drains the command buffer; commits as a history entry
-/// if `commit` is true and the buffer is non-empty, otherwise discards.
+/// Exit modal mode. Commits the before-snapshot diff as a history entry
+/// if `commit`, otherwise discards it.
 fn finalize_modal(world: &mut World, commit: bool) {
-    let label = {
+    let (label, before) = {
         let mut active = world.resource_mut::<ActiveModalOperator>();
         let label = active.label.take().unwrap_or_default();
+        let before = active.before_snapshot.take();
         active.id = None;
         active.operator_entity = None;
         active.invoke_system = None;
-        label
+        (label, before)
     };
-    finalize_operator_session(world, &label, commit);
+    if commit {
+        finalize(world, &label, before);
+    }
 }
 
 /// Unload an extension. Despawns the root entity; the cascade and
@@ -442,14 +594,14 @@ pub fn deindex_and_cleanup_operator_on_remove(
     };
     info!("Unregistering operator: {}", op.id);
     index.by_id.remove(op.id);
-    let (exec, inv, poll) = (op.execute, op.invoke, op.poll);
+    let (exec, inv, check) = (op.execute, op.invoke, op.availability_check);
     commands.queue(move |world: &mut World| {
         let _ = world.unregister_system(exec);
         if exec != inv {
             let _ = world.unregister_system(inv);
         }
-        if let Some(p) = poll {
-            let _ = world.unregister_system(p);
+        if let Some(c) = check {
+            let _ = world.unregister_system(c);
         }
     });
 }

--- a/crates/jackdaw_api/src/operator.rs
+++ b/crates/jackdaw_api/src/operator.rs
@@ -1,12 +1,11 @@
 use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::InputAction;
-use jackdaw_commands::EditorCommand;
 
 /// A Blender-style operator.
 ///
-/// The trait is bounded on [`InputAction`] so the operator type itself can be
-/// used as a BEI action:
+/// The trait is bounded on [`InputAction`] so the operator type itself
+/// can be used as a BEI action:
 ///
 /// ```ignore
 /// use bevy_enhanced_input::prelude::*;
@@ -25,14 +24,15 @@ use jackdaw_commands::EditorCommand;
 /// }
 /// ```
 ///
-/// Extensions then bind the operator to a key via pure BEI syntax:
+/// Extensions then bind the operator to a key via pure BEI syntax. Use
+/// BEI binding modifiers (`Press`, `Release`, `Hold`) when specific
+/// input timing is needed:
 ///
 /// ```ignore
 /// ctx.spawn((
 ///     MyPluginContext,
 ///     actions!(MyPluginContext[
-///         Action::<PlaceCube>::new(),
-///         bindings![KeyCode::C],
+///         (Action::<PlaceCube>::new(), bindings![KeyCode::C]),
 ///     ]),
 /// ));
 /// ```
@@ -41,135 +41,64 @@ pub trait Operator: InputAction + 'static {
     const LABEL: &'static str;
     const DESCRIPTION: &'static str = "";
 
-    /// Which BEI event triggers the operator's invoke system.
+    /// Whether an observer should be auto-wired to call this operator.
     ///
-    /// - `Trigger::Start` (default): fires on key down. Discrete,
-    ///   one-shot semantics matching Blender's common case.
-    /// - `Trigger::Fire`: fires every frame the input is held. Usually
-    ///   paired with `MODAL = true` for state-tracking sessions; also
-    ///   useful for per-frame probes.
-    /// - `Trigger::Complete`: fires on key up. Useful for "press to arm,
-    ///   release to commit" flows that don't need a modal state machine.
-    /// - `Trigger::Manual`: no BEI observer is wired up. Callers invoke
-    ///   the operator directly through
-    ///   [`crate::lifecycle::dispatch_operator_by_id`], for example from
-    ///   UI buttons, F3 search, or other code paths.
-    const TRIGGER: Trigger = Trigger::Start;
+    /// When `false` (default), registration spawns a `Fire<Self>`
+    /// observer that dispatches the operator whenever any bound input
+    /// fires it. Authors shape timing via BEI binding modifiers
+    /// (`Press`, `Release`, `Hold`, etc.) on the binding.
+    ///
+    /// When `true`, no observer is spawned. The operator is invocable
+    /// only through `World::call_operator(Self::ID)`. Useful for
+    /// operators driven by menus, UI buttons, or F3-search without
+    /// a keybind.
+    const MANUAL: bool = false;
 
     /// Modal operators stay active across frames.
     ///
     /// When `MODAL = true` and the invoke system returns
-    /// [`OperatorResult::Running`], the dispatcher keeps the
-    /// [`OperatorCommandBuffer`] prepared and re-runs the invoke system
-    /// every frame until it returns `Finished` or `Cancelled`. Every
-    /// `record` call across those frames lands in the same `CommandGroup`,
-    /// so the entire modal session commits as one undo entry.
+    /// [`OperatorResult::Running`], the dispatcher re-runs the invoke
+    /// system every frame until it returns `Finished` or `Cancelled`.
+    /// The scene snapshot captured at `Start` is diffed against the
+    /// state at `Finished`, so the whole session commits as one undo
+    /// entry.
     ///
     /// When `MODAL = false` (default), `Running` is treated like
-    /// `Finished`: the operator runs once, the buffer is drained, and a
-    /// history entry is pushed immediately.
+    /// `Finished` and one invoke runs to completion.
     const MODAL: bool = false;
 
     /// Register the primary execute system. Called once during
     /// `ExtensionContext::register_operator::<Self>()`. The returned
-    /// `SystemId` is stored on the operator entity and unregistered on
-    /// despawn.
+    /// `SystemId` is stored on the operator entity and unregistered
+    /// on despawn.
     fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult>;
 
-    /// Register an optional poll system. Returns `true` if the operator is
-    /// currently callable; `false` skips execution. Default: always callable.
-    fn register_poll(_commands: &mut Commands) -> Option<SystemId<(), bool>> {
+    /// Register an optional availability check. Returns `true` if the
+    /// operator can run in the current editor state, `false` if it
+    /// should be skipped. Default: always callable.
+    fn register_availability_check(_commands: &mut Commands) -> Option<SystemId<(), bool>> {
         None
     }
 
     /// Register an optional invoke system. `invoke` is what UI,
-    /// keybinds, and F3 search run; it can differ from `execute` when
-    /// the caller wants to open a dialog or start a drag before the
-    /// primary work happens. Defaults to `execute`.
+    /// keybinds, and F3 search run; it can differ from `execute`
+    /// when the caller wants to open a dialog or start a drag before
+    /// the primary work happens. Defaults to `execute`.
     fn register_invoke(commands: &mut Commands) -> SystemId<(), OperatorResult> {
         Self::register_execute(commands)
     }
 }
 
-/// Which BEI event an operator reacts to. See [`Operator::TRIGGER`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Trigger {
-    /// Key/button down (`Start<A>`). One-shot, discrete.
-    Start,
-    /// Every frame while held (`Fire<A>`). Usually paired with `MODAL = true`.
-    Fire,
-    /// Key/button up (`Complete<A>`).
-    Complete,
-    /// No auto-wired observer. Caller dispatches explicitly.
-    Manual,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OperatorResult {
-    /// Operator finished successfully. Any recorded commands are grouped and
-    /// pushed to `CommandHistory` as a single undo entry.
+    /// Operator finished successfully. The dispatcher captures the
+    /// resulting scene diff as a single undo entry.
     Finished,
-    /// Operator explicitly cancelled. Recorded commands are dropped.
+    /// Operator explicitly cancelled. No history entry is pushed.
     Cancelled,
-    /// Operator is in a modal state (drag, dialog). The dispatcher re-runs
-    /// the invoke system next frame until `Finished` or `Cancelled`.
-    /// Modal support is future work; first pass treats `Running` like
-    /// `Finished` to simplify the dispatcher.
+    /// Operator is in a modal session (drag, dialog, multi-frame
+    /// edit). The dispatcher re-runs the invoke system every frame
+    /// until it returns `Finished` or `Cancelled`. Non-modal
+    /// operators that return `Running` collapse to `Finished`.
     Running,
-}
-
-/// Resource operator systems use to record `EditorCommand`s for undo.
-///
-/// Operators call [`Self::record`] from their execute/invoke system.
-/// The dispatcher handles preparing and draining the buffer around each
-/// invocation. The command's `execute` must already have been run by
-/// the caller (or be implicit in how the system modified state).
-///
-/// All scene mutations go through an `EditorCommand`. Operators never
-/// mutate `SceneJsnAst` directly.
-#[derive(Resource, Default)]
-pub struct OperatorCommandBuffer {
-    pub(crate) recorded: Vec<Box<dyn EditorCommand>>,
-    pub(crate) creates_history_entry: bool,
-}
-
-impl OperatorCommandBuffer {
-    /// Record an already-executed command for undo. Use this when your
-    /// operator system constructs commands that have already been applied
-    /// to the world (e.g. by using `cmd.execute(world)` before calling
-    /// record, or by doing the mutation directly and then recording a
-    /// command that can reverse it on undo).
-    pub fn record(&mut self, cmd: Box<dyn EditorCommand>) {
-        self.recorded.push(cmd);
-    }
-
-    /// Execute a command and record it. Convenience for operators that
-    /// have `&mut World` (exclusive systems).
-    pub fn execute_and_record(&mut self, mut cmd: Box<dyn EditorCommand>, world: &mut World) {
-        cmd.execute(world);
-        self.recorded.push(cmd);
-    }
-
-    /// Called by the dispatcher before running the operator's invoke system.
-    pub(crate) fn prepare(&mut self, creates_history_entry: bool) {
-        self.recorded.clear();
-        self.creates_history_entry = creates_history_entry;
-    }
-
-    /// Called by the dispatcher after the operator finishes. Returns the
-    /// recorded commands and whether they should be turned into a history
-    /// entry.
-    pub(crate) fn take(&mut self) -> (Vec<Box<dyn EditorCommand>>, bool) {
-        let recorded = std::mem::take(&mut self.recorded);
-        let creates_history = self.creates_history_entry;
-        self.creates_history_entry = false;
-        (recorded, creates_history)
-    }
-
-    /// Whether the current operator run will create a history entry. Useful
-    /// if an operator's execute system wants to behave differently when
-    /// called from a nested context (e.g. skip dialog prompts).
-    pub fn creates_history_entry(&self) -> bool {
-        self.creates_history_entry
-    }
 }

--- a/crates/jackdaw_api/src/snapshot.rs
+++ b/crates/jackdaw_api/src/snapshot.rs
@@ -1,0 +1,37 @@
+//! Backend-neutral scene snapshots for undo.
+//!
+//! The operator dispatcher captures a snapshot before invoke and diffs
+//! after. The snapshot format is behind a trait so the current
+//! `SceneJsnAst`-backed implementation can be swapped for a BSN-backed
+//! one without touching the dispatcher or extension authors' code.
+
+use std::any::Any;
+
+use bevy::prelude::*;
+
+/// A point-in-time representation of the editor scene.
+pub trait SceneSnapshot: Any + Send + Sync + 'static {
+    /// Make the world match this snapshot. Used for both undo and redo.
+    fn apply(&self, world: &mut World);
+
+    /// Whether this snapshot represents the same scene as `other`. Used
+    /// by the dispatcher to skip pushing history entries when an
+    /// operator finished without actually changing the scene.
+    fn equals(&self, other: &dyn SceneSnapshot) -> bool;
+
+    fn clone_box(&self) -> Box<dyn SceneSnapshot>;
+
+    /// Implementors should forward to `self`. Needed for downcasting
+    /// inside [`Self::equals`].
+    fn as_any(&self) -> &dyn Any;
+}
+
+/// Strategy for producing snapshots from the current world.
+pub trait SceneSnapshotter: Send + Sync + 'static {
+    fn capture(&self, world: &World) -> Box<dyn SceneSnapshot>;
+}
+
+/// The active snapshotter. Inserted once at plugin setup. Swapped on
+/// BSN migration.
+#[derive(Resource)]
+pub struct ActiveSnapshotter(pub Box<dyn SceneSnapshotter>);

--- a/crates/jackdaw_api_macros/Cargo.toml
+++ b/crates/jackdaw_api_macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "jackdaw_api_macros"
+version = "0.4.0"
+edition = "2024"
+description = "Proc macros for jackdaw_api"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jbuehler23/jackdaw"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/jackdaw_api_macros/src/lib.rs
+++ b/crates/jackdaw_api_macros/src/lib.rs
@@ -1,0 +1,181 @@
+//! Proc macros for `jackdaw_api`.
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote};
+use syn::{
+    Expr, ExprLit, ItemFn, Lit, LitBool, LitStr, MetaNameValue, Token, parse_macro_input,
+    punctuated::Punctuated, spanned::Spanned,
+};
+
+/// Marks a plain Bevy system function as an operator. Generates the
+/// zero-sized action type, the `InputAction` derive, and the
+/// `Operator` trait impl, leaving the function itself in place as
+/// the `execute` system.
+///
+/// Required keys:
+/// - `id`: the global operator id string
+/// - `label`: human-readable label
+///
+/// Optional keys:
+/// - `description`: long-form description (default `""`)
+/// - `modal`: `bool`, default `false`
+/// - `manual`: `bool`, default `false`. When `true`, no Fire observer
+///   is wired up; callers invoke the operator via
+///   `World::call_operator`.
+/// - `name`: override the generated struct name. Default is
+///   `PascalCase(fn_name) + "Op"`.
+///
+/// ```ignore
+/// use jackdaw_api::prelude::*;
+///
+/// #[operator(id = "sample.hello", label = "Hello")]
+/// fn hello() -> OperatorResult {
+///     info!("hello");
+///     OperatorResult::Finished
+/// }
+/// ```
+///
+/// Expands to a `HelloOp` struct with `InputAction` derived and an
+/// `impl Operator for HelloOp` whose `register_execute` registers the
+/// `hello` function as a Bevy system.
+#[proc_macro_attribute]
+pub fn operator(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(
+        attr with Punctuated::<MetaNameValue, Token![,]>::parse_terminated
+    );
+    let item_fn = parse_macro_input!(item as ItemFn);
+
+    let mut id: Option<LitStr> = None;
+    let mut label: Option<LitStr> = None;
+    let mut description: Option<LitStr> = None;
+    let mut modal: bool = false;
+    let mut manual: bool = false;
+    let mut name_override: Option<String> = None;
+
+    for arg in args {
+        let Some(key) = arg.path.get_ident().map(|i| i.to_string()) else {
+            continue;
+        };
+        match key.as_str() {
+            "id" => {
+                if let Some(s) = as_lit_str(&arg.value) {
+                    id = Some(s);
+                }
+            }
+            "label" => {
+                if let Some(s) = as_lit_str(&arg.value) {
+                    label = Some(s);
+                }
+            }
+            "description" => {
+                if let Some(s) = as_lit_str(&arg.value) {
+                    description = Some(s);
+                }
+            }
+            "modal" => {
+                if let Some(b) = as_lit_bool(&arg.value) {
+                    modal = b.value;
+                }
+            }
+            "manual" => {
+                if let Some(b) = as_lit_bool(&arg.value) {
+                    manual = b.value;
+                }
+            }
+            "name" => {
+                if let Some(s) = as_lit_str(&arg.value) {
+                    name_override = Some(s.value());
+                }
+            }
+            other => {
+                return syn::Error::new(
+                    arg.path.span(),
+                    format!("unknown `#[operator]` argument: `{other}`"),
+                )
+                .into_compile_error()
+                .into();
+            }
+        }
+    }
+
+    let Some(id) = id else {
+        return syn::Error::new(Span::call_site(), "`#[operator]` requires `id = \"...\"`")
+            .into_compile_error()
+            .into();
+    };
+    let Some(label) = label else {
+        return syn::Error::new(
+            Span::call_site(),
+            "`#[operator]` requires `label = \"...\"`",
+        )
+        .into_compile_error()
+        .into();
+    };
+    let description = description.unwrap_or_else(|| LitStr::new("", Span::call_site()));
+
+    let fn_name = &item_fn.sig.ident;
+    let struct_name = match name_override {
+        Some(n) => format_ident!("{}", n),
+        None => format_ident!("{}Op", to_pascal_case(&fn_name.to_string())),
+    };
+    let vis = &item_fn.vis;
+
+    let expanded = quote! {
+        #[derive(::core::default::Default, ::bevy_enhanced_input::prelude::InputAction)]
+        #[action_output(bool)]
+        #vis struct #struct_name;
+
+        impl ::jackdaw_api::Operator for #struct_name {
+            const ID: &'static str = #id;
+            const LABEL: &'static str = #label;
+            const DESCRIPTION: &'static str = #description;
+            const MODAL: bool = #modal;
+            const MANUAL: bool = #manual;
+
+            fn register_execute(
+                commands: &mut ::bevy::ecs::system::Commands,
+            ) -> ::bevy::ecs::system::SystemId<(), ::jackdaw_api::OperatorResult> {
+                commands.register_system(#fn_name)
+            }
+        }
+
+        #item_fn
+    };
+
+    expanded.into()
+}
+
+fn as_lit_str(expr: &Expr) -> Option<LitStr> {
+    if let Expr::Lit(ExprLit {
+        lit: Lit::Str(s), ..
+    }) = expr
+    {
+        Some(s.clone())
+    } else {
+        None
+    }
+}
+
+fn as_lit_bool(expr: &Expr) -> Option<LitBool> {
+    if let Expr::Lit(ExprLit {
+        lit: Lit::Bool(b), ..
+    }) = expr
+    {
+        Some(b.clone())
+    } else {
+        None
+    }
+}
+
+fn to_pascal_case(snake: &str) -> String {
+    let mut out = String::with_capacity(snake.len());
+    for part in snake.split('_') {
+        let mut chars = part.chars();
+        if let Some(c) = chars.next() {
+            out.extend(c.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}

--- a/crates/jackdaw_jsn/src/ast.rs
+++ b/crates/jackdaw_jsn/src/ast.rs
@@ -12,7 +12,7 @@ use crate::format::{JsnAssets, JsnEntity, JsnMetadata, JsnScene};
 ///
 /// Structurally parallel to the BSN branch's `SceneBsnAst`, enabling a
 /// mechanical swap when BSN ships upstream.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Clone, PartialEq)]
 pub struct SceneJsnAst {
     /// Entity nodes, indexed by position.
     pub nodes: Vec<JsnEntityNode>,
@@ -29,6 +29,7 @@ pub struct SceneJsnAst {
 /// Mirrors `JsnEntity` from the file format  -- `name` and `parent` are
 /// structural fields, everything else (Transform, Visibility, Brush, etc.)
 /// lives in `components` as `serde_json::Value`.
+#[derive(Clone, PartialEq)]
 pub struct JsnEntityNode {
     /// Parent index into `SceneJsnAst::nodes`.
     pub parent: Option<usize>,

--- a/crates/jackdaw_jsn/src/format.rs
+++ b/crates/jackdaw_jsn/src/format.rs
@@ -216,7 +216,7 @@ pub struct JsnMetadata {
 ///   }
 /// }
 /// ```
-#[derive(Serialize, Clone, Debug, Default)]
+#[derive(Serialize, Clone, Debug, Default, PartialEq)]
 pub struct JsnAssets(pub HashMap<String, HashMap<String, serde_json::Value>>);
 
 impl<'de> serde::Deserialize<'de> for JsnAssets {

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
@@ -48,21 +47,13 @@ fn build_hello_panel(world: &mut World, parent: Entity) {
 #[derive(Component, Default)]
 pub struct SampleContext;
 
-#[derive(Default, InputAction)]
-#[action_output(bool)]
-pub struct HelloOp;
-
-impl Operator for HelloOp {
-    const ID: &'static str = "sample.hello";
-    const LABEL: &'static str = "Hello";
-    const DESCRIPTION: &'static str = "Logs a hello message";
-
-    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
-        commands.register_system(hello_op_system)
-    }
-}
-
-fn hello_op_system() -> OperatorResult {
+#[operator(
+    id = "sample.hello",
+    label = "Hello",
+    description = "Logs a hello message",
+    name = "HelloOp"
+)]
+fn hello_op() -> OperatorResult {
     info!("Hello from the sample extension operator!");
     OperatorResult::Finished
 }

--- a/examples/viewable_camera_extension/Cargo.toml
+++ b/examples/viewable_camera_extension/Cargo.toml
@@ -10,4 +10,3 @@ path = "src/lib.rs"
 bevy.workspace = true
 bevy_enhanced_input.workspace = true
 jackdaw_api.workspace = true
-jackdaw_commands.workspace = true

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -1,17 +1,18 @@
 //! Viewable Camera extension.
 //!
 //! - **F6**: place a viewable camera at the editor camera position.
-//!   Undoable via a custom `EditorCommand`.
+//!   The dispatcher captures the scene diff automatically, so one
+//!   Ctrl+Z despawns the camera.
 //! - **F7**: toggle between the editor view and looking through the
-//!   viewable camera. Preview is view state, not scene data, and is
-//!   not recorded in the undo history.
+//!   viewable camera. Preview mutates Bevy resources and components
+//!   that aren't in the scene AST, so the dispatcher's diff is empty
+//!   and no history entry is pushed.
 
 use bevy::camera::RenderTarget;
 use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_commands::EditorCommand;
 
 pub struct ViewableCameraExtension;
 
@@ -105,12 +106,28 @@ fn place_viewable_camera(world: &mut World) -> OperatorResult {
         .and_then(|e| world.get::<Transform>(e).copied())
         .unwrap_or_default();
 
-    let mut cmd: Box<dyn EditorCommand> = Box::new(PlaceViewableCameraCommand {
-        spawned: None,
-        transform: spawn_transform,
-    });
-    cmd.execute(world);
-    world.resource_mut::<OperatorCommandBuffer>().record(cmd);
+    world.spawn((
+        Name::new("Viewable Camera"),
+        ViewableCamera,
+        Camera3d::default(),
+        Camera {
+            // Stays off until `enter_preview` hands over the viewport
+            // image target.
+            is_active: false,
+            order: -1,
+            ..default()
+        },
+        // `Camera`'s required components default `RenderTarget` to the
+        // primary window, which would render over the editor UI if
+        // `is_active` ever flipped true. Keep the camera inert until
+        // `enter_preview` swaps in the viewport image target.
+        RenderTarget::None {
+            size: UVec2::splat(1),
+        },
+        spawn_transform,
+        Visibility::default(),
+    ));
+
     OperatorResult::Finished
 }
 
@@ -245,55 +262,5 @@ fn restore_editor_camera(world: &mut World) {
 
     if let Some(mut c) = world.get_mut::<Camera>(editor_cam) {
         c.is_active = true;
-    }
-}
-
-/// Undoable placement of a viewable camera. Redo re-executes, which
-/// spawns a new entity id; the scene tree and inspector resolve by id
-/// each frame so that's fine.
-struct PlaceViewableCameraCommand {
-    spawned: Option<Entity>,
-    transform: Transform,
-}
-
-impl EditorCommand for PlaceViewableCameraCommand {
-    fn execute(&mut self, world: &mut World) {
-        let entity = world
-            .spawn((
-                Name::new("Viewable Camera"),
-                ViewableCamera,
-                Camera3d::default(),
-                Camera {
-                    // Stays off until `enter_preview` hands over the
-                    // viewport image target.
-                    is_active: false,
-                    order: -1,
-                    ..default()
-                },
-                // `Camera`'s required components default `RenderTarget`
-                // to the primary window, which would render over the
-                // editor UI if `is_active` ever flipped true. Keep the
-                // camera inert until `enter_preview` swaps in the
-                // viewport image target.
-                RenderTarget::None {
-                    size: UVec2::splat(1),
-                },
-                self.transform,
-                Visibility::default(),
-            ))
-            .id();
-        self.spawned = Some(entity);
-    }
-
-    fn undo(&mut self, world: &mut World) {
-        if let Some(entity) = self.spawned.take()
-            && let Ok(ec) = world.get_entity_mut(entity)
-        {
-            ec.despawn();
-        }
-    }
-
-    fn description(&self) -> &str {
-        "Place Viewable Camera"
     }
 }

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -9,7 +9,6 @@
 //!   and no history entry is pushed.
 
 use bevy::camera::RenderTarget;
-use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
@@ -84,21 +83,13 @@ struct CameraPreviewState {
 }
 
 /// Place a viewable camera at the editor camera's current position.
-/// Undoable.
-#[derive(Default, InputAction)]
-#[action_output(bool)]
-pub struct PlaceViewableCamera;
-
-impl Operator for PlaceViewableCamera {
-    const ID: &'static str = "viewable_camera.place";
-    const LABEL: &'static str = "Place Viewable Camera";
-    const DESCRIPTION: &'static str = "Place a camera at the viewport position";
-
-    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
-        commands.register_system(place_viewable_camera)
-    }
-}
-
+/// Undoable via the dispatcher's automatic snapshot-diff.
+#[operator(
+    id = "viewable_camera.place",
+    label = "Place Viewable Camera",
+    description = "Place a camera at the viewport position",
+    name = "PlaceViewableCamera"
+)]
 fn place_viewable_camera(world: &mut World) -> OperatorResult {
     // Match the editor camera's transform so "look through" feels
     // natural on the first toggle.
@@ -132,21 +123,15 @@ fn place_viewable_camera(world: &mut World) -> OperatorResult {
 }
 
 /// Toggle "look through the viewable camera" against the editor view.
-/// Preview is view state, not a scene edit, so it isn't undoable.
-#[derive(Default, InputAction)]
-#[action_output(bool)]
-pub struct ToggleCameraPreview;
-
-impl Operator for ToggleCameraPreview {
-    const ID: &'static str = "viewable_camera.toggle_preview";
-    const LABEL: &'static str = "Toggle Camera Preview";
-    const DESCRIPTION: &'static str = "Look through the selected viewable camera";
-
-    fn register_execute(commands: &mut Commands) -> SystemId<(), OperatorResult> {
-        commands.register_system(toggle_preview)
-    }
-}
-
+/// Preview only mutates Bevy resources and components that aren't in
+/// the scene AST, so the dispatcher's snapshot-diff is empty and no
+/// history entry is pushed.
+#[operator(
+    id = "viewable_camera.toggle_preview",
+    label = "Toggle Camera Preview",
+    description = "Look through the selected viewable camera",
+    name = "ToggleCameraPreview"
+)]
 fn toggle_preview(world: &mut World) -> OperatorResult {
     let currently_active = world.resource::<CameraPreviewState>().active;
     if currently_active.is_some() {

--- a/src/extension_loader.rs
+++ b/src/extension_loader.rs
@@ -12,14 +12,16 @@
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::EnhancedInputPlugin;
 use jackdaw_api::{
-    ActiveModalOperator, ExtensionCatalog, OperatorCommandBuffer, OperatorIndex,
+    ActiveModalOperator, ActiveSnapshotter, ExtensionCatalog, OperatorIndex,
     PanelExtensionRegistry,
     lifecycle::{
-        cleanup_panel_extension_on_remove, cleanup_window_on_remove, cleanup_workspace_on_remove,
-        deindex_and_cleanup_operator_on_remove, index_operator_on_add,
+        OperatorSession, cleanup_panel_extension_on_remove, cleanup_window_on_remove,
+        cleanup_workspace_on_remove, deindex_and_cleanup_operator_on_remove, index_operator_on_add,
     },
     tick_modal_operator,
 };
+
+use crate::undo_snapshot::JsnAstSnapshotter;
 
 pub struct ExtensionLoaderPlugin;
 
@@ -27,10 +29,11 @@ impl Plugin for ExtensionLoaderPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(EnhancedInputPlugin)
             .init_resource::<ExtensionCatalog>()
-            .init_resource::<OperatorCommandBuffer>()
             .init_resource::<OperatorIndex>()
+            .init_resource::<OperatorSession>()
             .init_resource::<PanelExtensionRegistry>()
             .init_resource::<ActiveModalOperator>()
+            .insert_resource(ActiveSnapshotter(Box::new(JsnAstSnapshotter)))
             .add_observer(index_operator_on_add)
             .add_observer(deindex_and_cleanup_operator_on_remove)
             .add_observer(cleanup_window_on_remove)

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1014,7 +1014,8 @@ fn on_context_menu_action(
             // invoked them.
             let operator_id = action.strip_prefix("op:").unwrap().to_string();
             commands.queue(move |world: &mut World| {
-                jackdaw_api::lifecycle::dispatch_operator_by_id(world, &operator_id, true);
+                use jackdaw_api::OperatorWorldExt;
+                let _ = world.call_operator(operator_id);
             });
         }
         _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod snapping;
 pub mod status_bar;
 pub mod terrain;
 pub mod texture_browser;
+pub mod undo_snapshot;
 pub mod view_modes;
 pub mod viewport;
 pub mod viewport_overlays;
@@ -2086,7 +2087,8 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
             // keybind-triggered operators.
             let operator_id = action.strip_prefix("op:").unwrap().to_string();
             commands.queue(move |world: &mut World| {
-                jackdaw_api::lifecycle::dispatch_operator_by_id(world, &operator_id, true);
+                use jackdaw_api::OperatorWorldExt;
+                let _ = world.call_operator(operator_id);
             });
         }
         action if action.starts_with("window.") => {

--- a/src/scene_io.rs
+++ b/src/scene_io.rs
@@ -1631,34 +1631,38 @@ fn collect_editor_entities(world: &mut World) -> HashSet<Entity> {
 
 /// Remove scene entities from the world (named non-editor entities + their descendants).
 pub(crate) fn clear_scene_entities(world: &mut World) {
-    // Clear the AST
     world.resource_mut::<jackdaw_jsn::SceneJsnAst>().clear();
 
-    // Clear selection first to prevent on_entity_deselected observer from
-    // firing on stale/despawned tree row entities.
     world
         .resource_mut::<crate::selection::Selection>()
         .entities
         .clear();
 
-    // Clear hierarchy tree rows and TreeIndex before despawning scene entities.
     crate::hierarchy::clear_all_tree_rows(world);
 
-    // Clear undo/redo stacks  -- they hold entity references that become stale.
+    // Clear undo/redo stacks; they hold entity references that become
+    // stale when the scene is dropped. Callers who want to preserve
+    // history (e.g. undo/redo itself) use `despawn_scene_entities`
+    // directly.
     let mut history = world.resource_mut::<jackdaw_commands::CommandHistory>();
     history.undo_stack.clear();
     history.redo_stack.clear();
 
+    despawn_scene_entities(world);
+}
+
+/// Despawn every non-editor scene entity, leaving editor infrastructure
+/// (cameras, grids, gizmos) and the undo/redo stacks intact. Used by
+/// snapshot apply during undo/redo.
+pub(crate) fn despawn_scene_entities(world: &mut World) {
     let editor_set = collect_editor_entities(world);
 
-    // Collect named non-editor entities as roots
     let roots: Vec<Entity> = world
         .query_filtered::<Entity, With<Name>>()
         .iter(world)
         .filter(|e| !editor_set.contains(e))
         .collect();
 
-    // Expand to include all descendants
     let mut scene_set = HashSet::new();
     let mut stack = roots;
     while let Some(entity) = stack.pop() {
@@ -1675,6 +1679,37 @@ pub(crate) fn clear_scene_entities(world: &mut World) {
             entity_mut.despawn();
         }
     }
+}
+
+/// Replace the current world's scene with the one encoded in `ast`.
+///
+/// Despawns existing scene entities (without touching undo/redo
+/// history), serialises the AST back to a `JsnScene`, and runs it
+/// through the regular load path so the snapshot apply doesn't have
+/// its own parallel spawn logic to maintain.
+pub fn apply_ast_to_world(world: &mut World, ast: &jackdaw_jsn::SceneJsnAst) {
+    use jackdaw_jsn::format::JsnMetadata;
+
+    // Clear selection + tree rows before touching entities so observers
+    // don't fire on stale references.
+    world
+        .resource_mut::<crate::selection::Selection>()
+        .entities
+        .clear();
+    crate::hierarchy::clear_all_tree_rows(world);
+
+    despawn_scene_entities(world);
+
+    let scene = ast.to_jsn_scene(JsnMetadata::default());
+    let parent_path = world
+        .get_resource::<crate::project::ProjectRoot>()
+        .map(|p| p.root.clone())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let local_assets = load_inline_assets(world, &scene.assets, &parent_path);
+    let spawned = load_scene_from_jsn(world, &scene.scene, &parent_path, &local_assets);
+
+    *world.resource_mut::<jackdaw_jsn::SceneJsnAst>() =
+        jackdaw_jsn::SceneJsnAst::from_jsn_scene(&scene, &spawned);
 }
 
 /// ISO 8601 timestamp (simplified  -- no chrono dependency).

--- a/src/undo_snapshot.rs
+++ b/src/undo_snapshot.rs
@@ -1,0 +1,46 @@
+//! `SceneJsnAst`-backed implementation of the snapshotter traits.
+//!
+//! Swapped out for a BSN-backed implementation on BSN migration day.
+
+use std::any::Any;
+
+use bevy::prelude::*;
+use jackdaw_api::snapshot::{SceneSnapshot, SceneSnapshotter};
+use jackdaw_jsn::SceneJsnAst;
+
+pub struct JsnAstSnapshotter;
+
+impl SceneSnapshotter for JsnAstSnapshotter {
+    fn capture(&self, world: &World) -> Box<dyn SceneSnapshot> {
+        Box::new(JsnAstSnapshot {
+            ast: world.resource::<SceneJsnAst>().clone(),
+        })
+    }
+}
+
+pub struct JsnAstSnapshot {
+    ast: SceneJsnAst,
+}
+
+impl SceneSnapshot for JsnAstSnapshot {
+    fn apply(&self, world: &mut World) {
+        crate::scene_io::apply_ast_to_world(world, &self.ast);
+    }
+
+    fn equals(&self, other: &dyn SceneSnapshot) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|o| self.ast == o.ast)
+    }
+
+    fn clone_box(&self) -> Box<dyn SceneSnapshot> {
+        Box::new(Self {
+            ast: self.ast.clone(),
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}


### PR DESCRIPTION
## Summary

- Dispatcher snapshots `SceneJsnAst` before every operator invoke and diffs after; a single `SnapshotDiff` lands on history per call. No more `OperatorCommandBuffer`; operators are plain Bevy systems that just mutate the world.
- Inner `world.call_operator(...)` calls inside an outer operator are subsumed into the outer's diff — composition gives one undo entry covering everything.
- `OperatorWorldExt` trait on `World` (`call_operator`, `call_operator_with`, `is_operator_available`) replaces the free `dispatch_operator_by_id` function.
- `#[operator]` attribute macro collapses the struct + `InputAction` derive + `Operator` impl boilerplate into one line on the function.
- Snapshotting sits behind `SceneSnapshot` / `SceneSnapshotter` traits, so the BSN migration is a one-line `insert_resource` swap.
- Trigger simplification: `Trigger::{Start, Fire, Complete}` removed. Authors shape timing with BEI binding modifiers; `MANUAL: bool` replaces the old enum for the "no observer wired up" case.

## Example

```rust
use bevy::prelude::*;
use jackdaw_api::prelude::*;

#[operator(id = "sample.enable_physics", label = "Enable Physics")]
fn enable_physics(world: &mut World) -> OperatorResult {
    let target = world
        .resource::<Selection>()
        .primary()
        .expect("no selection");
    world.entity_mut(target).insert((
        RigidBody::Dynamic,
        Collider::cuboid(1.0, 1.0, 1.0),
    ));
    OperatorResult::Finished
}
```

Ctrl+Z reverses both component inserts in one step. No `EditorCommand`, no buffer, no manual `record(...)`.

**Composite operator** — inner calls roll up into the outer's single undo entry:

```rust
#[operator(id = "sample.place_physics_cube", label = "Place Physics Cube")]
fn place_physics_cube(world: &mut World) -> OperatorResult {
    let _ = world.call_operator("sample.place_cube");
    let _ = world.call_operator("sample.enable_physics");
    OperatorResult::Finished
}
```

**Dispatching from UI**:

```rust
fn my_button(mut commands: Commands) {
    commands.queue(|world: &mut World| {
        let _ = world.call_operator("avian.add_rigid_body");
    });
}
```

**Non-undoable effect** (view state like preview toggles):

```rust
let _ = world.call_operator_with(
    "viewable_camera.toggle_preview",
    &CallOperatorSettings { creates_history_entry: false },
);
```