### PR TITLE
Use dynamic Bevy in dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ collapsible_if = "allow"
 redundant_closure = "allow"
 
 [dev-dependencies]
+bevy = { workspace = true, features = ["dynamic_linking"] }
 jackdaw_runtime.workspace = true
 # Pulled in so cargo builds the fixture cdylib as part of the
 # workspace test-target graph. `tests/dylib_loading.rs` dlopens the


### PR DESCRIPTION
The CI machine is running out of disk space, so let's help it out by using dynamic linking in dev. This is faster for local iteration anyways.