### PR TITLE
Cache some queries

### DIFF
--- a/crates/jackdaw_api_internal/src/operator.rs
+++ b/crates/jackdaw_api_internal/src/operator.rs
@@ -220,12 +220,13 @@ pub enum ExecutionContext {
     Invoke,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum CallOperatorError {
     UnknownId(Cow<'static, str>),
     ModalAlreadyActive(&'static str),
     NotAvailable,
     ExecuteFailed,
+    Other(BevyError),
 }
 
 impl std::fmt::Display for CallOperatorError {
@@ -237,7 +238,13 @@ impl std::fmt::Display for CallOperatorError {
             }
             Self::NotAvailable => f.write_str("operator's availability check failed"),
             Self::ExecuteFailed => f.write_str("operator's execute system failed"),
+            Self::Other(err) => write!(f, "operator execution failed: {err}"),
         }
+    }
+}
+impl From<BevyError> for CallOperatorError {
+    fn from(err: BevyError) -> Self {
+        Self::Other(err)
     }
 }
 
@@ -296,38 +303,37 @@ impl<'a> OperatorCallBuilder<'a, World> {
     /// `Ok(true)` if it's ready, `Ok(false)` if not, `Err` for unknown
     /// ids.
     pub fn is_available(self) -> Result<bool, CallOperatorError> {
-        let Some(op_entity) = self
-            .world_commands
-            .resource::<OperatorIndex>()
-            .by_id
-            .get(self.id.as_ref())
-            .copied()
-        else {
-            return Err(CallOperatorError::UnknownId(self.id));
-        };
-        let Some(op) = self
-            .world_commands
-            .get::<OperatorEntity>(op_entity)
-            .cloned()
-        else {
-            return Err(CallOperatorError::UnknownId(self.id));
-        };
-        if op.modal
-            && self
-                .world_commands
-                .query_filtered::<Entity, With<ActiveModalOperator>>()
-                .iter(self.world_commands)
-                .next()
-                .is_some()
-        {
-            return Err(CallOperatorError::ModalAlreadyActive(op.id));
+        fn is_available_inner(
+            In(id): In<Cow<'static, str>>,
+            world: &mut World,
+            active: &mut SystemState<ActiveModalQuery>,
+        ) -> Result<bool, CallOperatorError> {
+            let Some(op_entity) = world
+                .resource::<OperatorIndex>()
+                .by_id
+                .get(id.as_ref())
+                .copied()
+            else {
+                return Err(CallOperatorError::UnknownId(id));
+            };
+            let Some(op) = world.get::<OperatorEntity>(op_entity).cloned() else {
+                return Err(CallOperatorError::UnknownId(id));
+            };
+            if op.modal && active.get(world).is_modal_running() {
+                return Err(CallOperatorError::ModalAlreadyActive(op.id));
+            }
+            let Some(check) = op.availability_check else {
+                return Ok(true);
+            };
+            world
+                .run_system(check)
+                .map_err(|_| CallOperatorError::NotAvailable)
         }
-        let Some(check) = op.availability_check else {
-            return Ok(true);
-        };
         self.world_commands
-            .run_system(check)
-            .map_err(|_| CallOperatorError::NotAvailable)
+            .run_system_cached_with(is_available_inner, self.id.clone())
+            .map_err(BevyError::from)
+            .map_err(CallOperatorError::from)
+            .flatten()
     }
 
     /// Call an operator by id. The availability check runs before the

--- a/crates/jackdaw_loader/src/lib.rs
+++ b/crates/jackdaw_loader/src/lib.rs
@@ -252,6 +252,7 @@ pub enum LoadError {
     /// is surfaced through the same Result so call sites have a
     /// single error type to match on.
     InstallIo(String),
+    Other(BevyError),
 }
 
 impl LoadError {
@@ -292,6 +293,7 @@ impl std::fmt::Display for LoadError {
                 write!(f, "extension name is not valid UTF-8 or contains NUL")
             }
             Self::InstallIo(msg) => write!(f, "install io: {msg}"),
+            Self::Other(e) => write!(f, "other: {e}"),
         }
     }
 }
@@ -307,6 +309,12 @@ impl From<libloading::Error> for LoadError {
 impl From<CompatError> for LoadError {
     fn from(value: CompatError) -> Self {
         Self::Compat(value)
+    }
+}
+
+impl From<BevyError> for LoadError {
+    fn from(value: BevyError) -> Self {
+        Self::Other(value)
     }
 }
 

--- a/crates/jackdaw_panels/src/workspace_tabs.rs
+++ b/crates/jackdaw_panels/src/workspace_tabs.rs
@@ -59,7 +59,10 @@ pub struct WorkspaceListSnapshot {
 /// in-place via `handle_workspace_rename_commit`; per-tab `tree`
 /// mutations don't touch the strip at all. This avoids despawning the
 /// X / rename input out from under their deferred init systems.
-pub fn populate_workspace_tabs(world: &mut World) {
+pub fn populate_workspace_tabs(
+    world: &mut World,
+    workspace_strips: &mut QueryState<Entity, (With<WorkspaceTabStrip>, Without<WorkspaceTab>)>,
+) {
     let current_ids: Vec<String> = world
         .resource::<WorkspaceRegistry>()
         .workspaces
@@ -71,9 +74,7 @@ pub fn populate_workspace_tabs(world: &mut World) {
 
     let mut strips: Vec<Entity> = Vec::new();
     {
-        let mut query =
-            world.query_filtered::<Entity, (With<WorkspaceTabStrip>, Without<WorkspaceTab>)>();
-        for entity in query.iter(world) {
+        for entity in workspace_strips.iter(world) {
             let is_empty = world
                 .entity(entity)
                 .get::<Children>()

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -113,9 +113,11 @@ pub enum JackdawLoadError {
     Parse(String),
 }
 
-fn spawn_loaded_scenes(world: &mut World) {
-    let mut query = world.query_filtered::<(Entity, &JackdawSceneRoot), Without<SceneSpawned>>();
-    let to_spawn: Vec<(Entity, Handle<JackdawScene>)> = query
+fn spawn_loaded_scenes(
+    world: &mut World,
+    scene_roots: &mut QueryState<(Entity, &JackdawSceneRoot), Without<SceneSpawned>>,
+) {
+    let to_spawn: Vec<(Entity, Handle<JackdawScene>)> = scene_roots
         .iter(world)
         .map(|(e, root)| (e, root.0.clone()))
         .collect();

--- a/examples/sample_extension/Cargo.toml
+++ b/examples/sample_extension/Cargo.toml
@@ -16,3 +16,6 @@ bevy.workspace = true
 bevy_enhanced_input.workspace = true
 jackdaw_api.workspace = true
 jackdaw_commands.workspace = true
+
+[lints]
+workspace = true

--- a/examples/viewable_camera_extension/Cargo.toml
+++ b/examples/viewable_camera_extension/Cargo.toml
@@ -10,3 +10,6 @@ path = "src/lib.rs"
 bevy.workspace = true
 bevy_enhanced_input.workspace = true
 jackdaw_api.workspace = true
+
+[lints]
+workspace = true

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -92,7 +92,10 @@ struct CameraPreviewState {
 fn place_viewable_camera(_: In<OperatorParameters>, world: &mut World) -> OperatorResult {
     // Match the editor camera's transform so "look through" feels
     // natural on the first toggle.
-    let spawn_transform = find_editor_camera(world)
+    let spawn_transform = world
+        .run_system_cached(find_editor_camera)
+        .ok()
+        .flatten()
         .and_then(|e| world.get::<Transform>(e).copied())
         .unwrap_or_default();
 
@@ -137,7 +140,7 @@ fn toggle_preview(_: In<OperatorParameters>, world: &mut World) -> OperatorResul
         restore_editor_camera(world);
         info!("Exited viewable-camera preview");
     } else {
-        let Some(target) = pick_preview_target(world) else {
+        let Ok(Some(target)) = world.run_system_cached(pick_preview_target) else {
             warn!("No viewable camera to preview; press F6 to place one first");
             return OperatorResult::Cancelled;
         };
@@ -151,12 +154,14 @@ fn toggle_preview(_: In<OperatorParameters>, world: &mut World) -> OperatorResul
 
 /// Find the active editor-viewport camera: an active `Camera3d` with an
 /// `Image` render target that isn't one of ours.
-fn find_editor_camera(world: &mut World) -> Option<Entity> {
-    let mut q = world.query_filtered::<
+fn find_editor_camera(
+    world: &mut World,
+    cameras: &mut QueryState<
         (Entity, &Camera, &RenderTarget),
         (With<Camera3d>, Without<ViewableCamera>),
-    >();
-    for (entity, camera, target) in q.iter(world) {
+    >,
+) -> Option<Entity> {
+    for (entity, camera, target) in cameras.iter(world) {
         if camera.is_active && matches!(target, RenderTarget::Image(_)) {
             return Some(entity);
         }
@@ -168,11 +173,11 @@ fn find_editor_camera(world: &mut World) -> Option<Entity> {
 /// exactly one, otherwise the first one found. A richer rule honouring
 /// the editor's `Selection` resource would require depending on the
 /// main jackdaw crate.
-fn pick_preview_target(world: &mut World) -> Option<Entity> {
-    let cams: Vec<Entity> = world
-        .query_filtered::<Entity, With<ViewableCamera>>()
-        .iter(world)
-        .collect();
+fn pick_preview_target(
+    world: &mut World,
+    cameras: &mut QueryState<Entity, With<ViewableCamera>>,
+) -> Option<Entity> {
+    let cams: Vec<Entity> = cameras.iter(world).collect();
     if cams.len() == 1 {
         return Some(cams[0]);
     }
@@ -180,7 +185,7 @@ fn pick_preview_target(world: &mut World) -> Option<Entity> {
 }
 
 fn enter_preview(world: &mut World, target: Entity) -> Result<(), &'static str> {
-    let Some(editor_cam) = find_editor_camera(world) else {
+    let Ok(Some(editor_cam)) = world.run_system_cached(find_editor_camera) else {
         return Err("couldn't find the editor viewport camera");
     };
     let render_target = world

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -124,11 +124,11 @@ pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
 
 /// Open the Add Entity picker as a centered blocking dialog. Styled
 /// to match the Add Component dialog. Toggles off if already open.
-pub fn open_add_entity_picker(world: &mut World) {
-    let existing: Vec<Entity> = world
-        .query_filtered::<Entity, With<AddEntityPicker>>()
-        .iter(world)
-        .collect();
+pub fn open_add_entity_picker(
+    world: &mut World,
+    entity_pickers: &mut QueryState<Entity, With<AddEntityPicker>>,
+) {
+    let existing: Vec<Entity> = entity_pickers.iter(world).collect();
     if !existing.is_empty() {
         for e in existing {
             if let Ok(ec) = world.get_entity_mut(e) {
@@ -322,17 +322,15 @@ pub fn open_add_entity_picker(world: &mut World) {
                             commands.trigger(jackdaw_widgets::menu_bar::MenuAction {
                                 action: action.clone(),
                             });
-                            commands.queue(|world: &mut World| {
-                                let pickers: Vec<Entity> = world
-                                    .query_filtered::<Entity, With<AddEntityPicker>>()
-                                    .iter(world)
-                                    .collect();
-                                for picker in pickers {
-                                    if let Ok(ec) = world.get_entity_mut(picker) {
-                                        ec.despawn();
-                                    }
+                            fn despawn_pickers(
+                                mut commands: Commands,
+                                pickers: Query<Entity, With<AddEntityPicker>>,
+                            ) {
+                                for picker in &pickers {
+                                    commands.entity(picker).try_despawn();
                                 }
-                            });
+                            }
+                            commands.run_system_cached(despawn_pickers);
                         }
                     }),
                     observe(

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -1,6 +1,10 @@
 use std::path::Path;
 
-use bevy::{ecs::system::SystemState, gltf::GltfAssetLabel, prelude::*};
+use bevy::{
+    ecs::system::{SystemParam, SystemState},
+    gltf::GltfAssetLabel,
+    prelude::*,
+};
 
 use crate::{
     EditorEntity,
@@ -467,11 +471,14 @@ fn camera_snapped_rotation_axes(gt: &GlobalTransform) -> (Vec3, Vec3, Vec3) {
     (yaw_axis, roll_axis, pitch_axis)
 }
 
-pub fn handle_entity_keys(world: &mut World) {
+pub fn handle_entity_keys(
+    world: &mut World,
+    cameras: &mut QueryState<&GlobalTransform, With<crate::viewport::MainViewportCamera>>,
+) -> Result {
     // Don't process entity keys when a text input is focused
     let has_input_focus = world.resource::<InputFocus>().0.is_some();
     if has_input_focus {
-        return;
+        return Ok(());
     }
 
     // Don't process entity keys during modal transform operations or draw mode
@@ -480,14 +487,14 @@ pub fn handle_entity_keys(world: &mut World) {
         .active
         .is_some();
     if modal_active {
-        return;
+        return Ok(());
     }
     let draw_active = world
         .resource::<crate::draw_brush::DrawBrushState>()
         .active
         .is_some();
     if draw_active {
-        return;
+        return Ok(());
     }
 
     // Don't process entity ops during brush edit mode (Delete etc. handled by brush systems)
@@ -496,7 +503,7 @@ pub fn handle_entity_keys(world: &mut World) {
         crate::brush::EditMode::Object
     );
     if in_brush_edit {
-        return;
+        return Ok(());
     }
 
     use crate::keybinds::EditorAction;
@@ -550,9 +557,9 @@ pub fn handle_entity_keys(world: &mut World) {
     } else if reset_scale {
         reset_transform_selected(world, TransformReset::Scale);
     } else if unhide_all {
-        unhide_all_entities(world);
+        world.run_system_cached(unhide_all_entities)?
     } else if hide_unselected {
-        hide_all_entities(world);
+        world.run_system_cached(hide_all_entities)?
     } else if do_hide_selected {
         hide_selected(world);
     } else if any_rotation {
@@ -560,9 +567,7 @@ pub fn handle_entity_keys(world: &mut World) {
         // so rotations always produce axis-aligned results while still feeling
         // intuitive from the current viewpoint.
         let (yaw_axis, roll_axis, pitch_axis) = {
-            let mut cam_query = world
-                .query_filtered::<&GlobalTransform, With<crate::viewport::MainViewportCamera>>();
-            cam_query
+            cameras
                 .iter(world)
                 .next()
                 .map(|gt| camera_snapped_rotation_axes(gt))
@@ -610,6 +615,7 @@ pub fn handle_entity_keys(world: &mut World) {
         }
         nudge_selected(world, offset);
     }
+    Ok(())
 }
 
 enum TransformReset {
@@ -913,18 +919,25 @@ fn hide_selected(world: &mut World) {
     }
 }
 
-fn unhide_all_entities(world: &mut World) {
+// FIXME: this breaks down whenever an extension uses `Name`
+#[derive(SystemParam, Deref, DerefMut)]
+struct SceneEntities<'w, 's> {
+    query: Query<
+        'w,
+        's,
+        (Entity, &'static Visibility),
+        (With<Name>, Without<EditorEntity>, Without<Node>),
+    >,
+}
+
+fn unhide_all_entities(world: &mut World, scene_entities: &mut SystemState<SceneEntities>) {
     let mut cmds: Vec<Box<dyn EditorCommand>> = Vec::new();
 
     // Only unhide top-level scene entities (with Name), matching hide_unselected logic.
     let hidden: Vec<Entity> = {
-        let mut query = world.query_filtered::<(Entity, &Visibility), (
-            With<Name>,
-            Without<EditorEntity>,
-            Without<Node>,
-        )>();
-        query
-            .iter(world)
+        scene_entities
+            .get(world)
+            .iter()
             .filter(|(_, vis)| **vis == Visibility::Hidden)
             .map(|(e, _)| e)
             .collect()
@@ -953,18 +966,14 @@ fn unhide_all_entities(world: &mut World) {
     }
 }
 
-fn hide_all_entities(world: &mut World) {
+fn hide_all_entities(world: &mut World, scene_entities: &mut SystemState<SceneEntities>) {
     let mut cmds: Vec<Box<dyn EditorCommand>> = Vec::new();
 
     // Hide all top-level scene entities (same filter as H, applied to everything).
     let to_hide: Vec<(Entity, Visibility)> = {
-        let mut query = world.query_filtered::<(Entity, &Visibility), (
-            With<Name>,
-            Without<EditorEntity>,
-            Without<Node>,
-        )>();
-        query
-            .iter(world)
+        scene_entities
+            .get(world)
+            .iter()
             .filter(|(_, vis)| **vis != Visibility::Hidden)
             .map(|(e, vis)| (e, *vis))
             .collect()

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -1,6 +1,8 @@
 //! File > Extensions dialog. Toggles compiled-in extensions at runtime
 //! and persists the current state to `extensions.json`.
 
+use std::path::PathBuf;
+
 use bevy::{
     prelude::*,
     tasks::{AsyncComputeTaskPool, Task, futures_lite::future},
@@ -360,7 +362,9 @@ fn poll_install_task(
                 // name was already loaded, it runs the prior
                 // teardown first and then calls the new build.
                 // No restart needed.
-                let _ = handle_install(world, src);
+                if let Err(err) = world.run_system_cached_with(handle_install, src) {
+                    error!("Failed to install extension: {err}")
+                }
             });
         }
         None => {
@@ -399,12 +403,17 @@ pub fn handle_install_from_path(
     world: &mut World,
     src: std::path::PathBuf,
 ) -> Result<jackdaw_loader::LoadedKind, jackdaw_loader::LoadError> {
-    handle_install(world, src)
+    world
+        .run_system_cached_with(handle_install, src)
+        .map_err(BevyError::from)
+        .map_err(jackdaw_loader::LoadError::from)
+        .flatten()
 }
 
 fn handle_install(
+    In(src): In<PathBuf>,
     world: &mut World,
-    src: std::path::PathBuf,
+    extension_dialogs: &mut QueryState<Entity, With<ExtensionsDialogContent>>,
 ) -> Result<jackdaw_loader::LoadedKind, jackdaw_loader::LoadError> {
     let target = classify_for_install(&src);
     let dest = match install_picked_file(&src, target) {
@@ -446,8 +455,7 @@ fn handle_install(
 
     // Despawn the existing list so `populate_extensions_dialog`
     // rebuilds it from the now-updated catalog.
-    let mut q = world.query_filtered::<Entity, With<ExtensionsDialogContent>>();
-    let targets: Vec<Entity> = q.iter(world).collect();
+    let targets: Vec<Entity> = extension_dialogs.iter(world).collect();
     for entity in targets {
         if let Ok(ec) = world.get_entity_mut(entity) {
             ec.despawn();

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 
-use bevy::{input_focus::InputFocus, prelude::*, ui::ui_transform::UiGlobalTransform};
+use bevy::{
+    ecs::system::SystemState, input_focus::InputFocus, prelude::*,
+    ui::ui_transform::UiGlobalTransform,
+};
 use bevy_monitors::prelude::{Mutation, NotifyChanged};
 use jackdaw_api::prelude::*;
 use jackdaw_feathers::{
@@ -174,51 +177,53 @@ fn rebuild_hierarchy_on_container_added(
     }
 }
 
-fn rebuild_hierarchy(world: &mut World) {
-    let container = world
-        .query_filtered::<Entity, With<HierarchyTreeContainer>>()
-        .iter(world)
-        .next();
+fn rebuild_hierarchy(world: &mut World) -> Result {
+    fn rebuild_hierarchy_inner(
+        world: &mut World,
+        container: &mut SystemState<Single<Entity, With<HierarchyTreeContainer>>>,
+        roots: &mut QueryState<
+            Entity,
+            (
+                With<Transform>,
+                Without<EditorEntity>,
+                Without<EditorHidden>,
+                Without<ChildOf>,
+            ),
+        >,
+    ) {
+        let container = *container.get(world);
 
-    let Some(container) = container else {
-        return;
-    };
+        // Collect all root scene entities (Transform, no ChildOf, no editor markers)
+        let roots: Vec<Entity> = roots.iter(world).collect();
 
-    // Collect all root scene entities (Transform, no ChildOf, no editor markers)
-    let roots: Vec<Entity> = world
-        .query_filtered::<Entity, (
-            With<Transform>,
-            Without<EditorEntity>,
-            Without<EditorHidden>,
-            Without<ChildOf>,
-        )>()
-        .iter(world)
-        .collect();
+        let show_all = world.resource::<HierarchyShowAll>().0;
 
-    let show_all = world.resource::<HierarchyShowAll>().0;
+        // Sort by (category, name) for consistent ordering
+        let mut root_data: Vec<(Entity, EntityCategory, String)> = roots
+            .into_iter()
+            .filter(|&e| !world.resource::<TreeIndex>().contains(e))
+            .filter(|&e| show_all || world.get::<Name>(e).is_some())
+            .map(|e| {
+                let category = classify_entity(world, e);
+                let name = world
+                    .get::<Name>(e)
+                    .map(|n| n.as_str().to_string())
+                    .unwrap_or_else(|| format!("Entity {e}"));
+                (e, category, name)
+            })
+            .collect();
 
-    // Sort by (category, name) for consistent ordering
-    let mut root_data: Vec<(Entity, EntityCategory, String)> = roots
-        .into_iter()
-        .filter(|&e| !world.resource::<TreeIndex>().contains(e))
-        .filter(|&e| show_all || world.get::<Name>(e).is_some())
-        .map(|e| {
-            let category = classify_entity(world, e);
-            let name = world
-                .get::<Name>(e)
-                .map(|n| n.as_str().to_string())
-                .unwrap_or_else(|| format!("Entity {e}"));
-            (e, category, name)
-        })
-        .collect();
+        root_data.sort_by(|(_, cat_a, name_a), (_, cat_b, name_b)| {
+            cat_a.cmp(cat_b).then_with(|| name_a.cmp(name_b))
+        });
 
-    root_data.sort_by(|(_, cat_a, name_a), (_, cat_b, name_b)| {
-        cat_a.cmp(cat_b).then_with(|| name_a.cmp(name_b))
-    });
-
-    for (entity, _category, _name) in root_data {
-        spawn_single_tree_row(world, entity, container);
+        for (entity, _category, _name) in root_data {
+            spawn_single_tree_row(world, entity, container);
+        }
     }
+    world
+        .run_system_cached(rebuild_hierarchy_inner)
+        .map_err(BevyError::from)
 }
 
 /// When a new entity gets Transform and has no parent, create a root tree row.
@@ -1463,21 +1468,20 @@ fn update_show_all_button_appearance(
 fn on_show_all_changed(show_all: Res<HierarchyShowAll>, mut commands: Commands) {
     if show_all.is_changed() && !show_all.is_added() {
         commands.queue(|world: &mut World| {
-            clear_all_tree_rows(world);
-            rebuild_hierarchy(world);
+            if let Err(err) = world.run_system_cached(clear_all_tree_rows) {
+                error!("Failed to clear tree rows: {err}");
+            }
+            rebuild_hierarchy(world)
         });
     }
 }
 
 /// Despawn all tree rows and clear the TreeIndex.
-pub fn clear_all_tree_rows(world: &mut World) {
-    let container = world
-        .query_filtered::<Entity, With<HierarchyTreeContainer>>()
-        .iter(world)
-        .next();
-    let Some(container) = container else {
-        return;
-    };
+pub fn clear_all_tree_rows(
+    world: &mut World,
+    container: &mut SystemState<Single<Entity, With<HierarchyTreeContainer>>>,
+) {
+    let container = *container.get(world);
 
     // Collect tree row children of the container
     let tree_rows: Vec<Entity> = world

--- a/src/inspector/component_picker.rs
+++ b/src/inspector/component_picker.rs
@@ -1,5 +1,4 @@
 use crate::EditorEntity;
-use crate::commands::EditorCommand;
 use crate::selection::{Selected, Selection};
 use std::any::TypeId;
 use std::collections::{BTreeMap, HashSet};
@@ -337,14 +336,21 @@ pub(crate) fn on_add_component_button_click(
                         move |mut click: On<Pointer<Click>>, mut commands: Commands| {
                             click.propagate(false); // Don't let click through to backdrop
                             let tp = type_path_full.clone();
-                            commands.queue(move |world: &mut World| {
-                                let cmd = crate::commands::AddComponent::new(
-                                    source_entity,
-                                    type_id,
-                                    component_id,
-                                    tp,
-                                );
-                                let mut cmd = Box::new(cmd);
+                            let cmd = crate::commands::AddComponent::new(
+                                source_entity,
+                                type_id,
+                                component_id,
+                                tp,
+                            );
+                            let cmd = Box::new(cmd);
+                            fn remove_pickers(
+                                In((source_entity, mut cmd)): In<(
+                                    Entity,
+                                    Box<dyn crate::commands::EditorCommand>,
+                                )>,
+                                world: &mut World,
+                                pickers: &mut QueryState<Entity, With<ComponentPicker>>,
+                            ) {
                                 cmd.execute(world);
                                 let mut history =
                                     world.resource_mut::<crate::commands::CommandHistory>();
@@ -354,16 +360,14 @@ pub(crate) fn on_add_component_button_click(
                                 world.entity_mut(source_entity).insert(InspectorDirty);
 
                                 // Close the picker dialog
-                                let pickers: Vec<Entity> = world
-                                    .query_filtered::<Entity, With<ComponentPicker>>()
-                                    .iter(world)
-                                    .collect();
+                                let pickers: Vec<Entity> = pickers.iter(world).collect();
                                 for picker in pickers {
                                     if let Ok(ec) = world.get_entity_mut(picker) {
                                         ec.despawn();
                                     }
                                 }
-                            });
+                            }
+                            commands.run_system_cached_with(remove_pickers, (source_entity, cmd))
                         }
                     }),
                     observe(

--- a/src/inspector/custom_props_display.rs
+++ b/src/inspector/custom_props_display.rs
@@ -1,6 +1,7 @@
 use crate::commands::{CommandHistory, EditorCommand};
 use crate::custom_properties::{CustomProperties, PropertyValue, SetCustomProperties};
 
+use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
 use bevy::ui_widgets::observe;
 use jackdaw_feathers::combobox::{ComboBoxSelectedIndex, combobox_with_selected};
@@ -359,21 +360,23 @@ fn spawn_add_property_row(
         TextColor(tokens::TEXT_ACCENT),
         ChildOf(row),
         observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-            commands.queue(move |world: &mut World| {
-                add_custom_property_from_ui(world, source_entity);
-            });
+            commands.run_system_cached_with(add_custom_property_from_ui, source_entity)
         }),
     ));
 }
 
 /// Read the name input and type selector, then add a new property.
-fn add_custom_property_from_ui(world: &mut World, source_entity: Entity) {
+fn add_custom_property_from_ui(
+    In(source_entity): In<Entity>,
+    world: &mut World,
+    text_edit: &mut SystemState<Single<&TextEditValue, With<CustomPropertyNameInput>>>,
+    combo_box_index: &mut SystemState<
+        Single<&ComboBoxSelectedIndex, With<CustomPropertyTypeSelector>>,
+    >,
+) {
     // Read the name input value
     let name = {
-        let mut query = world.query_filtered::<&TextEditValue, With<CustomPropertyNameInput>>();
-        let Some(input) = query.iter(world).next() else {
-            return;
-        };
+        let input = *text_edit.get(world);
         let name = input.0.trim().to_string();
         if name.is_empty() {
             return;
@@ -383,11 +386,7 @@ fn add_custom_property_from_ui(world: &mut World, source_entity: Entity) {
 
     // Read the type selector
     let type_name = {
-        let mut query =
-            world.query_filtered::<&ComboBoxSelectedIndex, With<CustomPropertyTypeSelector>>();
-        let Some(index) = query.iter(world).next() else {
-            return;
-        };
+        let index = *combo_box_index.get(world);
         let all_types = PropertyValue::all_type_names();
         let idx = index.0.min(all_types.len().saturating_sub(1));
         all_types[idx].to_string()

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1116,7 +1116,7 @@ pub fn hierarchy_content(icon_font: Handle<Font>) -> impl Bundle {
                 observe(|mut click: On<Pointer<Click>>, mut commands: Commands| {
                     click.propagate(false);
                     commands.queue(|world: &mut World| {
-                        crate::add_entity_picker::open_add_entity_picker(world);
+                        world.run_system_cached(crate::add_entity_picker::open_add_entity_picker)
                     });
                 },),
                 children![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,9 @@ fn rebuild_menu_if_dirty(world: &mut World) {
         return;
     }
     world.resource_mut::<MenuBarDirty>().0 = false;
-    populate_menu(world);
+    if let Err(err) = world.run_system_cached(populate_menu) {
+        error!("Failed to rebuild menu: {err:?}");
+    }
 }
 
 fn flag_menu_dirty_on_window_add(_: On<Add, RegisteredWindow>, mut dirty: ResMut<MenuBarDirty>) {
@@ -1805,22 +1807,19 @@ fn discover_gltf_clips(
     }
 }
 
-fn populate_menu(world: &mut World) {
-    let menu_bar_entity = world
-        .query_filtered::<Entity, With<jackdaw_feathers::menu_bar::MenuBarRoot>>()
-        .iter(world)
-        .next();
-    let Some(menu_bar_entity) = menu_bar_entity else {
-        return;
-    };
+fn populate_menu(
+    world: &mut World,
+    menu_bar_entity: &mut SystemState<
+        Single<Entity, With<jackdaw_feathers::menu_bar::MenuBarRoot>>,
+    >,
+    items: &mut QueryState<Entity, With<jackdaw_widgets::menu_bar::MenuBarItem>>,
+) {
+    let menu_bar_entity = *menu_bar_entity.get(world);
 
     // Despawn existing menu-bar items before re-populating. Idempotent on
     // first call (nothing to remove), necessary for rebuilds when the
     // window registry changes (extensions toggled on/off).
-    let existing: Vec<Entity> = world
-        .query_filtered::<Entity, With<jackdaw_widgets::menu_bar::MenuBarItem>>()
-        .iter(world)
-        .collect();
+    let existing: Vec<Entity> = items.iter(world).collect();
     for entity in existing {
         if let Ok(ec) = world.get_entity_mut(entity) {
             ec.despawn();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use bevy::{
     asset::{AssetPlugin, UnapprovedPathMode},
+    ecs::error::ErrorContext,
     image::{ImageAddressMode, ImagePlugin, ImageSamplerDescriptor},
     prelude::*,
 };
@@ -45,7 +46,7 @@ fn main() -> AppExit {
     app
         // The default error handler panics, which we never *ever*
         // want to happen to the editor. Log an error instead.
-        .set_error_handler(bevy::ecs::error::error)
+        .set_error_handler(error_handler)
         .add_plugins(
             DefaultPlugins
                 .set(AssetPlugin {
@@ -97,4 +98,16 @@ fn spawn_scene(mut commands: Commands) {
     commands.queue(|world: &mut World| {
         jackdaw::scene_io::spawn_default_lighting(world);
     });
+}
+
+#[track_caller]
+#[inline]
+fn error_handler(error: BevyError, ctx: ErrorContext) {
+    let msg = format!("{error}");
+    if msg.contains("Note that interacting with a despawned entity is the most common cause of this error but there are others") {
+        // TODO: Ideally these should not happen. But as-is, we get a lot of them and they are benign, so let's not flood the logs
+        bevy::ecs::error::debug(error, ctx);
+        return;
+    }
+    bevy::ecs::error::error(error, ctx)
 }

--- a/src/scene_io.rs
+++ b/src/scene_io.rs
@@ -1642,7 +1642,9 @@ pub(crate) fn clear_scene_entities(world: &mut World) {
         .entities
         .clear();
 
-    crate::hierarchy::clear_all_tree_rows(world);
+    if let Err(err) = world.run_system_cached(crate::hierarchy::clear_all_tree_rows) {
+        error!("Failed to clear tree rows: {err}");
+    }
 
     // Clear undo/redo stacks; they hold entity references that become
     // stale when the scene is dropped. Callers who want to preserve
@@ -1671,7 +1673,10 @@ pub(crate) fn despawn_scene_entities(world: &mut World) {
     let editor_set = collect_editor_entities(world);
 
     let roots: Vec<Entity> = world
-        .query_filtered::<Entity, (With<Name>, Without<bevy_enhanced_input::prelude::ActionSettings>)>()
+        .query_filtered::<Entity, (
+            With<Name>,
+            Without<bevy_enhanced_input::prelude::ActionSettings>,
+        )>()
         .iter(world)
         .filter(|e| !editor_set.contains(e))
         .collect();
@@ -1709,7 +1714,9 @@ pub fn apply_ast_to_world(world: &mut World, ast: &jackdaw_jsn::SceneJsnAst) {
         .resource_mut::<crate::selection::Selection>()
         .entities
         .clear();
-    crate::hierarchy::clear_all_tree_rows(world);
+    if let Err(err) = world.run_system_cached(crate::hierarchy::clear_all_tree_rows) {
+        error!("Failed to clear tree rows: {err}");
+    }
 
     // Reset volatile tool state so an undo/redo can't leave the
     // draw-brush modal "half-active" — i.e. `DrawBrushState.active`
@@ -1717,9 +1724,7 @@ pub fn apply_ast_to_world(world: &mut World, ast: &jackdaw_jsn::SceneJsnAst) {
     // out. A stale `Some` would make the next activate-modal return
     // immediately (modal-already-suspected path) and the B key
     // appear dead until the user reloaded the project.
-    if let Some(mut draw_state) =
-        world.get_resource_mut::<crate::draw_brush::DrawBrushState>()
-    {
+    if let Some(mut draw_state) = world.get_resource_mut::<crate::draw_brush::DrawBrushState>() {
         draw_state.active = None;
     }
     debug!("apply_ast_to_world: cleared DrawBrushState.active and selection before scene reload");


### PR DESCRIPTION
PR against https://github.com/jbuehler23/jackdaw/pull/182 so that it's easier to merge.

Doing `world.query` or `world.query_filtered` will set up a brand new `SystemState` every time it's called. The idea is that you store that, because it's assumed by Bevy that it can cache stuff there. Since it's very annoying to store this by hand every time, there's a utility in the upstream API that allows you to get `&mut SystemState` injected. In fact, if you only care about a given query, you can even inject just the slimmer `&mut QueryState`! This PR goes through a bunch of cases of `query_filtered` and replaces them by injected state caches until I got bored :)

Also ignored some extremely noisy logs that already exist on `main` while on it.

TL;DR for new code running exclusive systems:
- Avoid `.query` or `.query_filter`
- Use `stuff: &mut QueryState<&SomeComponent>` instead
- If you need `Single`, you'll want `single_thing: &mut SystemState<Single<&SomeComponent>>` instead
- Instead of doing `some_function(world, param1, param2)`, call `world.run_system_cached_with(some_function, (param1, param2))`
  - the result is almost always kinda useless. For correctness' sake, I do a print on `if let Err(err) = ...`, but you can just as well do `let _ = ...`
  - note that a `Single` that didn't match anything will return an `Err`, which *will* get printed by this. In practice, this is not a problem for the systems I touched here it seems. Just if you want to avoid it, `let _ = ...` is fine.
  - also note that `run_system_cached` cannot use closures, hence why I had to define some inline `fn`s