### PR TITLE
Fix the hierarchy not refreshing every other time

### DIFF
--- a/crates/jackdaw_widgets/src/tree_view.rs
+++ b/crates/jackdaw_widgets/src/tree_view.rs
@@ -177,7 +177,7 @@ impl Plugin for TreeViewPlugin {
 }
 
 /// Keep TreeIndex in sync with TreeNode additions and removals.
-fn maintain_tree_index(
+pub fn maintain_tree_index(
     mut index: ResMut<TreeIndex>,
     added: Query<(Entity, &TreeNode), Added<TreeNode>>,
     mut removed: RemovedComponents<TreeNode>,

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -64,7 +64,6 @@ impl Plugin for HierarchyPlugin {
             .init_resource::<HierarchyShowAll>()
             .add_systems(Startup, setup_tree_node_expanded_watcher)
             .add_systems(OnEnter(crate::AppState::Editor), setup_name_watcher)
-            .add_observer(rebuild_hierarchy_on_container_added)
             .add_systems(
                 Update,
                 (
@@ -79,6 +78,11 @@ impl Plugin for HierarchyPlugin {
                     jackdaw_feathers::tree_view::tree_keyboard_navigation,
                 )
                     .run_if(in_state(crate::AppState::Editor)),
+            )
+            .add_systems(
+                PostUpdate,
+                rebuild_hierarchy_on_container_added
+                    .after(jackdaw_widgets::tree_view::maintain_tree_index),
             )
             .add_observer(handle_inline_rename_commit)
             .add_observer(on_root_entity_added)
@@ -159,11 +163,14 @@ fn spawn_single_tree_row(world: &mut World, source: Entity, parent_container: En
     tree_row_entity
 }
 
+// This has to be a system instead of an observer because it must run after `tree_view::maintain_tree_index`
 fn rebuild_hierarchy_on_container_added(
-    _trigger: On<Add, HierarchyTreeContainer>,
+    added: Query<Entity, Added<HierarchyTreeContainer>>,
     mut commands: Commands,
 ) {
-    commands.queue(rebuild_hierarchy);
+    if !added.is_empty() {
+        commands.queue(rebuild_hierarchy);
+    }
 }
 
 fn rebuild_hierarchy(world: &mut World) {


### PR DESCRIPTION
Here's a recording of the bug:

https://github.com/user-attachments/assets/fbf2140b-c87e-4647-aaf2-56021463b07f

The bug happened because the `rebuild_hierarchy_on_container_added` observer was running _before_ the tree index was updated, which caused the check for an entry not already existing to fail because the tree index hadn't been updated since before the old window was removed

It was fixed by making `rebuild_hierarchy_on_container_added` a system and making it run in post update after `jackdaw_widgets::tree_view::maintain_tree_index`