### PR TITLE
Add headless execution tests

### DIFF
--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -82,8 +82,8 @@ pub use snapshot::{ActiveSnapshotter, SceneSnapshot, SceneSnapshotter};
 /// Re-exports plugin authors will want in one import.
 pub mod prelude {
     pub use crate::lifecycle::{
-        CallOperatorError, CallOperatorSettings, Extension, ExtensionCatalog, ExtensionKind,
-        OperatorEntity, OperatorIndex, OperatorWorldExt,
+        CallOperatorError, CallOperatorSettings, Extension, ExtensionAppExt, ExtensionCatalog,
+        ExtensionKind, OperatorEntity, OperatorIndex, OperatorWorldExt,
     };
     pub use crate::operator::{Operator, OperatorResult};
     pub use crate::{

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -274,7 +274,8 @@ impl ExtensionAppExt for App {
     fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self {
         let ext = T::default();
         let name = ext.name();
-        // TODO: remove `name` duplication, just don't pass `name` to it and make it not take `self`
+        // TODO: remove `name` duplication
+        // can we do `fn name() -> String` without `&self` plz?
         register_extension(self, name, || Box::new(T::default()));
         self
     }

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -262,6 +262,33 @@ where
         .register(name, kind, ctor);
 }
 
+pub trait ExtensionAppExt {
+    fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self;
+    fn register_extension_with<T: crate::JackdawExtension + Default>(
+        &mut self,
+        ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
+    ) -> &mut Self;
+}
+
+impl ExtensionAppExt for App {
+    fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self {
+        let ext = T::default();
+        let name = ext.name();
+        // TODO: remove `name` duplication, just don't pass `name` to it and make it not take `self`
+        register_extension(self, name, || Box::new(T::default()));
+        self
+    }
+    fn register_extension_with<T: crate::JackdawExtension + Default>(
+        &mut self,
+        ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
+    ) -> &mut Self {
+        let ext = ctor();
+        let name = ext.name();
+        register_extension(self, name, ctor);
+        self
+    }
+}
+
 /// Extension trait on [`World`] for calling operators by id.
 ///
 /// Usage:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! Main crate for the Jackdaw editor.
+//! Usage of this crate is meant for headless operation. If you want to interact with the jackdaw API for extensions, use the `jackdaw_api` crate instead.
 pub mod add_entity_picker;
 pub mod alignment_guides;
 pub mod asset_browser;
@@ -57,6 +59,11 @@ use jackdaw_feathers::EditorFeathersPlugin;
 use jackdaw_feathers::dialog::EditorDialog;
 use jackdaw_widgets::menu_bar::MenuAction;
 use selection::Selection;
+
+/// Everything needed to start using Jackdaw.
+pub mod prelude {
+    pub use crate::EditorPlugin;
+}
 
 /// System set for all editor interaction systems (input handling, viewport clicks,
 /// gizmo drags, etc.). Automatically disabled when any dialog is open.

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -67,22 +67,12 @@ fn can_call_operator() {
         .count();
     // TODO: why is this panel not spawned?
     assert_eq!(amount_of_panels, 0);
-    let amount_of_markers = app
-        .world_mut()
-        .query_filtered::<(), With<Marker>>()
-        .iter(app.world())
-        .count();
-    assert_eq!(amount_of_markers, 0);
+    assert!(!app.world_mut().contains_resource::<Marker>());
 
     let result = app.world_mut().call_operator(SampleExtension::OP).unwrap();
     assert_eq!(result, OperatorResult::Finished);
 
-    let amount_of_markers = app
-        .world_mut()
-        .query_filtered::<(), With<Marker>>()
-        .iter(app.world())
-        .count();
-    assert_eq!(amount_of_markers, 1);
+    assert!(app.world_mut().contains_resource::<Marker>());
 }
 
 #[derive(Default)]
@@ -123,11 +113,11 @@ pub struct SampleContext;
     name = "SpawnMarkerOp"
 )]
 fn spawn_marker(mut commands: Commands) -> OperatorResult {
-    commands.spawn(Marker);
+    commands.init_resource::<Marker>();
     OperatorResult::Finished
 }
 
-#[derive(Component)]
+#[derive(Resource, Default)]
 struct Marker;
 
 #[derive(Component)]

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -43,10 +43,29 @@ fn can_run_extension() {
     let mut app = headless_app();
     app.register_extension::<SampleExtension>();
     app.finish();
+    // first update sets the extension up
+    // todo: maybe do this in `Startup`?
+    app.update();
+    for _ in 0..10 {
+        let result = app.world_mut().call_operator(SampleExtension::OP).unwrap();
+        assert_eq!(result, OperatorResult::Finished);
+        app.update();
+    }
+}
+
+#[test]
+fn can_call_operator() {
+    let mut app = headless_app();
+    app.register_extension::<SampleExtension>();
+    app.finish();
 }
 
 #[derive(Default)]
 pub struct SampleExtension;
+
+impl SampleExtension {
+    const OP: &'static str = "sample.hello";
+}
 
 impl JackdawExtension for SampleExtension {
     fn name(&self) -> &str {
@@ -59,7 +78,7 @@ impl JackdawExtension for SampleExtension {
 
     fn register(&self, ctx: &mut ExtensionContext) {
         ctx.register_window(WindowDescriptor {
-            id: "sample.hello".into(),
+            id: Self::OP.into(),
             name: "Hello Extension".into(),
             icon: None,
             default_area: None,
@@ -88,6 +107,7 @@ fn build_hello_panel(world: &mut World, parent: Entity) {
 pub struct SampleContext;
 
 #[operator(
+    // TODO: replace with `SampleExtension::OP`
     id = "sample.hello",
     label = "Hello",
     description = "Logs a hello message",

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -44,7 +44,7 @@ fn can_run_extension() {
     app.register_extension::<SampleExtension>();
     app.finish();
     // first update sets the extension up
-    // todo: maybe do this in `Startup`?
+    // todo: maybe do plugin setup in `Startup` so that jackdaw is actually ready in the first frame?
     app.update();
     for _ in 0..10 {
         let result = app.world_mut().call_operator(SampleExtension::OP).unwrap();
@@ -65,7 +65,7 @@ fn can_call_operator() {
         .query_filtered::<(), With<Panel>>()
         .iter(app.world())
         .count();
-    // TODO: why is this panel not spawned?
+    // TODO: why is this panel not spawned? What do I need to do in order to make it spawn?
     assert_eq!(amount_of_panels, 0);
     assert!(!app.world_mut().contains_resource::<Marker>());
 
@@ -106,9 +106,11 @@ fn build_panel(world: &mut World, parent: Entity) {
 pub struct SampleContext;
 
 #[operator(
-    // TODO: replace with `SampleExtension::OP`
+    // TODO: replace with `SampleExtension::OP`. The current `operator` macro requires a string here, but an expression would be better
+    // see #[require(...)]
     id = "sample.spawn",
     label = "Spawn Marker",
+    // TODO: This bit here feels clunky. Could we use `heck` to generate the name in PascalCase for us?
     name = "SpawnMarkerOp"
 )]
 fn spawn_marker(mut commands: Commands) -> OperatorResult {

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bevy::{
     prelude::*,
     render::{
@@ -7,9 +9,9 @@ use bevy::{
     winit::WinitPlugin,
 };
 use jackdaw::prelude::*;
+use jackdaw_api::prelude::*;
 
-#[test]
-fn smoke_test_headless_update() {
+fn headless_app() -> App {
     let mut app = App::new();
     app.add_plugins(
         DefaultPlugins
@@ -22,10 +24,97 @@ fn smoke_test_headless_update() {
             })
             .disable::<WinitPlugin>(),
     )
-    .add_plugins(EditorPlugin)
-    .finish();
+    .add_plugins(EditorPlugin);
+    app
+}
+
+#[test]
+fn smoke_test_headless_update() {
+    let mut app = headless_app();
+    app.finish();
 
     for _ in 0..10 {
         app.update();
     }
+}
+
+#[test]
+fn can_run_extension() {
+    let mut app = headless_app();
+    jackdaw_api::register_extension(&mut app, "sample_extension", || Box::new(SampleExtension));
+    app.finish();
+}
+
+pub struct SampleExtension;
+
+impl JackdawExtension for SampleExtension {
+    fn name(&self) -> &str {
+        "sample"
+    }
+
+    fn register_input_contexts(&self, app: &mut App) {
+        app.add_input_context::<SampleContext>();
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(WindowDescriptor {
+            id: "sample.hello".into(),
+            name: "Hello Extension".into(),
+            icon: None,
+            default_area: None,
+            priority: None,
+            build: Arc::new(build_hello_panel),
+        });
+
+        ctx.register_operator::<HelloOp>();
+        ctx.register_operator::<HelloTimeOp>();
+
+        ctx.spawn((
+            SampleContext,
+            actions!(SampleContext[
+                (Action::<HelloOp>::new(), bindings![KeyCode::F9]),
+                (Action::<HelloTimeOp>::new(), bindings![KeyCode::F10]),
+            ]),
+        ));
+    }
+}
+
+fn build_hello_panel(world: &mut World, parent: Entity) {
+    world.spawn((ChildOf(parent), Text::new("Hello from an extension!")));
+}
+
+#[derive(Component, Default)]
+pub struct SampleContext;
+
+#[operator(
+    id = "sample.hello",
+    label = "Hello",
+    description = "Logs a hello message",
+    name = "HelloOp"
+)]
+fn hello_op() -> OperatorResult {
+    info!("Hello from the sample extension operator!");
+    OperatorResult::Finished
+}
+
+/// Availability check for [`HelloTimeOp`]. Bevy systems returning
+/// `bool` can inject any `SystemParam`; here we read `Time` and only
+/// allow the operator to run while the clock is advancing.
+fn time_is_running(time: Res<Time>) -> bool {
+    time.delta_secs() > 0.0
+}
+
+#[operator(
+    id = "sample.hello_time",
+    label = "Hello (Time)",
+    description = "Logs a hello message, but only while time is advancing",
+    is_available = time_is_running,
+    name = "HelloTimeOp"
+)]
+fn hello_time_op(time: Res<Time>) -> OperatorResult {
+    info!(
+        "Hello at frame delta {:.3}s from the sample extension",
+        time.delta_secs()
+    );
+    OperatorResult::Finished
 }

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -58,13 +58,38 @@ fn can_call_operator() {
     let mut app = headless_app();
     app.register_extension::<SampleExtension>();
     app.finish();
+    app.update();
+
+    let amount_of_panels = app
+        .world_mut()
+        .query_filtered::<(), With<Panel>>()
+        .iter(app.world())
+        .count();
+    // TODO: why is this panel not spawned?
+    assert_eq!(amount_of_panels, 0);
+    let amount_of_markers = app
+        .world_mut()
+        .query_filtered::<(), With<Marker>>()
+        .iter(app.world())
+        .count();
+    assert_eq!(amount_of_markers, 0);
+
+    let result = app.world_mut().call_operator(SampleExtension::OP).unwrap();
+    assert_eq!(result, OperatorResult::Finished);
+
+    let amount_of_markers = app
+        .world_mut()
+        .query_filtered::<(), With<Marker>>()
+        .iter(app.world())
+        .count();
+    assert_eq!(amount_of_markers, 1);
 }
 
 #[derive(Default)]
 pub struct SampleExtension;
 
 impl SampleExtension {
-    const OP: &'static str = "sample.hello";
+    const OP: &'static str = "sample.spawn";
 }
 
 impl JackdawExtension for SampleExtension {
@@ -72,35 +97,20 @@ impl JackdawExtension for SampleExtension {
         "sample"
     }
 
-    fn register_input_contexts(&self, app: &mut App) {
-        app.add_input_context::<SampleContext>();
-    }
-
     fn register(&self, ctx: &mut ExtensionContext) {
         ctx.register_window(WindowDescriptor {
             id: Self::OP.into(),
             name: "Hello Extension".into(),
-            icon: None,
-            default_area: None,
-            priority: None,
-            build: Arc::new(build_hello_panel),
+            build: Arc::new(build_panel),
+            default_area: Some("left".into()),
+            ..default()
         });
-
-        ctx.register_operator::<HelloOp>();
-        ctx.register_operator::<HelloTimeOp>();
-
-        ctx.spawn((
-            SampleContext,
-            actions!(SampleContext[
-                (Action::<HelloOp>::new(), bindings![KeyCode::F9]),
-                (Action::<HelloTimeOp>::new(), bindings![KeyCode::F10]),
-            ]),
-        ));
+        ctx.register_operator::<SpawnMarkerOp>();
     }
 }
 
-fn build_hello_panel(world: &mut World, parent: Entity) {
-    world.spawn((ChildOf(parent), Text::new("Hello from an extension!")));
+fn build_panel(world: &mut World, parent: Entity) {
+    world.spawn((ChildOf(parent), Panel, Text::new("Some panel")));
 }
 
 #[derive(Component, Default)]
@@ -108,34 +118,17 @@ pub struct SampleContext;
 
 #[operator(
     // TODO: replace with `SampleExtension::OP`
-    id = "sample.hello",
-    label = "Hello",
-    description = "Logs a hello message",
-    name = "HelloOp"
+    id = "sample.spawn",
+    label = "Spawn Marker",
+    name = "SpawnMarkerOp"
 )]
-fn hello_op() -> OperatorResult {
-    info!("Hello from the sample extension operator!");
+fn spawn_marker(mut commands: Commands) -> OperatorResult {
+    commands.spawn(Marker);
     OperatorResult::Finished
 }
 
-/// Availability check for [`HelloTimeOp`]. Bevy systems returning
-/// `bool` can inject any `SystemParam`; here we read `Time` and only
-/// allow the operator to run while the clock is advancing.
-fn time_is_running(time: Res<Time>) -> bool {
-    time.delta_secs() > 0.0
-}
+#[derive(Component)]
+struct Marker;
 
-#[operator(
-    id = "sample.hello_time",
-    label = "Hello (Time)",
-    description = "Logs a hello message, but only while time is advancing",
-    is_available = time_is_running,
-    name = "HelloTimeOp"
-)]
-fn hello_time_op(time: Res<Time>) -> OperatorResult {
-    info!(
-        "Hello at frame delta {:.3}s from the sample extension",
-        time.delta_secs()
-    );
-    OperatorResult::Finished
-}
+#[derive(Component)]
+struct Panel;

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -90,7 +90,6 @@ impl JackdawExtension for SampleExtension {
     fn register(&self, ctx: &mut ExtensionContext) {
         ctx.register_window(WindowDescriptor {
             id: Self::OP.into(),
-            name: "Hello Extension".into(),
             build: Arc::new(build_panel),
             default_area: Some("left".into()),
             ..default()

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -4,10 +4,8 @@ use bevy::{
         RenderPlugin,
         settings::{RenderCreation, WgpuSettings},
     },
-    state::app::StatesPlugin,
     winit::WinitPlugin,
 };
-use bevy_enhanced_input::prelude::*;
 use jackdaw::prelude::*;
 
 #[test]

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -1,0 +1,33 @@
+use bevy::{
+    prelude::*,
+    render::{
+        RenderPlugin,
+        settings::{RenderCreation, WgpuSettings},
+    },
+    state::app::StatesPlugin,
+    winit::WinitPlugin,
+};
+use bevy_enhanced_input::prelude::*;
+use jackdaw::prelude::*;
+
+#[test]
+fn smoke_test_headless_update() {
+    let mut app = App::new();
+    app.add_plugins(
+        DefaultPlugins
+            .set(RenderPlugin {
+                render_creation: RenderCreation::Automatic(WgpuSettings {
+                    backends: None,
+                    ..default()
+                }),
+                ..default()
+            })
+            .disable::<WinitPlugin>(),
+    )
+    .add_plugins(EditorPlugin)
+    .finish();
+
+    for _ in 0..10 {
+        app.update();
+    }
+}

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -41,10 +41,11 @@ fn smoke_test_headless_update() {
 #[test]
 fn can_run_extension() {
     let mut app = headless_app();
-    jackdaw_api::register_extension(&mut app, "sample_extension", || Box::new(SampleExtension));
+    app.register_extension::<SampleExtension>();
     app.finish();
 }
 
+#[derive(Default)]
 pub struct SampleExtension;
 
 impl JackdawExtension for SampleExtension {


### PR DESCRIPTION
Future steps would involve shipping `jackdaw` without requiring the renderer at all by using @atlv24's work on the `_api` crates. This here is just the bare minimum needed to verify that we support headless execution for automated testing.