### PR TITLE
Fix search bar in the asset browser

### DIFF
--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -10,6 +10,7 @@ use bevy::{
     ui_widgets::observe,
     window::{PrimaryWindow, RawHandleWrapper},
 };
+use jackdaw_feathers::text_edit::TextEditValue;
 use jackdaw_feathers::{file_browser, icons, icons::IconFont, popover, tokens};
 use jackdaw_widgets::file_browser::{FileBrowserItem, FileItemDoubleClicked};
 use rfd::AsyncFileDialog;
@@ -95,6 +96,7 @@ impl Plugin for AssetBrowserPlugin {
                     update_preview_panel,
                     check_watcher_events,
                     remove_incompatible_image_nodes,
+                    update_asset_browser_filter,
                 )
                     .run_if(in_state(crate::AppState::Editor)),
             )
@@ -203,6 +205,9 @@ pub struct AssetBrowserContent;
 
 #[derive(Component)]
 pub struct AssetBrowserBreadcrumb;
+
+#[derive(Component)]
+pub struct AssetBrowserFilter;
 
 #[derive(Component)]
 struct PreviewPanelContainer;
@@ -657,6 +662,16 @@ fn refresh_browser_on_change(
                 }
             }
         });
+}
+
+fn update_asset_browser_filter(
+    mut state: ResMut<AssetBrowserState>,
+    filters: Query<&TextEditValue, (With<AssetBrowserFilter>, Changed<TextEditValue>)>,
+) {
+    for filter in filters {
+        state.filter = filter.0.clone();
+        state.needs_refresh = true;
+    }
 }
 
 fn highlight_on_hover(hover: On<Pointer<Over>>, mut bg: Query<&mut BackgroundColor>) {
@@ -1311,7 +1326,7 @@ pub fn asset_browser_panel(icon_font: Handle<Font>) -> impl Bundle {
                                             width: Val::Px(200.0),
                                             ..Default::default()
                                         },
-                                        children![(jackdaw_feathers::text_edit::text_edit(
+                                        children![(AssetBrowserFilter, jackdaw_feathers::text_edit::text_edit(
                                             jackdaw_feathers::text_edit::TextEditProps::default()
                                                 .with_placeholder("Search...")
                                                 .allow_empty()


### PR DESCRIPTION
The search bar in the asset browser now correctly filters assets
Fixes #68