### PR TITLE
Add label and description to extensions

### DIFF
--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -38,10 +38,6 @@ pub use jackdaw_api_internal::{
     JackdawExtension, MenuEntryDescriptor, PanelContext, SectionBuildFn, WindowDescriptor,
 };
 
-/// Classifies a registered extension. Authors return this from
-/// [`JackdawExtension::kind`]; defaults to
-/// [`ExtensionKind::Custom`]. [`ExtensionKind::Builtin`] is reserved
-/// for extensions shipped inside the editor binary.
 pub use jackdaw_api_internal::lifecycle::ExtensionKind;
 
 /// `#[operator]` attribute macro. See [`jackdaw_api_macros`] for the

--- a/crates/jackdaw_api_internal/src/export.rs
+++ b/crates/jackdaw_api_internal/src/export.rs
@@ -52,16 +52,33 @@
 /// dylib would fail at link time anyway (duplicate symbol).
 #[macro_export]
 macro_rules! export_extension {
-    ($name:literal, $ctor:expr) => {
+    ($id:expr, $label:expr, $description:expr, $ctor:expr) => {
         const _: () = {
-            const __JACKDAW_NAME: &::core::ffi::CStr = match ::core::ffi::CStr::from_bytes_with_nul(
-                ::core::concat!($name, "\0").as_bytes(),
-            ) {
-                ::core::result::Result::Ok(s) => s,
-                ::core::result::Result::Err(_) => {
-                    ::core::panic!("extension name contains interior NUL byte")
-                }
-            };
+            const __JACKDAW_ID: &::core::ffi::CStr =
+                match ::core::ffi::CStr::from_bytes_with_nul(::core::concat!($id, "\0").as_bytes())
+                {
+                    ::core::result::Result::Ok(s) => s,
+                    ::core::result::Result::Err(_) => {
+                        ::core::panic!("extension ID contains interior NUL byte")
+                    }
+                };
+            const __JACKDAW_LABEL: &::core::ffi::CStr =
+                match ::core::ffi::CStr::from_bytes_with_nul(::core::concat!($label, "\0").as_bytes())
+                {
+                    ::core::result::Result::Ok(s) => s,
+                    ::core::result::Result::Err(_) => {
+                        ::core::panic!("extension label contains interior NUL byte")
+                    }
+                };
+            const __JACKDAW_DESCRIPTION: &::core::ffi::CStr =
+                match ::core::ffi::CStr::from_bytes_with_nul(
+                    ::core::concat!($description, "\0").as_bytes(),
+                ) {
+                    ::core::result::Result::Ok(s) => s,
+                    ::core::result::Result::Err(_) => {
+                        ::core::panic!("extension description contains interior NUL byte")
+                    }
+                };
 
             unsafe extern "C" fn __jackdaw_ctor() -> ::std::boxed::Box<dyn $crate::JackdawExtension>
             {
@@ -75,7 +92,9 @@ macro_rules! export_extension {
                     api_version: $crate::ffi::API_VERSION,
                     bevy_version: $crate::ffi::BEVY_VERSION.as_ptr(),
                     profile: $crate::ffi::PROFILE.as_ptr(),
-                    name: __JACKDAW_NAME.as_ptr(),
+                    id: __JACKDAW_ID.as_ptr(),
+                    label: __JACKDAW_LABEL.as_ptr(),
+                    description: __JACKDAW_DESCRIPTION.as_ptr(),
                     ctor: __jackdaw_ctor,
                 }
             }

--- a/crates/jackdaw_api_internal/src/ffi.rs
+++ b/crates/jackdaw_api_internal/src/ffi.rs
@@ -130,7 +130,9 @@ pub struct ExtensionEntry {
     pub api_version: u32,
     pub bevy_version: *const c_char,
     pub profile: *const c_char,
-    pub name: *const c_char,
+    pub id: *const c_char,
+    pub label: *const c_char,
+    pub description: *const c_char,
     pub ctor: unsafe extern "C" fn() -> Box<dyn crate::JackdawExtension>,
 }
 

--- a/crates/jackdaw_api_internal/src/lib.rs
+++ b/crates/jackdaw_api_internal/src/lib.rs
@@ -177,7 +177,7 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
 /// Allows access to the extension's static methods via a dynamic dispatch.
 /// This is needed for when you're holding a `Box<dyn JackdawExtension>` and need to call methods that wouldn't require `self`.
 pub trait DynJackdawExtension {
-    /// Returns [`JackdawExtension::name`] via dynamic dispatch.
+    /// Returns [`JackdawExtension::id`] via dynamic dispatch.
     fn dyn_id(&self) -> String;
     /// Returns [`JackdawExtension::label`] via dynamic dispatch.
     fn dyn_label(&self) -> String;

--- a/crates/jackdaw_api_internal/src/lib.rs
+++ b/crates/jackdaw_api_internal/src/lib.rs
@@ -109,12 +109,29 @@ pub mod prelude {
 /// Trait implemented by every extension. Declares the extension's name
 /// and registration logic; the framework handles everything else.
 pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
-    /// A human-readable name for this extension. This will be displayed in UIs.
-    fn name() -> String
+    /// A unique identifier for this extension. This will be used to refer to the extension internally.
+    /// The prefix `"jackdaw."` as well as the name `jackdaw` itself are reserved for built-in extensions.
+    fn id() -> String
     where
         Self: Sized;
 
-    /// Classify this extension. Defaults to [`ExtensionKind::Custom`].
+    /// A human-readable name for this extension. This will be displayed in UIs.
+    fn label() -> String
+    where
+        Self: Sized,
+    {
+        Self::id()
+    }
+
+    /// A human-readable description for this extension. This will be displayed in UIs.
+    fn description() -> String
+    where
+        Self: Sized,
+    {
+        "".to_string()
+    }
+
+    /// Classify this extension. Defaults to [`ExtensionKind::Regular`].
     ///
     /// The Extensions dialog reads this to split the list into Built-in
     /// and Custom sections. Reserved as a future hook for marketplace
@@ -123,7 +140,7 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
     where
         Self: Sized,
     {
-        ExtensionKind::Custom
+        ExtensionKind::Regular
     }
 
     /// Hook for one-time BEI input-context registration.
@@ -161,18 +178,29 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
 /// This is needed for when you're holding a `Box<dyn JackdawExtension>` and need to call methods that wouldn't require `self`.
 pub trait DynJackdawExtension {
     /// Returns [`JackdawExtension::name`] via dynamic dispatch.
-    fn dyn_name(&self) -> String;
+    fn dyn_id(&self) -> String;
+    /// Returns [`JackdawExtension::label`] via dynamic dispatch.
+    fn dyn_label(&self) -> String;
     /// Returns [`JackdawExtension::kind`] via dynamic dispatch.
     fn dyn_kind(&self) -> ExtensionKind;
+    /// Returns [`JackdawExtension::description`] via dynamic dispatch.
+    fn dyn_description(&self) -> String;
     /// Registers input contexts for this extension.
     fn dyn_register_input_context(&self, app: &mut App);
 }
 
 impl<T: JackdawExtension> DynJackdawExtension for T {
-    fn dyn_name(&self) -> String {
-        T::name()
+    fn dyn_id(&self) -> String {
+        T::id()
     }
 
+    fn dyn_label(&self) -> String {
+        T::label()
+    }
+
+    fn dyn_description(&self) -> String {
+        T::description()
+    }
     fn dyn_kind(&self) -> ExtensionKind {
         T::kind()
     }

--- a/crates/jackdaw_api_internal/src/lifecycle.rs
+++ b/crates/jackdaw_api_internal/src/lifecycle.rs
@@ -217,6 +217,9 @@ struct CatalogEntry {
 /// Jackdaw-shipped feature areas and third-party extensions can be
 /// presented separately. Extensions declare their own kind via
 /// [`crate::JackdawExtension::kind`]; registration captures it.
+///
+/// Defaults to [`ExtensionKind::Regular`]. [`ExtensionKind::Builtin`] is reserved
+/// for extensions shipped inside the editor binary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExtensionKind {
     /// Ships with Jackdaw as a core feature area (scene tree, inspector,

--- a/crates/jackdaw_api_internal/src/lifecycle.rs
+++ b/crates/jackdaw_api_internal/src/lifecycle.rs
@@ -208,6 +208,8 @@ pub struct ExtensionCatalog {
 
 struct CatalogEntry {
     ctor: ExtensionCtor,
+    label: String,
+    description: String,
     kind: ExtensionKind,
 }
 
@@ -222,22 +224,29 @@ pub enum ExtensionKind {
     Builtin,
     /// Everything else: example extensions bundled for demonstration,
     /// third-party extensions loaded from disk, user-authored addons.
-    Custom,
+    Regular,
 }
 
 impl ExtensionCatalog {
     /// Register a constructor with its declared kind. Most callers
     /// should use [`App::register_extension`] instead, which handles BEI
     /// context registration.
-    pub(crate) fn register<F>(&mut self, name: impl Into<String>, kind: ExtensionKind, ctor: F)
-    where
-        F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
-    {
-        self.entries.insert(
-            name.into(),
+    fn register(&mut self, id: impl Into<String>, entry: CatalogEntry) {
+        self.entries.insert(id.into(), entry);
+    }
+
+    /// Convenience method for calling [`register`] on a known type.
+    fn register_generic<T: crate::JackdawExtension>(
+        &mut self,
+        ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
+    ) {
+        self.register(
+            T::id(),
             CatalogEntry {
+                kind: T::kind(),
                 ctor: Arc::new(ctor),
-                kind,
+                label: T::label(),
+                description: T::description(),
             },
         );
     }
@@ -250,12 +259,17 @@ impl ExtensionCatalog {
         self.entries.keys().map(|s| s.as_str())
     }
 
-    /// Iterate names with their declared [`ExtensionKind`]. Useful for
+    /// Iterate IDs with their declared [`ExtensionKind`]. Useful for
     /// grouping the Extensions dialog into Built-in and Custom sections.
-    pub fn iter_with_kind(&self) -> impl Iterator<Item = (&str, ExtensionKind)> {
-        self.entries
-            .iter()
-            .map(|(name, entry)| (name.as_str(), entry.kind))
+    pub fn iter_with_content(&self) -> impl Iterator<Item = (&str, &str, &str, ExtensionKind)> {
+        self.entries.iter().map(|(id, entry)| {
+            (
+                id.as_str(),
+                entry.label.as_str(),
+                entry.description.as_str(),
+                entry.kind,
+            )
+        })
     }
 
     /// Look up the declared [`ExtensionKind`] for a registered name.
@@ -316,10 +330,10 @@ impl ExtensionAppExt for App {
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self {
+        T::register_input_context(self);
         self.world_mut()
             .resource_mut::<ExtensionCatalog>()
-            .register(T::name(), T::kind(), ctor);
-        T::register_input_context(self);
+            .register_generic::<T>(ctor);
         self
     }
 
@@ -328,14 +342,24 @@ impl ExtensionAppExt for App {
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self {
         let sample = ctor();
-        let name = sample.dyn_name();
+        let id = sample.dyn_id();
+        let label = sample.dyn_label();
+        let description = sample.dyn_description();
         let kind = sample.dyn_kind();
         sample.dyn_register_input_context(self);
         drop(sample);
 
         self.world_mut()
             .resource_mut::<ExtensionCatalog>()
-            .register(name, kind, ctor);
+            .register(
+                id,
+                CatalogEntry {
+                    ctor: Arc::new(ctor),
+                    label,
+                    description,
+                    kind,
+                },
+            );
         self
     }
 }
@@ -383,7 +407,7 @@ pub fn load_static_extension(
     world: &mut World,
     extension: Box<dyn crate::JackdawExtension>,
 ) -> Entity {
-    let name = extension.dyn_name();
+    let name = extension.dyn_id();
     info!("Loading extension: {}", name);
 
     let extension_entity = world.spawn(Extension { name }).id();
@@ -421,20 +445,28 @@ pub fn disable_extension(world: &mut World, name: &str) -> bool {
 pub(crate) struct StoredExtension(pub(crate) Box<dyn crate::JackdawExtension>);
 
 /// Register a dylib-loaded extension into a running editor's catalog.
-/// The dylib loader uses this after reading `name` and `kind` from
-/// the dylib's entry metadata. Operates on `&mut World` (not `&mut
-/// App`) because installs happen post-startup.
+/// The dylib loader uses this after reading the dylib's entry metadata.
+/// Operates on `&mut World` (not `&mut App`) because installs happen post-startup.
 pub fn register_dylib_extension<F>(
     world: &mut World,
-    name: impl Into<String>,
+    id: impl Into<String>,
+    label: impl Into<String>,
+    description: impl Into<String>,
     kind: ExtensionKind,
     ctor: F,
 ) where
     F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
 {
-    world
-        .resource_mut::<ExtensionCatalog>()
-        .register(name, kind, ctor);
+    // FIXME: what about BEI contexts? Where are they added?
+    world.resource_mut::<ExtensionCatalog>().register(
+        id,
+        CatalogEntry {
+            ctor: Arc::new(ctor),
+            label: label.into(),
+            description: description.into(),
+            kind,
+        },
+    );
 }
 
 /// Keep `OperatorIndex` in sync when an operator entity is spawned.

--- a/crates/jackdaw_api_internal/src/lifecycle.rs
+++ b/crates/jackdaw_api_internal/src/lifecycle.rs
@@ -238,7 +238,7 @@ impl ExtensionCatalog {
         self.entries.insert(id.into(), entry);
     }
 
-    /// Convenience method for calling [`register`] on a known type.
+    /// Convenience method for calling [`ExtensionCatalog::register`] on a known type.
     fn register_generic<T: crate::JackdawExtension>(
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,

--- a/crates/jackdaw_loader/src/compat.rs
+++ b/crates/jackdaw_loader/src/compat.rs
@@ -57,7 +57,7 @@ pub fn verify_compat(entry: &ExtensionEntry) -> Result<(), CompatError> {
         entry.api_version,
         entry.bevy_version,
         entry.profile,
-        entry.name,
+        entry.id,
     )
 }
 

--- a/crates/jackdaw_loader/src/lib.rs
+++ b/crates/jackdaw_loader/src/lib.rs
@@ -211,7 +211,7 @@ impl LoadedKind {
 /// gets reopened from its final destination.
 pub fn peek_kind(path: &Path) -> Result<LoadedKind, LoadError> {
     match open_and_verify(path)? {
-        OpenedDylib::Extension { name, .. } => Ok(LoadedKind::Extension(name)),
+        OpenedDylib::Extension { id: name, .. } => Ok(LoadedKind::Extension(name)),
         OpenedDylib::Game { name, .. } => Ok(LoadedKind::Game(name)),
     }
 }
@@ -339,7 +339,9 @@ fn is_dylib(path: &Path) -> bool {
 enum OpenedDylib {
     Extension {
         lib: libloading::Library,
-        name: String,
+        id: String,
+        label: String,
+        description: String,
         ctor: unsafe extern "C" fn() -> Box<dyn jackdaw_api_internal::JackdawExtension>,
     },
     Game {
@@ -409,17 +411,22 @@ fn open_and_verify(path: &Path) -> Result<OpenedDylib, LoadError> {
 
     compat::verify_compat(&entry)?;
 
-    // SAFETY: `verify_compat` rejected null; the library stays
-    // alive at least until `lib` is dropped by the caller.
-    let name_cstr = unsafe { CStr::from_ptr(entry.name) };
-    let name = name_cstr
-        .to_str()
-        .map_err(|_| LoadError::InvalidName)?
-        .to_owned();
+    let read_cstr = |field| -> Result<String, LoadError> {
+        // SAFETY: `verify_compat` rejected null; the library stays
+        // alive at least until `lib` is dropped by the caller.
+        let id_ctstr = unsafe { CStr::from_ptr(field) };
+        let owned = id_ctstr
+            .to_str()
+            .map_err(|_| LoadError::InvalidName)?
+            .to_owned();
+        Ok(owned)
+    };
 
     Ok(OpenedDylib::Extension {
         lib,
-        name,
+        id: read_cstr(entry.id)?,
+        label: read_cstr(entry.label)?,
+        description: read_cstr(entry.description)?,
         ctor: entry.ctor,
     })
 }
@@ -431,7 +438,15 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
     // while still holding it on our side of ownership.
     let lib_and_kind = open_and_verify_keep_lib(path)?;
     match lib_and_kind {
-        (lib, OpenedKind::Extension { name, ctor }) => {
+        (
+            lib,
+            OpenedKind::Extension {
+                id,
+                label,
+                description,
+                ctor,
+            },
+        ) => {
             // Run the per-dylib reflect registrar against our registry
             // BEFORE handing the library off. Uses the exported
             // `REFLECT_REGISTER_SYMBOL` (if present); absent on older
@@ -449,7 +464,9 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
 
             jackdaw_api_internal::lifecycle::register_dylib_extension(
                 app.world_mut(),
-                &name,
+                &id,
+                label,
+                description,
                 kind,
                 move || {
                     // SAFETY: the dylib stays loaded because its
@@ -471,7 +488,7 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
             // the game to start querying.
             register_derived_component_ids(app.world_mut());
 
-            Ok(LoadedKind::Extension(name))
+            Ok(LoadedKind::Extension(id))
         }
         (
             lib,
@@ -556,7 +573,15 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
 pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, LoadError> {
     let lib_and_kind = open_and_verify_keep_lib(path)?;
     match lib_and_kind {
-        (lib, OpenedKind::Extension { name, ctor }) => {
+        (
+            lib,
+            OpenedKind::Extension {
+                id: name,
+                label,
+                description,
+                ctor,
+            },
+        ) => {
             // Already-registered extensions come through this path
             // when the user re-installs a rebuild. Don't double-
             // register; registering the same extension twice produces
@@ -588,6 +613,8 @@ pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, Load
             jackdaw_api_internal::lifecycle::register_dylib_extension(
                 world,
                 &name,
+                label,
+                description,
                 kind,
                 move || unsafe { ctor() },
             );
@@ -661,7 +688,9 @@ pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, Load
 #[allow(improper_ctypes_definitions)]
 enum OpenedKind {
     Extension {
-        name: String,
+        id: String,
+        label: String,
+        description: String,
         ctor: unsafe extern "C" fn() -> Box<dyn jackdaw_api_internal::JackdawExtension>,
     },
     Game {
@@ -677,9 +706,21 @@ enum OpenedKind {
 /// into `LoadedDylibs`.
 fn open_and_verify_keep_lib(path: &Path) -> Result<(libloading::Library, OpenedKind), LoadError> {
     match open_and_verify(path)? {
-        OpenedDylib::Extension { lib, name, ctor } => {
-            Ok((lib, OpenedKind::Extension { name, ctor }))
-        }
+        OpenedDylib::Extension {
+            lib,
+            id,
+            label,
+            description,
+            ctor,
+        } => Ok((
+            lib,
+            OpenedKind::Extension {
+                id,
+                label,
+                description,
+                ctor,
+            },
+        )),
         OpenedDylib::Game {
             lib,
             name,

--- a/examples/embedded_game.rs
+++ b/examples/embedded_game.rs
@@ -3,7 +3,7 @@
 //! Demonstrates the Fyrox-style / embedded-editor shape: Jackdaw
 //! linked into the binary as a library, the user's game plugin
 //! registered statically through
-//! [`EditorPlugin::with_extension`]. No dylib loading, no
+//! [`ExtensionPlugin::with_extension`]. No dylib loading, no
 //! rustc-wrapper, no `.cargo/config.toml` stitching — one
 //! `cargo run --example embedded_game` and you're in the editor with
 //! `MyGamePlugin` already active.

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -105,7 +105,7 @@ fn hello_time(_: In<OperatorParameters>, time: Res<Time>) -> OperatorResult {
 // which is harmless.
 jackdaw_api::export_extension!(
     "sample",
-    "Sample Extension",
-    "A sample extension that logs hello messages",
+    "Example Extension",
+    "Just a tiny example extension :)",
     || Box::new(SampleExtension)
 );

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -16,11 +16,20 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
+#[derive(Default)]
 pub struct SampleExtension;
 
 impl JackdawExtension for SampleExtension {
-    fn name() -> String {
+    fn id() -> String {
         "sample".to_string()
+    }
+
+    fn label() -> String {
+        "Example Extension".to_string()
+    }
+
+    fn description() -> String {
+        "Just a tiny example extension :)".to_string()
     }
 
     fn register_input_context(app: &mut App) {
@@ -94,4 +103,9 @@ fn hello_time(_: In<OperatorParameters>, time: Res<Time>) -> OperatorResult {
 // cdylib output needs it; the rlib output that's statically
 // linked into the prebuilt binary just carries a dead symbol,
 // which is harmless.
-jackdaw_api::export_extension!("sample", || Box::new(SampleExtension));
+jackdaw_api::export_extension!(
+    "sample",
+    "Sample Extension",
+    "A sample extension that logs hello messages",
+    || Box::new(SampleExtension)
+);

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -17,8 +17,12 @@ use jackdaw_api::prelude::*;
 pub struct ViewableCameraExtension;
 
 impl JackdawExtension for ViewableCameraExtension {
-    fn name() -> String {
+    fn id() -> String {
         "viewable_camera".to_string()
+    }
+
+    fn label() -> String {
+        "Viewable Camera".to_string()
     }
 
     fn register_input_context(app: &mut App) {

--- a/src/builtin_extensions.rs
+++ b/src/builtin_extensions.rs
@@ -14,8 +14,12 @@ use jackdaw_feathers::icons::Icon;
 pub struct CoreWindowsExtension;
 
 impl JackdawExtension for CoreWindowsExtension {
-    fn name() -> String {
-        "core_windows".to_string()
+    fn id() -> String {
+        "jackdaw.core_windows".to_string()
+    }
+
+    fn label() -> String {
+        "Core Windows".to_string()
     }
 
     fn kind() -> ExtensionKind {
@@ -89,8 +93,12 @@ impl JackdawExtension for CoreWindowsExtension {
 pub struct AssetBrowserExtension;
 
 impl JackdawExtension for AssetBrowserExtension {
-    fn name() -> String {
-        "asset_browser".to_string()
+    fn id() -> String {
+        "jackdaw.asset_browser".to_string()
+    }
+
+    fn label() -> String {
+        "Asset Browser".to_string()
     }
 
     fn kind() -> ExtensionKind {
@@ -126,8 +134,12 @@ impl JackdawExtension for AssetBrowserExtension {
 pub struct TimelineExtension;
 
 impl JackdawExtension for TimelineExtension {
-    fn name() -> String {
-        "timeline".to_string()
+    fn id() -> String {
+        "jackdaw.timeline".to_string()
+    }
+
+    fn label() -> String {
+        "Timeline".to_string()
     }
 
     fn kind() -> ExtensionKind {
@@ -153,8 +165,12 @@ impl JackdawExtension for TimelineExtension {
 pub struct TerminalExtension;
 
 impl JackdawExtension for TerminalExtension {
-    fn name() -> String {
-        "terminal".to_string()
+    fn id() -> String {
+        "jackdaw.terminal".to_string()
+    }
+
+    fn label() -> String {
+        "Terminal".to_string()
     }
 
     fn kind() -> ExtensionKind {
@@ -197,8 +213,12 @@ impl JackdawExtension for TerminalExtension {
 pub struct InspectorExtension;
 
 impl JackdawExtension for InspectorExtension {
-    fn name() -> String {
-        "inspector".to_string()
+    fn id() -> String {
+        "jackdaw.inspector".to_string()
+    }
+
+    fn label() -> String {
+        "Inspector".to_string()
     }
 
     fn kind() -> ExtensionKind {

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -7,7 +7,7 @@ use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
 /// [`crate::extensions_config::REQUIRED_EXTENSIONS`] and the
 /// Extensions dialog can refer to it without duplicating the
 /// literal string.
-pub const CORE_EXTENSION_NAME: &str = "jackdaw_core";
+pub const CORE_EXTENSION_ID: &str = "jackdaw.core";
 
 pub(super) fn plugin(app: &mut App) {
     app.register_extension::<JackdawCoreExtension>();
@@ -17,9 +17,18 @@ pub(super) fn plugin(app: &mut App) {
 pub struct JackdawCoreExtension;
 
 impl JackdawExtension for JackdawCoreExtension {
-    fn name() -> String {
-        CORE_EXTENSION_NAME.to_string()
+    fn id() -> String {
+        CORE_EXTENSION_ID.to_string()
     }
+
+    fn label() -> String {
+        "Jackdaw Core Functionality".to_string()
+    }
+
+    fn description() -> String {
+        "Important functionality for the Jackdaw editor. This extension is always loaded and cannot be disabled.".to_string()
+    }
+
     fn kind() -> ExtensionKind {
         ExtensionKind::Builtin
     }

--- a/src/extensions_config.rs
+++ b/src/extensions_config.rs
@@ -5,7 +5,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use bevy::prelude::*;
+use bevy::{platform::collections::HashMap, prelude::*};
 use jackdaw_api::prelude::ExtensionKind;
 use jackdaw_api_internal::lifecycle::ExtensionCatalog;
 use serde::{Deserialize, Serialize};
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// was extracted) can't take the editor down. The Extensions dialog
 /// should also hide or lock these so users can't try to turn them
 /// off.
-pub const REQUIRED_EXTENSIONS: &[&str] = &[crate::core_extension::CORE_EXTENSION_NAME];
+pub const REQUIRED_EXTENSIONS: &[&str] = &[crate::core_extension::CORE_EXTENSION_ID];
 
 /// True if the named extension is load-bearing and must not be
 /// user-toggleable.
@@ -69,16 +69,16 @@ pub fn write_enabled_list(enabled: &[String]) {
 pub fn resolve_enabled_list(world: &World) -> Vec<String> {
     let catalog = world.resource::<ExtensionCatalog>();
     let available: Vec<String> = catalog.iter().map(|s| s.to_string()).collect();
-    let builtins: HashSet<String> = catalog
-        .iter_with_kind()
-        .filter(|(_, kind)| *kind == ExtensionKind::Builtin)
-        .map(|(name, _)| name.to_string())
+    let builtins: HashMap<String, String> = catalog
+        .iter_with_content()
+        .filter(|(.., kind)| *kind == ExtensionKind::Builtin)
+        .map(|(id, label, ..)| (id.to_string(), label.to_string()))
         .collect();
 
     let mut resolved = match read_enabled_list() {
         Some(list) => {
             let on_disk: HashSet<String> = list.into_iter().collect();
-            let has_any_builtin = builtins.iter().any(|name| on_disk.contains(name));
+            let has_any_builtin = builtins.keys().any(|id| on_disk.contains(id));
             if !has_any_builtin {
                 available.clone()
             } else {

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -44,7 +44,7 @@ struct ExtensionsDialogOpen(bool);
 /// can look up which one to toggle.
 #[derive(Component)]
 struct ExtensionCheckbox {
-    extension_name: String,
+    extension_id: String,
 }
 
 /// Marks the "Install from file..." button. A single click observer
@@ -119,21 +119,25 @@ fn populate_extensions_dialog(
     // from each extension's declared `ExtensionKind`.
     let enabled_names: std::collections::HashSet<String> =
         loaded.iter().map(|e| e.name.clone()).collect();
-    let mut builtin_rows: Vec<(String, bool)> = Vec::new();
-    let mut custom_rows: Vec<(String, bool)> = Vec::new();
-    for (name, kind) in catalog.iter_with_kind() {
+    let mut builtin_rows: Vec<(String, String, bool)> = Vec::new();
+    let mut custom_rows: Vec<(String, String, bool)> = Vec::new();
+    for (id, label, _description, kind) in catalog.iter_with_content() {
         // Required extensions are load-bearing (the editor panics
         // without them), so they're not user-toggleable. Omit them
         // from the dialog entirely rather than rendering a locked
         // checkbox — they're implementation detail, not a user
         // choice.
-        if extensions_config::is_required(name) {
+        if extensions_config::is_required(id) {
             continue;
         }
-        let row = (name.to_string(), enabled_names.contains(name));
+        let row = (
+            id.to_string(),
+            label.to_string(),
+            enabled_names.contains(id),
+        );
         match kind {
             ExtensionKind::Builtin => builtin_rows.push(row),
-            ExtensionKind::Custom => custom_rows.push(row),
+            ExtensionKind::Regular => custom_rows.push(row),
         }
     }
     builtin_rows.sort_by(|a, b| a.0.cmp(&b.0));
@@ -153,12 +157,11 @@ fn populate_extensions_dialog(
         .id();
 
     spawn_section_header(&mut commands, list, "Built-in");
-    for (name, checked) in builtin_rows {
-        let label = prettify(&name);
+    for (id, label, checked) in builtin_rows {
         commands.spawn((
             ChildOf(list),
             ExtensionCheckbox {
-                extension_name: name.clone(),
+                extension_id: id.clone(),
             },
             checkbox(CheckboxProps::new(label).checked(checked), &font, &ifont),
         ));
@@ -182,12 +185,11 @@ fn populate_extensions_dialog(
             )],
         ));
     } else {
-        for (name, checked) in custom_rows {
-            let label = prettify(&name);
+        for (id, label, checked) in custom_rows {
             commands.spawn((
                 ChildOf(list),
                 ExtensionCheckbox {
-                    extension_name: name.clone(),
+                    extension_id: id.clone(),
                 },
                 checkbox(CheckboxProps::new(label).checked(checked), &font, &ifont),
             ));
@@ -282,7 +284,7 @@ fn on_extension_checkbox_commit(
     let Ok(cb) = checkboxes.get(event.entity) else {
         return;
     };
-    let name = cb.extension_name.clone();
+    let name = cb.extension_id.clone();
     let checked = event.checked;
 
     // Belt-and-suspenders: required extensions shouldn't have a
@@ -605,21 +607,4 @@ fn classify_for_install(path: &std::path::Path) -> InstallTarget {
         Ok(jackdaw_loader::LoadedKind::Game(_)) => InstallTarget::Game,
         _ => InstallTarget::Extension,
     }
-}
-
-/// Convert `"jackdaw.asset_browser"` → `"Asset Browser"`.
-fn prettify(name: &str) -> String {
-    let stripped = name.strip_prefix("jackdaw.").unwrap_or(name);
-    let mut out = String::new();
-    for (i, part) in stripped.split(&['_', '.'][..]).enumerate() {
-        if i > 0 {
-            out.push(' ');
-        }
-        let mut chars = part.chars();
-        if let Some(c) = chars.next() {
-            out.extend(c.to_uppercase());
-            out.push_str(chars.as_str());
-        }
-    }
-    out
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,11 +184,17 @@ impl EditorPlugin {
     }
 
     /// Register a custom extension. May be called any number of times.
+    pub fn with_extension<T: JackdawExtension + Default>(mut self) -> Self {
+        self.extensions
+            .push(std::sync::Arc::new(|| Box::new(T::default())));
+        self
+    }
+
+    /// Like [`EditorPlugin::with_extension`], but takes a constructor function
+    /// instead of a type implementing `JackdawExtension`.
     ///
-    /// The extension's declared name comes from `JackdawExtension::name()`;
-    /// the `_name` argument is kept for backwards compatibility with the
-    /// pre-1.0 API and is ignored.
-    pub fn with_extension<F>(mut self, _name: impl Into<String>, ctor: F) -> Self
+    /// See also [`EditorPlugin::with_extension_ctor`].
+    pub fn with_extension_ctor<F>(mut self, ctor: F) -> Self
     where
         F: Fn() -> Box<dyn JackdawExtension> + Send + Sync + 'static,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,10 +353,8 @@ impl ExtensionPlugin {
         self
     }
 
-    /// Like [`EditorPlugin::with_extension`], but takes a constructor function
-    /// instead of a type implementing `JackdawExtension`.
-    ///
-    /// See also [`EditorPlugin::with_extension_ctor`].
+    /// Like [`ExtensionPlugin::with_extension`], but takes a constructor function
+    /// instead of a type implementing [`JackdawExtension`].
     pub fn with_extension_ctor<F>(mut self, ctor: F) -> Self
     where
         F: Fn() -> Box<dyn JackdawExtension> + Send + Sync + 'static,

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,10 +85,8 @@ fn editor_plugin() -> EditorPlugin {
 
     #[cfg(feature = "dev")]
     let plugin = plugin
-        .with_extension("sample", || Box::new(sample_extension::SampleExtension))
-        .with_extension("viewable_camera", || {
-            Box::new(viewable_camera_extension::ViewableCameraExtension)
-        });
+        .with_extension::<sample_extension::SampleExtension>()
+        .with_extension::<viewable_camera_extension::ViewableCameraExtension>();
 
     plugin
 }

--- a/tests/fixtures/test_fixture_extension/src/lib.rs
+++ b/tests/fixtures/test_fixture_extension/src/lib.rs
@@ -13,7 +13,7 @@ use jackdaw_api::prelude::*;
 pub struct TestFixtureExtension;
 
 impl JackdawExtension for TestFixtureExtension {
-    fn name() -> String {
+    fn id() -> String {
         "test_fixture".to_string()
     }
 
@@ -28,4 +28,9 @@ fn spawn_marker(_: In<OperatorParameters>, mut commands: Commands) -> OperatorRe
     OperatorResult::Finished
 }
 
-export_extension!("test_fixture", || Box::new(TestFixtureExtension));
+export_extension!(
+    "test_fixture",
+    "Test Fixture",
+    "A good old test fixture",
+    || Box::new(TestFixtureExtension)
+);

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -84,7 +84,7 @@ impl SampleExtension {
 }
 
 impl JackdawExtension for SampleExtension {
-    fn name() -> String {
+    fn id() -> String {
         "sample".to_string()
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,7 @@ impl<T: Operator> Default for IntegrationTestsExtension<T> {
 }
 
 impl<T: Operator + Send + Sync> JackdawExtension for IntegrationTestsExtension<T> {
-    fn name() -> String {
+    fn id() -> String {
         "Integration Tests".to_string()
     }
 


### PR DESCRIPTION
targets https://github.com/jbuehler23/jackdaw/pull/182 for easier merging :)

- NAME is now split into ID and LABEL
- also added DESCRIPTION, unused for now
- made `with_extension` a generic, much simpler :)
- renamed the old `with_extension` to `with_extension_ctor`
- removed the backwards-compatibility from `with_extension_ctor`, seems useless at this point

