### PR TITLE
Use `ColResize` and `RowResize` cursors for resizing split panels

### DIFF
--- a/crates/jackdaw_panels/src/split.rs
+++ b/crates/jackdaw_panels/src/split.rs
@@ -150,23 +150,18 @@ fn recalculate_group(
 fn on_handle_added(
     trigger: On<Add, PanelHandle>,
     handles: Query<&ChildOf, With<PanelHandle>>,
-    nodes: Query<(&Children, &Node)>,
+    nodes: Query<&Node>,
     mut commands: Commands,
 ) {
     let Ok(&ChildOf(parent)) = handles.get(trigger.entity) else {
         return;
     };
 
-    let Ok((children, node)) = nodes.get(parent) else {
+    let Ok(node) = nodes.get(parent) else {
         return;
     };
 
-    let index = children
-        .iter()
-        .position(|e| e == trigger.entity)
-        .unwrap_or(0);
-
-    let cursor_icon = get_drag_icon(node.flex_direction, index, children.len());
+    let cursor_icon = get_drag_icon(node.flex_direction);
 
     commands
         .entity(trigger.entity)
@@ -176,23 +171,18 @@ fn on_handle_added(
 fn on_handle_drag_start(
     trigger: On<Pointer<DragStart>>,
     handles: Query<&ChildOf, With<PanelHandle>>,
-    nodes: Query<(&Children, &Node)>,
+    nodes: Query<&Node>,
     mut override_cursor: ResMut<OverrideCursor>,
 ) {
     let Ok(&ChildOf(parent)) = handles.get(trigger.event_target()) else {
         return;
     };
 
-    let Ok((children, node)) = nodes.get(parent) else {
+    let Ok(node) = nodes.get(parent) else {
         return;
     };
 
-    let index = children
-        .iter()
-        .position(|e| e == trigger.entity)
-        .unwrap_or(0);
-
-    let cursor_icon = get_drag_icon(node.flex_direction, index, children.len());
+    let cursor_icon = get_drag_icon(node.flex_direction);
 
     if override_cursor.is_none() {
         override_cursor.0 = Some(EntityCursor::System(cursor_icon));
@@ -202,23 +192,18 @@ fn on_handle_drag_start(
 fn on_handle_drag_end(
     trigger: On<Pointer<DragEnd>>,
     handles: Query<&ChildOf, With<PanelHandle>>,
-    nodes: Query<(&Children, &Node)>,
+    nodes: Query<&Node>,
     mut override_cursor: ResMut<OverrideCursor>,
 ) {
     let Ok(&ChildOf(parent)) = handles.get(trigger.event_target()) else {
         return;
     };
 
-    let Ok((children, node)) = nodes.get(parent) else {
+    let Ok(node) = nodes.get(parent) else {
         return;
     };
 
-    let index = children
-        .iter()
-        .position(|e| e == trigger.entity)
-        .unwrap_or(0);
-
-    let cursor_icon = get_drag_icon(node.flex_direction, index, children.len());
+    let cursor_icon = get_drag_icon(node.flex_direction);
 
     if override_cursor.0 == Some(EntityCursor::System(cursor_icon)) {
         override_cursor.0 = None;
@@ -304,16 +289,9 @@ fn set_background_on_with<E: EntityEvent, F: QueryFilter>(
     }
 }
 
-fn get_drag_icon(direction: FlexDirection, index: usize, count: usize) -> SystemCursorIcon {
-    let is_right_half = index > count / 2;
-    match (direction, is_right_half) {
-        (FlexDirection::Row, false) => SystemCursorIcon::EResize,
-        (FlexDirection::Row, true) => SystemCursorIcon::WResize,
-        (FlexDirection::RowReverse, false) => SystemCursorIcon::WResize,
-        (FlexDirection::RowReverse, true) => SystemCursorIcon::EResize,
-        (FlexDirection::Column, false) => SystemCursorIcon::NResize,
-        (FlexDirection::Column, true) => SystemCursorIcon::SResize,
-        (FlexDirection::ColumnReverse, false) => SystemCursorIcon::SResize,
-        (FlexDirection::ColumnReverse, true) => SystemCursorIcon::NResize,
+fn get_drag_icon(direction: FlexDirection) -> SystemCursorIcon {
+    match direction {
+        FlexDirection::Row | FlexDirection::RowReverse => SystemCursorIcon::ColResize,
+        FlexDirection::Column | FlexDirection::ColumnReverse => SystemCursorIcon::RowResize,
     }
 }


### PR DESCRIPTION
Use `ColResize` and `RowResize` cursors instead of the directional ones for resizing split panels

Didn't notice they existed in #7 haha, they look the same on my DE, but might look weird when they are different