### PR TITLE
Changed the keybind for disconnecting a node connection from alt-click to right click

### DIFF
--- a/crates/jackdaw_node_graph/src/connection.rs
+++ b/crates/jackdaw_node_graph/src/connection.rs
@@ -45,8 +45,8 @@ pub struct ConnectionView {
 pub struct GhostConnection;
 
 /// Marker added to every `Connection` data entity whose source or target
-/// terminal is currently being hovered with Right Click held down. The 
-/// connection renderer fades wires carrying this marker to signal they'll 
+/// terminal is currently being hovered with Right Click held down. The
+/// connection renderer fades wires carrying this marker to signal they'll
 /// be removed on click.
 #[derive(Component, Debug, Clone, Copy)]
 pub struct PendingRemove;

--- a/crates/jackdaw_node_graph/src/connection.rs
+++ b/crates/jackdaw_node_graph/src/connection.rs
@@ -45,9 +45,9 @@ pub struct ConnectionView {
 pub struct GhostConnection;
 
 /// Marker added to every `Connection` data entity whose source or target
-/// terminal is currently being hovered with Alt held down. The connection
-/// renderer fades wires carrying this marker to signal they'll be removed
-/// on click.
+/// terminal is currently being hovered with Right Click held down. The 
+/// connection renderer fades wires carrying this marker to signal they'll 
+/// be removed on click.
 #[derive(Component, Debug, Clone, Copy)]
 pub struct PendingRemove;
 
@@ -69,7 +69,7 @@ const SNAP_RADIUS_PX: f32 = 40.0;
 /// Full-opacity wire color.
 const WIRE_COLOR: Vec4 = Vec4::new(0.6, 0.6, 0.7, 1.0);
 /// Dimmed wire color applied when a connection has a [`PendingRemove`]
-/// marker (alt+hover on one of its endpoints).
+/// marker (right+hover on one of its endpoints).
 const WIRE_COLOR_PENDING_REMOVE: Vec4 = Vec4::new(0.95, 0.35, 0.35, 0.45);
 /// Ghost color when the drag is free (no snap target yet). Warm
 /// translucent gray signals "free-floating end".
@@ -338,23 +338,23 @@ pub fn update_ghost_wire(
 }
 
 /// Add [`PendingRemove`] to every connection touching a terminal the user
-/// is currently hovering while holding Alt. Removes the marker from
+/// is currently hovering while holding Right. Removes the marker from
 /// connections that no longer qualify.
 ///
 /// Runs in `Update`. Combined with [`update_connection_endpoints`]'s
 /// alpha-switching logic this fades wires the user is about to delete.
 pub fn update_pending_remove_markers(
-    keys: Res<ButtonInput<KeyCode>>,
+    mouse: Res<ButtonInput<MouseButton>>,
     hover_map: Res<bevy::picking::hover::HoverMap>,
     terminal_views: Query<&GraphTerminalView>,
     connections: Query<(Entity, &Connection)>,
     marked: Query<Entity, With<PendingRemove>>,
     mut commands: Commands,
 ) {
-    let alt_held = keys.pressed(KeyCode::AltLeft) || keys.pressed(KeyCode::AltRight);
+    let right_held = mouse.pressed(MouseButton::Right);
 
     let mut target_connections: HashSet<Entity> = HashSet::new();
-    if alt_held {
+    if right_held {
         // Collect every terminal the pointer is currently over.
         let mut hovered: Vec<(Entity, TerminalDirection, u32)> = Vec::new();
         for pointer_map in hover_map.values() {

--- a/crates/jackdaw_node_graph/src/interaction.rs
+++ b/crates/jackdaw_node_graph/src/interaction.rs
@@ -352,22 +352,18 @@ pub fn on_terminal_click(mut event: On<Pointer<Click>>, terminals: Query<&GraphT
     event.propagate(false);
 }
 
-/// Alt+click on a terminal removes every connection touching it.
+/// Right click on a terminal removes every connection touching it.
 ///
 /// Simpler than hit-testing the wire's Bezier curve on the CPU; good enough
 /// for Phase 3. Each removal is pushed as an `EditorCommand` so undo/redo
 /// works automatically.
-pub fn on_terminal_alt_click(
+pub fn on_terminal_right_click(
     mut event: On<Pointer<Click>>,
     terminals: Query<&GraphTerminalView>,
-    keys: Res<ButtonInput<KeyCode>>,
     connections: Query<(Entity, &Connection, Option<&ChildOf>)>,
     mut commands: Commands,
 ) {
-    if event.button != PointerButton::Primary {
-        return;
-    }
-    if !keys.pressed(KeyCode::AltLeft) && !keys.pressed(KeyCode::AltRight) {
+    if event.button != PointerButton::Secondary {
         return;
     }
     let Ok(term) = terminals.get(event.event_target()) else {

--- a/crates/jackdaw_node_graph/src/lib.rs
+++ b/crates/jackdaw_node_graph/src/lib.rs
@@ -126,7 +126,6 @@ impl Plugin for NodeGraphPlugin {
         // before node observers so propagation can be stopped on the
         // handled path before the event bubbles to the node root.
         app.add_observer(interaction::on_terminal_click)
-//            .add_observer(interaction::on_terminal_right_pressed)
             .add_observer(interaction::on_terminal_right_click)
             .add_observer(interaction::on_terminal_drag_start)
             .add_observer(interaction::on_terminal_drag)

--- a/crates/jackdaw_node_graph/src/lib.rs
+++ b/crates/jackdaw_node_graph/src/lib.rs
@@ -126,7 +126,8 @@ impl Plugin for NodeGraphPlugin {
         // before node observers so propagation can be stopped on the
         // handled path before the event bubbles to the node root.
         app.add_observer(interaction::on_terminal_click)
-            .add_observer(interaction::on_terminal_alt_click)
+//            .add_observer(interaction::on_terminal_right_pressed)
+            .add_observer(interaction::on_terminal_right_click)
             .add_observer(interaction::on_terminal_drag_start)
             .add_observer(interaction::on_terminal_drag)
             .add_observer(interaction::on_terminal_drag_end)


### PR DESCRIPTION
Changed the keybinds for disconnecting a node connection and activating the remove markers from alt-click to right click. Closes issue #136