### PR TITLE
Extension refactor

### DIFF
--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -125,7 +125,8 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
     ///
     /// Defaults to no-op; override only if the extension adds BEI
     /// contexts.
-    fn register_input_contexts(&self, _app: &mut App) {}
+    #[expect(unused_variables, reason = "The default implementation does nothing")]
+    fn register_input_contexts(&self, app: &mut App) {}
 
     /// Main registration logic. Called each time the extension is
     /// enabled. Spawn operators, windows, BEI action entities, and any
@@ -137,7 +138,8 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
     /// Child-entity cleanup handles registered windows, operators, BEI
     /// contexts, and observers automatically. Override only for non-ECS
     /// state (file handles, network sessions, and the like).
-    fn unregister(&self, _world: &mut World, _extension_entity: Entity) {}
+    #[expect(unused_variables, reason = "The default implementation does nothing")]
+    fn unregister(&self, world: &mut World, extension_entity: Entity) {}
 }
 
 /// Allows access to the extension's static methods via a dynamic dispatch.

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -99,6 +99,7 @@ pub mod prelude {
 /// Trait implemented by every extension. Declares the extension's name
 /// and registration logic; the framework handles everything else.
 pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
+    /// A human-readable name for this extension. This will be displayed in UIs.
     fn name() -> String
     where
         Self: Sized;

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -73,7 +73,7 @@ pub use lifecycle::{
     ActiveModalOperator, CallOperatorError, CallOperatorSettings, Extension, ExtensionCatalog,
     ExtensionCtor, ExtensionKind, OperatorEntity, OperatorIndex, OperatorSession, OperatorWorldExt,
     RegisteredMenuEntry, RegisteredPanelExtension, RegisteredWindow, RegisteredWorkspace,
-    disable_extension, enable_extension, register_extension, tick_modal_operator, unload_extension,
+    disable_extension, enable_extension, tick_modal_operator, unload_extension,
 };
 pub use operator::{Operator, OperatorResult};
 pub use registries::PanelExtensionRegistry;
@@ -98,15 +98,20 @@ pub mod prelude {
 
 /// Trait implemented by every extension. Declares the extension's name
 /// and registration logic; the framework handles everything else.
-pub trait JackdawExtension: Send + Sync + 'static {
-    fn name(&self) -> &str;
+pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
+    fn name() -> String
+    where
+        Self: Sized;
 
     /// Classify this extension. Defaults to [`ExtensionKind::Custom`].
     ///
     /// The Extensions dialog reads this to split the list into Built-in
     /// and Custom sections. Reserved as a future hook for marketplace
     /// categories.
-    fn kind(&self) -> ExtensionKind {
+    fn kind() -> ExtensionKind
+    where
+        Self: Sized,
+    {
         ExtensionKind::Custom
     }
 
@@ -132,6 +137,25 @@ pub trait JackdawExtension: Send + Sync + 'static {
     /// contexts, and observers automatically. Override only for non-ECS
     /// state (file handles, network sessions, and the like).
     fn unregister(&self, _world: &mut World, _extension_entity: Entity) {}
+}
+
+/// Allows access to the extension's static methods via a dynamic dispatch.
+/// This is needed for when you're holding a `Box<dyn JackdawExtension>` and need to call methods that wouldn't require `self`.
+pub trait DynJackdawExtension {
+    /// Returns [`JackdawExtension::name`] via dynamic dispatch.
+    fn dyn_name(&self) -> String;
+    /// Returns [`JackdawExtension::kind`] via dynamic dispatch.
+    fn dyn_kind(&self) -> ExtensionKind;
+}
+
+impl<T: JackdawExtension> DynJackdawExtension for T {
+    fn dyn_name(&self) -> String {
+        T::name()
+    }
+
+    fn dyn_kind(&self) -> ExtensionKind {
+        T::kind()
+    }
 }
 
 /// Passed to [`JackdawExtension::register`]. Holds the extension entity
@@ -379,7 +403,7 @@ pub type SectionBuildFn = Arc<dyn Fn(&mut World, PanelContext) + Send + Sync>;
 /// [`JackdawExtension::register_input_contexts`], which is called at
 /// catalog registration time with App access.
 pub fn load_static_extension(world: &mut World, extension: Box<dyn JackdawExtension>) -> Entity {
-    let name = extension.name().to_string();
+    let name = extension.dyn_name();
     info!("Loading extension: {}", name);
 
     let extension_entity = world.spawn(Extension { name }).id();

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -236,56 +236,37 @@ impl ExtensionCatalog {
     }
 }
 
-/// Register an extension into the catalog and perform its one-time BEI
-/// input-context registration.
-///
-/// Call this once per extension during app setup. Registering the constructor
-/// lets the Plugins dialog list the extension; running
-/// `register_input_contexts` ensures its BEI context types are known to the
-/// framework. Enabling and disabling the extension later only re-runs
-/// `register()`, never `register_input_contexts()` (BEI panics on duplicate
-/// registrations).
-pub fn register_extension<F>(app: &mut App, name: &str, ctor: F)
-where
-    F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
-{
-    // Construct a throwaway instance to (a) register context types and
-    // (b) read the extension's declared `kind`. Doing both against the
-    // same instance avoids a second construction just to classify.
-    let sample = ctor();
-    sample.register_input_contexts(app);
-    let kind = sample.kind();
-    drop(sample);
-
-    app.world_mut()
-        .resource_mut::<ExtensionCatalog>()
-        .register(name, kind, ctor);
-}
-
 pub trait ExtensionAppExt {
-    fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self;
-    fn register_extension_with<T: crate::JackdawExtension + Default>(
+    /// Register an extension into the catalog and perform its one-time BEI
+    /// input-context registration.
+    ///
+    /// Call this once per extension during app setup. Registering the constructor
+    /// lets the Plugins dialog list the extension; running
+    /// `register_input_contexts` ensures its BEI context types are known to the
+    /// framework. Enabling and disabling the extension later only re-runs
+    /// `register()`, never `register_input_contexts()` (BEI panics on duplicate
+    /// registrations).
+    ///
+    /// See also [`Self::register_extension_with`].
+    fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self {
+        self.register_extension_with::<T>(|| Box::new(T::default()))
+    }
+
+    /// Like [`Self::register_extension`], but with a custom constructor.
+    fn register_extension_with<T: crate::JackdawExtension>(
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self;
 }
 
 impl ExtensionAppExt for App {
-    fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self {
-        let ext = T::default();
-        let name = ext.name();
-        // TODO: remove `name` duplication
-        // can we do `fn name() -> String` without `&self` plz?
-        register_extension(self, name, || Box::new(T::default()));
-        self
-    }
-    fn register_extension_with<T: crate::JackdawExtension + Default>(
+    fn register_extension_with<T: crate::JackdawExtension>(
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self {
-        let ext = ctor();
-        let name = ext.name();
-        register_extension(self, name, ctor);
+        self.world_mut()
+            .resource_mut::<ExtensionCatalog>()
+            .register(T::name(), T::kind(), ctor);
         self
     }
 }

--- a/crates/jackdaw_api/src/lifecycle.rs
+++ b/crates/jackdaw_api/src/lifecycle.rs
@@ -188,7 +188,7 @@ pub enum ExtensionKind {
 
 impl ExtensionCatalog {
     /// Register a constructor with its declared kind. Most callers
-    /// should use [`register_extension`] instead, which handles BEI
+    /// should use [`App::register_extension`] instead, which handles BEI
     /// context registration.
     pub fn register<F>(&mut self, name: impl Into<String>, kind: ExtensionKind, ctor: F)
     where

--- a/crates/jackdaw_api_macros/src/lib.rs
+++ b/crates/jackdaw_api_macros/src/lib.rs
@@ -56,9 +56,9 @@ pub fn operator(attr: TokenStream, item: TokenStream) -> TokenStream {
     );
     let item_fn = parse_macro_input!(item as ItemFn);
 
-    let mut id: Option<LitStr> = None;
-    let mut label: Option<LitStr> = None;
-    let mut description: Option<LitStr> = None;
+    let mut id: Option<Expr> = None;
+    let mut label: Option<Expr> = None;
+    let mut description: Option<Expr> = None;
     let mut modal: bool = false;
     let mut manual: bool = false;
     let mut name_override: Option<String> = None;
@@ -70,17 +70,17 @@ pub fn operator(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         match key.as_str() {
             "id" => {
-                if let Some(s) = as_lit_str(&arg.value) {
+                if let Some(s) = as_str_expr(&arg.value) {
                     id = Some(s);
                 }
             }
             "label" => {
-                if let Some(s) = as_lit_str(&arg.value) {
+                if let Some(s) = as_str_expr(&arg.value) {
                     label = Some(s);
                 }
             }
             "description" => {
-                if let Some(s) = as_lit_str(&arg.value) {
+                if let Some(s) = as_str_expr(&arg.value) {
                     description = Some(s);
                 }
             }
@@ -127,15 +127,13 @@ pub fn operator(attr: TokenStream, item: TokenStream) -> TokenStream {
             .into_compile_error()
             .into();
     };
-    let Some(label) = label else {
-        return syn::Error::new(
-            Span::call_site(),
-            "`#[operator]` requires `label = \"...\"`",
-        )
-        .into_compile_error()
-        .into();
-    };
-    let description = description.unwrap_or_else(|| LitStr::new("", Span::call_site()));
+    let label = label.unwrap_or(id.clone());
+    let description = description.unwrap_or_else(|| {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(LitStr::new("", Span::call_site())),
+            attrs: vec![],
+        })
+    });
 
     let fn_name = &item_fn.sig.ident;
     let struct_name = match name_override {
@@ -189,6 +187,18 @@ fn as_lit_str(expr: &Expr) -> Option<LitStr> {
         Some(s.clone())
     } else {
         None
+    }
+}
+
+fn as_str_expr(expr: &Expr) -> Option<Expr> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(_), ..
+        }) => Some(expr.clone()),
+
+        Expr::Path(_) => Some(expr.clone()),
+
+        _ => None,
     }
 }
 

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -43,6 +43,7 @@ impl JackdawExtension for SampleExtension {
         ctx.spawn((
             SampleContext,
             actions!(SampleContext[
+                // the `hello` operator function generates a struct called `HelloOp`
                 (Action::<HelloOp>::new(), bindings![KeyCode::F9]),
                 (Action::<HelloTimeOp>::new(), bindings![KeyCode::F10]),
             ]),
@@ -60,10 +61,9 @@ pub struct SampleContext;
 #[operator(
     id = "sample.hello",
     label = "Hello",
-    description = "Logs a hello message",
-    name = "HelloOp"
+    description = "Logs a hello message"
 )]
-fn hello_op() -> OperatorResult {
+fn hello() -> OperatorResult {
     info!("Hello from the sample extension operator!");
     OperatorResult::Finished
 }
@@ -80,9 +80,8 @@ fn time_is_running(time: Res<Time>) -> bool {
     label = "Hello (Time)",
     description = "Logs a hello message, but only while time is advancing",
     is_available = time_is_running,
-    name = "HelloTimeOp"
 )]
-fn hello_time_op(time: Res<Time>) -> OperatorResult {
+fn hello_time(time: Res<Time>) -> OperatorResult {
     info!(
         "Hello at frame delta {:.3}s from the sample extension",
         time.delta_secs()

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -19,8 +19,8 @@ use jackdaw_api::prelude::*;
 pub struct SampleExtension;
 
 impl JackdawExtension for SampleExtension {
-    fn name(&self) -> &str {
-        "sample"
+    fn name() -> String {
+        "sample".to_string()
     }
 
     fn register_input_contexts(&self, app: &mut App) {

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -13,11 +13,12 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
+#[derive(Default)]
 pub struct ViewableCameraExtension;
 
 impl JackdawExtension for ViewableCameraExtension {
-    fn name(&self) -> &str {
-        "viewable_camera"
+    fn name() -> String {
+        "viewable_camera".to_string()
     }
 
     fn register_input_contexts(&self, app: &mut App) {

--- a/src/builtin_extensions.rs
+++ b/src/builtin_extensions.rs
@@ -10,14 +10,15 @@ use jackdaw_api::{ExtensionContext, ExtensionKind, JackdawExtension, WindowDescr
 use jackdaw_feathers::icons::Icon;
 
 /// Scene Tree, Import, and Project Files in the left dock.
+#[derive(Default)]
 pub struct CoreWindowsExtension;
 
 impl JackdawExtension for CoreWindowsExtension {
-    fn name(&self) -> &str {
-        "core_windows"
+    fn name() -> String {
+        "core_windows".to_string()
     }
 
-    fn kind(&self) -> ExtensionKind {
+    fn kind() -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -84,14 +85,15 @@ impl JackdawExtension for CoreWindowsExtension {
 }
 
 /// Assets window in the bottom dock.
+#[derive(Default)]
 pub struct AssetBrowserExtension;
 
 impl JackdawExtension for AssetBrowserExtension {
-    fn name(&self) -> &str {
-        "asset_browser"
+    fn name() -> String {
+        "asset_browser".to_string()
     }
 
-    fn kind(&self) -> ExtensionKind {
+    fn kind() -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -120,14 +122,15 @@ impl JackdawExtension for AssetBrowserExtension {
 }
 
 /// Animation timeline in the bottom dock.
+#[derive(Default)]
 pub struct TimelineExtension;
 
 impl JackdawExtension for TimelineExtension {
-    fn name(&self) -> &str {
-        "timeline"
+    fn name() -> String {
+        "timeline".to_string()
     }
 
-    fn kind(&self) -> ExtensionKind {
+    fn kind() -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -146,14 +149,15 @@ impl JackdawExtension for TimelineExtension {
 }
 
 /// Terminal placeholder in the bottom dock.
+#[derive(Default)]
 pub struct TerminalExtension;
 
 impl JackdawExtension for TerminalExtension {
-    fn name(&self) -> &str {
-        "terminal"
+    fn name() -> String {
+        "terminal".to_string()
     }
 
-    fn kind(&self) -> ExtensionKind {
+    fn kind() -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -189,14 +193,15 @@ impl JackdawExtension for TerminalExtension {
 }
 
 /// Right-sidebar stack: Components, Materials, Resources, Systems.
+#[derive(Default)]
 pub struct InspectorExtension;
 
 impl JackdawExtension for InspectorExtension {
-    fn name(&self) -> &str {
-        "inspector"
+    fn name() -> String {
+        "inspector".to_string()
     }
 
-    fn kind(&self) -> ExtensionKind {
+    fn kind() -> ExtensionKind {
         ExtensionKind::Builtin
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,14 @@ use bevy::{
     picking::hover::HoverMap,
     prelude::*,
 };
+use jackdaw_api::prelude::ExtensionAppExt;
 use jackdaw_feathers::EditorFeathersPlugin;
 use jackdaw_feathers::dialog::EditorDialog;
 use jackdaw_widgets::menu_bar::MenuAction;
 use selection::Selection;
+use viewable_camera_extension::ViewableCameraExtension;
+
+use crate::builtin_extensions::*;
 
 /// Everything needed to start using Jackdaw.
 pub mod prelude {
@@ -241,27 +245,12 @@ impl Plugin for EditorPlugin {
         // Runs during `build()` so BEI's `finish()` hook sees every
         // context type. Built-ins override `kind()` to `Builtin`; the
         // rest default to `Custom`.
-        jackdaw_api::register_extension(app, "core_windows", || {
-            Box::new(builtin_extensions::CoreWindowsExtension)
-        });
-        jackdaw_api::register_extension(app, "asset_browser", || {
-            Box::new(builtin_extensions::AssetBrowserExtension)
-        });
-        jackdaw_api::register_extension(app, "timeline", || {
-            Box::new(builtin_extensions::TimelineExtension)
-        });
-        jackdaw_api::register_extension(app, "terminal", || {
-            Box::new(builtin_extensions::TerminalExtension)
-        });
-        jackdaw_api::register_extension(app, "inspector", || {
-            Box::new(builtin_extensions::InspectorExtension)
-        });
-        jackdaw_api::register_extension(app, "sample", || {
-            Box::new(sample_extension::SampleExtension)
-        });
-        jackdaw_api::register_extension(app, "viewable_camera", || {
-            Box::new(viewable_camera_extension::ViewableCameraExtension)
-        });
+        app.register_extension::<CoreWindowsExtension>()
+            .register_extension::<AssetBrowserExtension>()
+            .register_extension::<TimelineExtension>()
+            .register_extension::<TerminalExtension>()
+            .register_extension::<InspectorExtension>()
+            .register_extension::<ViewableCameraExtension>();
 
         // Must run after every plugin's `finish()`: BEI initializes
         // `ContextInstances<PreUpdate>` there, and spawning a context

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -106,12 +106,7 @@ fn build_panel(world: &mut World, parent: Entity) {
 pub struct SampleContext;
 
 #[operator(
-    // TODO: replace with `SampleExtension::OP`. The current `operator` macro requires a string here, but an expression would be better
-    // see #[require(...)]
-    id = "sample.spawn",
-    label = "Spawn Marker",
-    // TODO: This bit here feels clunky. Could we use `heck` to generate the name in PascalCase for us?
-    name = "SpawnMarkerOp"
+    id = SampleExtension::OP,
 )]
 fn spawn_marker(mut commands: Commands) -> OperatorResult {
     commands.init_resource::<Marker>();

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -83,8 +83,8 @@ impl SampleExtension {
 }
 
 impl JackdawExtension for SampleExtension {
-    fn name(&self) -> &str {
-        "sample"
+    fn name() -> String {
+        "sample".to_string()
     }
 
     fn register(&self, ctx: &mut ExtensionContext) {


### PR DESCRIPTION
## Registration
Before:
```rust
        jackdaw_api::register_extension(app, "core_windows", || {
            Box::new(builtin_extensions::CoreWindowsExtension)
        });
        jackdaw_api::register_extension(app, "asset_browser", || {
            Box::new(builtin_extensions::AssetBrowserExtension)
        });
        jackdaw_api::register_extension(app, "timeline", || {
            Box::new(builtin_extensions::TimelineExtension)
        });
        jackdaw_api::register_extension(app, "terminal", || {
            Box::new(builtin_extensions::TerminalExtension)
        });
        jackdaw_api::register_extension(app, "inspector", || {
            Box::new(builtin_extensions::InspectorExtension)
        });
        jackdaw_api::register_extension(app, "sample", || {
            Box::new(sample_extension::SampleExtension)
        });
        jackdaw_api::register_extension(app, "viewable_camera", || {
            Box::new(viewable_camera_extension::ViewableCameraExtension)
        });
```
After:
```rust
        app.register_extension::<CoreWindowsExtension>()
            .register_extension::<AssetBrowserExtension>()
            .register_extension::<TimelineExtension>()
            .register_extension::<TerminalExtension>()
            .register_extension::<InspectorExtension>()
            .register_extension::<ViewableCameraExtension>();
```

## `#[operator]`
- allow omitting `label`
- allow using expressions for strings, notably allowing exposing a `const ID: &'static str = "some.operator"`
