### PR TITLE
operatorify phase 1: on_operator button helper + menu/context dispatch

### DIFF
--- a/crates/jackdaw_api_internal/src/lib.rs
+++ b/crates/jackdaw_api_internal/src/lib.rs
@@ -407,7 +407,7 @@ impl<'a> ExtensionContext<'a> {
     /// Contribute an entry to one of the editor's top-level menus
     /// (`"Add"`, `"Tools"`, etc.). Clicking the entry dispatches the
     /// referenced operator.
-    pub fn register_menu_entry(&mut self, descriptor: MenuEntryDescriptor) {
+    pub fn register_menu_entry(&mut self, descriptor: MenuEntryDescriptor) -> &mut Self {
         let ext = self.extension_entity;
         self.world.spawn((
             RegisteredMenuEntry {
@@ -417,6 +417,19 @@ impl<'a> ExtensionContext<'a> {
             },
             ChildOf(ext),
         ));
+        self
+    }
+
+    /// Convenience that registers a menu entry using `O::LABEL` and
+    /// `O::ID` from the operator type, so callers only need to supply the
+    /// menu name. Equivalent to calling
+    /// [`Self::register_menu_entry`] with a full [`MenuEntryDescriptor`].
+    pub fn menu_entry_for<O: Operator>(&mut self, menu: impl Into<String>) -> &mut Self {
+        self.register_menu_entry(MenuEntryDescriptor {
+            menu: menu.into(),
+            label: O::LABEL.to_string(),
+            operator_id: O::ID,
+        })
     }
 }
 

--- a/crates/jackdaw_api_internal/src/operator.rs
+++ b/crates/jackdaw_api_internal/src/operator.rs
@@ -49,6 +49,32 @@ pub(super) fn plugin(app: &mut App) {
 /// Extensions then bind the operator to a key via pure BEI syntax. Use
 /// BEI binding modifiers (`Press`, `Release`, `Hold`) when specific
 /// input timing is needed. See the [`jackdaw_api` documentation](crate).
+///
+/// # Registering an operator end-to-end
+///
+/// The canonical pattern inside a [`crate::JackdawExtension::register`]
+/// implementation:
+///
+/// ```ignore
+/// // 1. Register the operator (spawns `OperatorEntity` + `Fire<Op>` observer)
+/// ctx.register_operator::<PlaceCubeOp>();
+///
+/// // 2. Bind input via BEI on the extension's input context
+/// ctx.entity_mut().with_related::<ActionOf<MyInputContext>>((
+///     Action::<PlaceCubeOp>::new(),
+///     bindings![(KeyCode::KeyP, Press::default())],
+/// ));
+///
+/// // 3. Contribute a menu entry (label + id pulled from the operator)
+/// ctx.menu_entry_for::<PlaceCubeOp>("Add");
+/// ```
+///
+/// Buttons in UI code dispatch the operator by attaching a
+/// `CallOperator` component (from `jackdaw_feathers::button`), usually via
+/// `ButtonProps::call_operator("sample.place_cube")`. The editor registers
+/// a global observer that, on `ButtonClickEvent`, calls
+/// [`OperatorWorldExt::operator`] with the stored id — so no per-button
+/// click handler is needed.
 pub trait Operator: InputAction + 'static {
     const ID: &'static str;
     const LABEL: &'static str;

--- a/crates/jackdaw_feathers/src/button.rs
+++ b/crates/jackdaw_feathers/src/button.rs
@@ -1,6 +1,7 @@
 use bevy::picking::hover::Hovered;
 use bevy::prelude::*;
 use lucide_icons::Icon;
+use std::borrow::Cow;
 
 use crate::icons::EditorFont;
 use crate::tokens::{
@@ -13,6 +14,19 @@ use crate::cursor::HoverCursor;
 #[derive(EntityEvent)]
 pub struct ButtonClickEvent {
     pub entity: Entity,
+}
+
+/// Attached to a button to declare that clicking it should dispatch
+/// the operator with this id. The editor registers the dispatch
+/// observer; feathers just carries the id so widgets can declare
+/// their intent without depending on the operator API.
+#[derive(Component, Clone, Debug)]
+pub struct CallOperator(pub Cow<'static, str>);
+
+impl CallOperator {
+    pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
+        Self(id.into())
+    }
 }
 
 pub fn plugin(app: &mut App) {
@@ -136,6 +150,7 @@ struct ButtonConfig {
     left_icon: Option<Icon>,
     right_icon: Option<Icon>,
     subtitle: Option<String>,
+    call_operator: Option<Cow<'static, str>>,
     initialized: bool,
 }
 
@@ -149,6 +164,7 @@ pub struct ButtonProps {
     pub right_icon: Option<Icon>,
     pub direction: FlexDirection,
     pub subtitle: Option<String>,
+    pub call_operator: Option<Cow<'static, str>>,
 }
 
 impl ButtonProps {
@@ -184,6 +200,13 @@ impl ButtonProps {
     }
     pub fn with_subtitle(mut self, subtitle: impl Into<String>) -> Self {
         self.subtitle = Some(subtitle.into());
+        self
+    }
+    /// Dispatch an operator by id when this button is clicked. The
+    /// editor provides the observer that actually calls
+    /// `world.operator(id).call()`; feathers only stores the id.
+    pub fn call_operator(mut self, id: impl Into<Cow<'static, str>>) -> Self {
+        self.call_operator = Some(id.into());
         self
     }
 }
@@ -288,6 +311,7 @@ pub fn button(props: ButtonProps) -> impl Bundle {
         right_icon,
         direction,
         subtitle,
+        call_operator,
     } = props;
 
     (
@@ -297,6 +321,7 @@ pub fn button(props: ButtonProps) -> impl Bundle {
             left_icon,
             right_icon,
             subtitle,
+            call_operator,
             initialized: false,
         },
     )
@@ -356,6 +381,7 @@ fn setup_button(
         let right_icon = config.right_icon;
         let content = config.content.clone();
         let subtitle = config.subtitle.clone();
+        let call_operator = config.call_operator.clone();
         let variant = *variant;
         let size = *size;
         let font = font.clone();
@@ -364,6 +390,9 @@ fn setup_button(
             let Ok(mut ec) = world.get_entity_mut(entity) else {
                 return;
             };
+            if let Some(id) = call_operator {
+                ec.insert(CallOperator(id));
+            }
             ec.with_children(|parent| {
                 if let Some(icon) = left_icon {
                     parent.spawn((
@@ -465,7 +494,13 @@ fn handle_button_click(
     }
 }
 
-/// Create an icon-only button using lucide icon font
+/// Create an icon-only button using lucide icon font.
+///
+/// To dispatch an operator on click, spawn the returned bundle alongside an
+/// [`CallOperator`] component: `commands.spawn((icon_button(props, font),
+/// CallOperator::new("my.op")))`. A setter isn't provided on
+/// [`IconButtonProps`] because `icon_button` has no staging/setup system;
+/// the tuple-form keeps the API small.
 pub fn icon_button(props: IconButtonProps, icon_font: &Handle<Font>) -> impl Bundle {
     let IconButtonProps {
         icon,

--- a/crates/jackdaw_feathers/src/context_menu.rs
+++ b/crates/jackdaw_feathers/src/context_menu.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::*;
 use jackdaw_widgets::context_menu::{ContextMenuAction, ContextMenuItem};
 
-use crate::button::{ButtonClickEvent, ButtonProps, ButtonVariant, button};
+use crate::button::{ButtonClickEvent, ButtonProps, ButtonVariant, CallOperator, button};
+use crate::menu_bar::OP_ACTION_PREFIX;
 use crate::tokens;
 
 pub fn plugin(app: &mut App) {
@@ -10,12 +11,18 @@ pub fn plugin(app: &mut App) {
 
 fn on_context_menu_item_click(
     event: On<ButtonClickEvent>,
-    items: Query<&ContextMenuItem>,
+    items: Query<(&ContextMenuItem, Option<&CallOperator>)>,
     mut commands: Commands,
 ) {
-    let Ok(item) = items.get(event.entity) else {
+    let Ok((item, call_op)) = items.get(event.entity) else {
         return;
     };
+    // Items that dispatch an operator are handled by the editor-side
+    // CallOperator observer; firing ContextMenuAction here would
+    // double-dispatch.
+    if call_op.is_some() {
+        return;
+    }
     commands.trigger(ContextMenuAction {
         action: item.action.clone(),
         target_entity: item.target_entity,
@@ -23,7 +30,8 @@ fn on_context_menu_item_click(
 }
 
 /// Spawn a context menu at the given position with the given items.
-/// Each item is `(action_id, label)`.
+/// Each item is `(action_id, label)`. Actions prefixed with
+/// [`OP_ACTION_PREFIX`] are attached as [`CallOperator`] ids on the item.
 pub fn spawn_context_menu(
     commands: &mut Commands,
     position: Vec2,
@@ -51,17 +59,23 @@ pub fn spawn_context_menu(
         .id();
 
     for &(action, label) in items {
-        commands.entity(menu).with_child((
-            ContextMenuItem {
-                action: action.to_string(),
-                target_entity,
-            },
-            button(
-                ButtonProps::new(label)
-                    .with_variant(ButtonVariant::Ghost)
-                    .align_left(),
-            ),
-        ));
+        let item = ContextMenuItem {
+            action: action.to_string(),
+            target_entity,
+        };
+        let btn = button(
+            ButtonProps::new(label)
+                .with_variant(ButtonVariant::Ghost)
+                .align_left(),
+        );
+
+        if let Some(op_id) = action.strip_prefix(OP_ACTION_PREFIX) {
+            commands
+                .entity(menu)
+                .with_child((item, btn, CallOperator::new(op_id.to_string())));
+        } else {
+            commands.entity(menu).with_child((item, btn));
+        }
     }
 
     menu

--- a/crates/jackdaw_feathers/src/menu_bar.rs
+++ b/crates/jackdaw_feathers/src/menu_bar.rs
@@ -3,9 +3,15 @@ use jackdaw_widgets::menu_bar::{
     MenuAction, MenuBar, MenuBarDropdown, MenuBarDropdownItem, MenuBarItem, MenuBarState,
 };
 
-use crate::button::{ButtonClickEvent, ButtonProps, ButtonVariant, button};
+use crate::button::{ButtonClickEvent, ButtonProps, ButtonVariant, CallOperator, button};
 use crate::tokens;
 use crate::tooltip::Tooltip;
+
+/// Action strings in menu entries that start with this prefix are
+/// interpreted as operator ids; the suffix becomes the [`CallOperator`] id
+/// attached to the dropdown button so the editor dispatches through the
+/// operator API instead of firing a generic [`MenuAction`].
+pub const OP_ACTION_PREFIX: &str = "op:";
 
 pub fn plugin(app: &mut App) {
     app.add_observer(on_dropdown_item_click)
@@ -14,15 +20,21 @@ pub fn plugin(app: &mut App) {
         .add_observer(on_menu_bar_item_out);
 }
 
-/// When a dropdown item is clicked, fire the [`MenuAction`].
+/// When a dropdown item is clicked, fire the [`MenuAction`] — unless the
+/// item carries a [`CallOperator`] component, in which case the editor's
+/// operator observer will handle dispatch and a `MenuAction` would
+/// double-fire.
 fn on_dropdown_item_click(
     event: On<ButtonClickEvent>,
-    items: Query<&MenuBarDropdownItem>,
+    items: Query<(&MenuBarDropdownItem, Option<&CallOperator>)>,
     mut commands: Commands,
 ) {
-    let Ok(item) = items.get(event.entity) else {
+    let Ok((item, call_op)) = items.get(event.entity) else {
         return;
     };
+    if call_op.is_some() {
+        return;
+    }
     commands.trigger(MenuAction {
         action: item.action.clone(),
     });
@@ -227,19 +239,28 @@ fn spawn_dropdown(commands: &mut Commands, x: f32, y: f32, actions: &[(String, S
             continue;
         }
 
-        commands.entity(dropdown).with_child((
-            MenuBarDropdownItem {
-                action: action.clone(),
-            },
-            button(
-                ButtonProps::new(label.clone())
-                    .with_variant(ButtonVariant::Ghost)
-                    // TODO: add keybind as subtitle
-                    .align_left(),
-            ),
-            // TODO: show this tooltip only when the user has opted into dev stuff
-            Tooltip(action.to_string()),
-        ));
+        let item = MenuBarDropdownItem {
+            action: action.clone(),
+        };
+        let btn = button(
+            ButtonProps::new(label.clone())
+                .with_variant(ButtonVariant::Ghost)
+                // TODO: add keybind as subtitle
+                .align_left(),
+        );
+        // TODO: show this tooltip only when the user has opted into dev stuff
+        let tooltip = Tooltip(action.to_string());
+
+        if let Some(op_id) = action.strip_prefix(OP_ACTION_PREFIX) {
+            commands.entity(dropdown).with_child((
+                item,
+                btn,
+                tooltip,
+                CallOperator::new(op_id.to_string()),
+            ));
+        } else {
+            commands.entity(dropdown).with_child((item, btn, tooltip));
+        }
     }
 
     dropdown

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
+use jackdaw_feathers::button::{ButtonClickEvent, CallOperator};
 
 /// Catalog name of the Core extension. Exported so
 /// [`crate::extensions_config::REQUIRED_EXTENSIONS`] and the
@@ -10,7 +11,38 @@ use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
 pub const CORE_EXTENSION_ID: &str = "jackdaw.core";
 
 pub(super) fn plugin(app: &mut App) {
-    app.register_extension::<JackdawCoreExtension>();
+    app.register_extension::<JackdawCoreExtension>()
+        .add_observer(dispatch_call_operator);
+}
+
+/// When a button carrying an [`CallOperator`] component is clicked,
+/// dispatch the referenced operator. This is the single editor-wide
+/// glue that makes `ButtonProps::call_operator(id)` and menu/context-menu
+/// `op:`-prefixed entries (which also attach `CallOperator` via feathers)
+/// actually run the operator. Without this, `CallOperator` is inert.
+///
+/// The feathers-level click handlers for menu/context items skip
+/// firing their own `MenuAction`/`ContextMenuAction` events when they
+/// see `CallOperator`, so this observer is the sole dispatch path for
+/// those items and won't double-fire.
+fn dispatch_call_operator(
+    event: On<ButtonClickEvent>,
+    call_op: Query<&CallOperator>,
+    mut commands: Commands,
+) {
+    let Ok(CallOperator(id)) = call_op.get(event.entity) else {
+        return;
+    };
+    let id = id.clone();
+    commands.queue(move |world: &mut World| {
+        world
+            .operator(id)
+            .settings(CallOperatorSettings {
+                execution_context: ExecutionContext::Invoke,
+                creates_history_entry: true,
+            })
+            .call()
+    });
 }
 
 #[derive(Default)]

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
 
 use crate::util::OperatorResultExt as _;
 mod util;
@@ -20,11 +19,7 @@ fn smoke_test_headless_update() {
 #[test]
 fn can_run_extension() {
     let mut app = util::headless_app();
-    app.register_extension::<SampleExtension>();
-    app.finish();
-    // first update sets the extension up
-    // todo: maybe do plugin setup in `Startup` so that jackdaw is actually ready in the first frame?
-    app.update();
+    util::register_and_enable_extension::<SampleExtension>(&mut app);
     for _ in 0..10 {
         app.world_mut()
             .operator(SampleExtension::SPAWN)
@@ -38,9 +33,7 @@ fn can_run_extension() {
 #[test]
 fn can_call_operator() {
     let mut app = util::headless_app();
-    app.register_extension::<SampleExtension>();
-    app.finish();
-    app.update();
+    util::register_and_enable_extension::<SampleExtension>(&mut app);
 
     let amount_of_panels = app
         .world_mut()
@@ -63,9 +56,7 @@ fn can_call_operator() {
 #[test]
 fn can_pass_params_to_operator() {
     let mut app = util::headless_app();
-    app.register_extension::<SampleExtension>();
-    app.finish();
-    app.update();
+    util::register_and_enable_extension::<SampleExtension>(&mut app);
     app.world_mut()
         .operator(SampleExtension::CHECK_PARAMS)
         .param("foo", "bar")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
 
 use crate::util::OperatorResultExt as _;
 mod util;
@@ -22,9 +21,7 @@ fn integration_test_one(_: In<OperatorParameters>) -> OperatorResult {
 
 fn run_test<T: Operator + Send + Sync>() {
     let mut app = util::headless_app();
-    app.register_extension::<IntegrationTestsExtension<T>>();
-    app.finish();
-    app.update();
+    util::register_and_enable_extension::<IntegrationTestsExtension<T>>(&mut app);
     app.world_mut()
         .operator(ID)
         .call()

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -7,6 +7,7 @@ use bevy::{
     winit::WinitPlugin,
 };
 use jackdaw::prelude::*;
+use jackdaw_api_internal::lifecycle::{ExtensionAppExt as _, enable_extension};
 
 pub fn headless_app() -> App {
     let mut app = App::new();
@@ -27,6 +28,38 @@ pub fn headless_app() -> App {
         include_env_dir: false,
     }));
     app
+}
+
+/// Register `T` in the catalog AND enable it.
+///
+/// `register_extension` alone only adds the extension to the catalog; the
+/// editor's normal startup enables whatever `~/.config/jackdaw/extensions.json`
+/// lists, plus [`REQUIRED_EXTENSIONS`](jackdaw::extensions_config::REQUIRED_EXTENSIONS).
+/// Tests don't populate the on-disk config, so custom test extensions would
+/// otherwise stay disabled and their operators wouldn't resolve.
+///
+/// This helper runs the usual `register → finish → first-update` dance, then
+/// force-enables the extension explicitly so `app.world_mut().operator(id)`
+/// can find it. It also ticks one more frame so any setup observers (operator
+/// index, BEI context attachment) have settled before the caller runs
+/// assertions.
+#[expect(clippy::allow_attributes, reason = "Some tests use this")]
+#[allow(
+    dead_code,
+    reason = "shared across integration test binaries; not every test file calls it."
+)]
+pub fn register_and_enable_extension<T: JackdawExtension + Default>(app: &mut App) {
+    app.register_extension::<T>();
+    app.finish();
+    // First update runs Startup (which enables whatever the on-disk config
+    // lists — typically nothing relevant to the test).
+    app.update();
+    // Force-enable the test extension; idempotent if it was already enabled
+    // (returns `None` in that case).
+    enable_extension(app.world_mut(), &T::id());
+    // Let any on-add observers for the operator entities settle before the
+    // caller starts asserting.
+    app.update();
 }
 
 #[expect(clippy::allow_attributes, reason = "Some tests use this")]


### PR DESCRIPTION
Phase 1 of #194. Lays ergonomic infrastructure so later phases can port a button or menu entry to an operator with a one-line setter. No behavior change.

Also fixes the headless and integration test suites, which were broken on main: registered test extensions weren't being enabled, so every operator-calling test panicked with `UnknownId`.