### PR TITLE
Make extensions a bit safer

### DIFF
--- a/book/src/developer-guide/extending-the-editor.md
+++ b/book/src/developer-guide/extending-the-editor.md
@@ -112,9 +112,10 @@ dylib path entirely:
 // your_editor/src/main.rs
 fn main() {
     App::new()
-        .add_plugins(jackdaw::EditorPlugins::default()
-            .with_extension("my_tool", || Box::new())
-            .build())
+        .add_plugins(
+            jackdaw::EditorPlugins::default()
+                .set(ExtensionPlugin::new().with_extension::<MyExtension>())
+        )
         .run();
 }
 ```

--- a/book/src/developer-guide/extending-the-editor.md
+++ b/book/src/developer-guide/extending-the-editor.md
@@ -113,7 +113,7 @@ dylib path entirely:
 fn main() {
     App::new()
         .add_plugins(jackdaw::EditorPlugins::default()
-            .with_extension("my_tool", || Box::new(MyTool))
+            .with_extension("my_tool", || Box::new())
             .build())
         .run();
 }

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -34,8 +34,8 @@ use jackdaw_dylib as _;
 // --- Extension authoring surface ---
 
 pub use jackdaw_api_internal::{
-    DynJackdawExtension, ExtensionContext, ExtensionPoint, HierarchyWindow, InspectorWindow,
-    JackdawExtension, MenuEntryDescriptor, PanelContext, SectionBuildFn, WindowDescriptor,
+    ExtensionContext, ExtensionPoint, HierarchyWindow, InspectorWindow, JackdawExtension,
+    MenuEntryDescriptor, PanelContext, SectionBuildFn, WindowDescriptor,
 };
 
 pub use jackdaw_api_internal::lifecycle::ExtensionKind;
@@ -94,9 +94,9 @@ pub mod prelude {
     pub use crate::pie::PlayState;
     pub use crate::runtime::{GameApp, GamePlugin, GameRegistered, GameRegistry, GameSystems};
     pub use crate::{
-        DynJackdawExtension, ExtensionContext, ExtensionKind, ExtensionPoint, HierarchyWindow,
-        InspectorWindow, JackdawExtension, MenuEntryDescriptor, PanelContext, SectionBuildFn,
-        WindowDescriptor, operator,
+        ExtensionContext, ExtensionKind, ExtensionPoint, HierarchyWindow, InspectorWindow,
+        JackdawExtension, MenuEntryDescriptor, PanelContext, SectionBuildFn, WindowDescriptor,
+        operator,
     };
 
     /// Helper [`SystemParam`](bevy::ecs::system::SystemParam) for

--- a/crates/jackdaw_api_internal/src/export.rs
+++ b/crates/jackdaw_api_internal/src/export.rs
@@ -52,38 +52,37 @@
 /// dylib would fail at link time anyway (duplicate symbol).
 #[macro_export]
 macro_rules! export_extension {
-    ($id:expr, $label:expr, $description:expr, $ctor:expr) => {
+    ($extension:ident) => {
         const _: () = {
-            const __JACKDAW_ID: &::core::ffi::CStr =
-                match ::core::ffi::CStr::from_bytes_with_nul(::core::concat!($id, "\0").as_bytes())
-                {
-                    ::core::result::Result::Ok(s) => s,
-                    ::core::result::Result::Err(_) => {
-                        ::core::panic!("extension ID contains interior NUL byte")
-                    }
-                };
-            const __JACKDAW_LABEL: &::core::ffi::CStr =
-                match ::core::ffi::CStr::from_bytes_with_nul(::core::concat!($label, "\0").as_bytes())
-                {
-                    ::core::result::Result::Ok(s) => s,
-                    ::core::result::Result::Err(_) => {
-                        ::core::panic!("extension label contains interior NUL byte")
-                    }
-                };
-            const __JACKDAW_DESCRIPTION: &::core::ffi::CStr =
-                match ::core::ffi::CStr::from_bytes_with_nul(
-                    ::core::concat!($description, "\0").as_bytes(),
-                ) {
-                    ::core::result::Result::Ok(s) => s,
-                    ::core::result::Result::Err(_) => {
-                        ::core::panic!("extension description contains interior NUL byte")
-                    }
-                };
+            // Using a ZST means that our common pattern of creating a sample extension to harvest the ID etc. is a no-op.
+            // We can also lift this requirement in the futureif we want.
+            const _: () = {
+                assert!(
+                    std::mem::size_of::<$extension>() == 0,
+                    "Extension must be a zero-sized type."
+                );
+            };
 
-            unsafe extern "C" fn __jackdaw_ctor() -> ::std::boxed::Box<dyn $crate::JackdawExtension>
-            {
-                let make: fn() -> ::std::boxed::Box<dyn $crate::JackdawExtension> = $ctor;
-                make()
+            unsafe extern "C" fn __jackdaw_ctor() -> $crate::ffi::JackdawExtensionPtr {
+                let obj: Box<dyn JackdawExtension> = Box::new($extension);
+                // SAFETY: Casting a trait object to a fat pointer is trivially fine in by itself,
+                // but note that we are ignoring the fact that the ABI border does not guarantee
+                // that we can actually turn this back
+                unsafe {
+                    let raw: *mut dyn JackdawExtension = Box::into_raw(obj);
+                    std::mem::transmute(raw)
+                }
+            }
+
+            unsafe extern "C" fn __jackdaw_dtor(ptr: $crate::ffi::JackdawExtensionPtr) {
+                // SAFETY: This is not safe lol
+                // We are just hoping that the ABI did not change in-between invocations
+                // by making sure the editor and the extension are built with the exact same
+                // compiler version + call
+                unsafe {
+                    let ptr: *mut dyn JackdawExtension = std::mem::transmute(ptr);
+                    drop(Box::from_raw(ptr));
+                }
             }
 
             #[unsafe(no_mangle)]
@@ -92,10 +91,8 @@ macro_rules! export_extension {
                     api_version: $crate::ffi::API_VERSION,
                     bevy_version: $crate::ffi::BEVY_VERSION.as_ptr(),
                     profile: $crate::ffi::PROFILE.as_ptr(),
-                    id: __JACKDAW_ID.as_ptr(),
-                    label: __JACKDAW_LABEL.as_ptr(),
-                    description: __JACKDAW_DESCRIPTION.as_ptr(),
                     ctor: __jackdaw_ctor,
+                    dtor: __jackdaw_dtor,
                 }
             }
         };

--- a/crates/jackdaw_api_internal/src/ffi.rs
+++ b/crates/jackdaw_api_internal/src/ffi.rs
@@ -119,24 +119,19 @@ pub type ReflectRegisterFn = unsafe extern "Rust" fn(&mut bevy::reflect::TypeReg
 /// must be allocated with the same allocator the host uses; this is
 /// guaranteed when both sides link against Bevy with
 /// `dynamic_linking` enabled, which shares the Rust allocator.
-///
-/// `improper_ctypes_definitions` is silenced for the `ctor` field:
-/// `Box<dyn Trait>` is a fat pointer with a rustc-defined layout,
-/// which is sound here because editor and extension are required
-/// to link against the same Bevy dylib and so agree on layout.
 #[repr(C)]
-#[expect(
-    improper_ctypes_definitions,
-    reason = "This is wrong, but I'll fix it in the next PR"
-)]
 pub struct ExtensionEntry {
     pub api_version: u32,
     pub bevy_version: *const c_char,
     pub profile: *const c_char,
-    pub id: *const c_char,
-    pub label: *const c_char,
-    pub description: *const c_char,
-    pub ctor: unsafe extern "C" fn() -> Box<dyn crate::JackdawExtension>,
+    pub ctor: unsafe extern "C" fn() -> JackdawExtensionPtr,
+    pub dtor: unsafe extern "C" fn(JackdawExtensionPtr),
+}
+
+#[repr(C)]
+pub struct JackdawExtensionPtr {
+    data: *mut (),
+    vtable: *mut (),
 }
 
 /// Shape returned by every game dylib's entry function.

--- a/crates/jackdaw_api_internal/src/lib.rs
+++ b/crates/jackdaw_api_internal/src/lib.rs
@@ -37,7 +37,7 @@
 //!             ]),
 //!         ));
 //!     }
-//!     fn register_input_context(app: &mut App) {
+//!     fn register_input_context(&self, app: &mut App) {
 //!         app.add_input_context::<SamplePluginContext>();
 //!     }
 //! }
@@ -108,26 +108,18 @@ pub mod prelude {
 
 /// Trait implemented by every extension. Declares the extension's name
 /// and registration logic; the framework handles everything else.
-pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
+pub trait JackdawExtension: Send + Sync + 'static {
     /// A unique identifier for this extension. This will be used to refer to the extension internally.
     /// The prefix `"jackdaw."` as well as the name `jackdaw` itself are reserved for built-in extensions.
-    fn id() -> String
-    where
-        Self: Sized;
+    fn id(&self) -> String;
 
     /// A human-readable name for this extension. This will be displayed in UIs.
-    fn label() -> String
-    where
-        Self: Sized,
-    {
-        Self::id()
+    fn label(&self) -> String {
+        self.id()
     }
 
     /// A human-readable description for this extension. This will be displayed in UIs.
-    fn description() -> String
-    where
-        Self: Sized,
-    {
+    fn description(&self) -> String {
         "".to_string()
     }
 
@@ -136,10 +128,7 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
     /// The Extensions dialog reads this to split the list into Built-in
     /// and Custom sections. Reserved as a future hook for marketplace
     /// categories.
-    fn kind() -> ExtensionKind
-    where
-        Self: Sized,
-    {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Regular
     }
 
@@ -154,11 +143,7 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
     /// contexts.
     // FIXME: this leaks memory when the extension is disabled
     #[expect(unused_variables, reason = "The default implementation does nothing")]
-    fn register_input_context(app: &mut App)
-    where
-        Self: Sized,
-    {
-    }
+    fn register_input_context(&self, app: &mut App) {}
 
     /// Main registration logic. Called each time the extension is
     /// enabled. Spawn operators, windows, BEI action entities, and any
@@ -172,42 +157,6 @@ pub trait JackdawExtension: Send + Sync + 'static + DynJackdawExtension {
     /// state (file handles, network sessions, and the like).
     #[expect(unused_variables, reason = "The default implementation does nothing")]
     fn unregister(&self, world: &mut World, extension_entity: Entity) {}
-}
-
-/// Allows access to the extension's static methods via a dynamic dispatch.
-/// This is needed for when you're holding a `Box<dyn JackdawExtension>` and need to call methods that wouldn't require `self`.
-pub trait DynJackdawExtension {
-    /// Returns [`JackdawExtension::id`] via dynamic dispatch.
-    fn dyn_id(&self) -> String;
-    /// Returns [`JackdawExtension::label`] via dynamic dispatch.
-    fn dyn_label(&self) -> String;
-    /// Returns [`JackdawExtension::kind`] via dynamic dispatch.
-    fn dyn_kind(&self) -> ExtensionKind;
-    /// Returns [`JackdawExtension::description`] via dynamic dispatch.
-    fn dyn_description(&self) -> String;
-    /// Registers input contexts for this extension.
-    fn dyn_register_input_context(&self, app: &mut App);
-}
-
-impl<T: JackdawExtension> DynJackdawExtension for T {
-    fn dyn_id(&self) -> String {
-        T::id()
-    }
-
-    fn dyn_label(&self) -> String {
-        T::label()
-    }
-
-    fn dyn_description(&self) -> String {
-        T::description()
-    }
-    fn dyn_kind(&self) -> ExtensionKind {
-        T::kind()
-    }
-
-    fn dyn_register_input_context(&self, app: &mut App) {
-        T::register_input_context(app);
-    }
 }
 
 /// Passed to [`JackdawExtension::register`]. Holds the extension entity

--- a/crates/jackdaw_api_internal/src/lifecycle.rs
+++ b/crates/jackdaw_api_internal/src/lifecycle.rs
@@ -300,50 +300,23 @@ pub trait ExtensionAppExt {
     ///
     /// See also [`Self::register_extension_with`].
     fn register_extension<T: crate::JackdawExtension + Default>(&mut self) -> &mut Self {
-        self.register_extension_with::<T>(|| Box::new(T::default()))
+        self.register_extension_with(|| Box::new(T::default()))
     }
 
     /// Like [`Self::register_extension`], but with a custom constructor.
-    fn register_extension_with<T: crate::JackdawExtension>(
-        &mut self,
-        ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
-    ) -> &mut Self;
-
-    /// Register an extension by constructor alone, without the
-    /// compile-time type parameter required by [`Self::register_extension`].
-    ///
-    /// Used by the runtime dylib loader: it gets a `Box<dyn JackdawExtension>`
-    /// from an FFI ctor and can't name the concrete type. Constructs one
-    /// instance up front to harvest `dyn_name()`, `dyn_kind()`, and
-    /// `dyn_register_input_context()`; the ctor itself is stored for
-    /// later invocations from the Extensions dialog.
-    fn register_extension_dynamic(
+    fn register_extension_with(
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self;
 }
 
 impl ExtensionAppExt for App {
-    fn register_extension_with<T: crate::JackdawExtension>(
+    fn register_extension_with(
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self {
         let ext = ctor();
         ext.register_input_context(self);
-        self.world_mut()
-            .resource_mut::<ExtensionCatalog>()
-            .register_extension_internal(ctor);
-        self
-    }
-
-    fn register_extension_dynamic(
-        &mut self,
-        ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
-    ) -> &mut Self {
-        let ext = ctor();
-        ext.register_input_context(self);
-        drop(ext);
-
         self.world_mut()
             .resource_mut::<ExtensionCatalog>()
             .register_extension_internal(ctor);

--- a/crates/jackdaw_api_internal/src/lifecycle.rs
+++ b/crates/jackdaw_api_internal/src/lifecycle.rs
@@ -208,9 +208,6 @@ pub struct ExtensionCatalog {
 
 struct CatalogEntry {
     ctor: ExtensionCtor,
-    label: String,
-    description: String,
-    kind: ExtensionKind,
 }
 
 /// Classifies an entry in the catalog. Surfaced in toggle UIs so
@@ -220,36 +217,31 @@ struct CatalogEntry {
 ///
 /// Defaults to [`ExtensionKind::Regular`]. [`ExtensionKind::Builtin`] is reserved
 /// for extensions shipped inside the editor binary.
+// Don't change the repr(u8) value of variants; they're used in FFI
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
 pub enum ExtensionKind {
     /// Ships with Jackdaw as a core feature area (scene tree, inspector,
     /// asset browser, etc.). Present in every build.
-    Builtin,
+    Builtin = 0,
     /// Everything else: example extensions bundled for demonstration,
     /// third-party extensions loaded from disk, user-authored addons.
-    Regular,
+    Regular = 1,
 }
 
 impl ExtensionCatalog {
     /// Register a constructor with its declared kind. Most callers
     /// should use [`App::register_extension`] instead, which handles BEI
     /// context registration.
-    fn register(&mut self, id: impl Into<String>, entry: CatalogEntry) {
-        self.entries.insert(id.into(), entry);
-    }
-
-    /// Convenience method for calling [`ExtensionCatalog::register`] on a known type.
-    fn register_generic<T: crate::JackdawExtension>(
+    fn register_extension_internal(
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) {
-        self.register(
-            T::id(),
+        let id = ctor().id();
+        self.entries.insert(
+            id,
             CatalogEntry {
-                kind: T::kind(),
                 ctor: Arc::new(ctor),
-                label: T::label(),
-                description: T::description(),
             },
         );
     }
@@ -264,20 +256,23 @@ impl ExtensionCatalog {
 
     /// Iterate IDs with their declared [`ExtensionKind`]. Useful for
     /// grouping the Extensions dialog into Built-in and Custom sections.
-    pub fn iter_with_content(&self) -> impl Iterator<Item = (&str, &str, &str, ExtensionKind)> {
+    pub fn iter_with_content(
+        &self,
+    ) -> impl Iterator<Item = (String, String, String, ExtensionKind)> {
         self.entries.iter().map(|(id, entry)| {
+            let ext = (entry.ctor)();
             (
-                id.as_str(),
-                entry.label.as_str(),
-                entry.description.as_str(),
-                entry.kind,
+                id.to_string(),
+                ext.label().to_string(),
+                ext.description().to_string(),
+                ext.kind(),
             )
         })
     }
 
     /// Look up the declared [`ExtensionKind`] for a registered name.
     pub fn kind(&self, name: &str) -> Option<ExtensionKind> {
-        self.entries.get(name).map(|e| e.kind)
+        self.entries.get(name).map(|e| (e.ctor)().kind())
     }
 
     /// Whether the named extension is a Jackdaw-shipped built-in.
@@ -333,10 +328,11 @@ impl ExtensionAppExt for App {
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self {
-        T::register_input_context(self);
+        let ext = ctor();
+        ext.register_input_context(self);
         self.world_mut()
             .resource_mut::<ExtensionCatalog>()
-            .register_generic::<T>(ctor);
+            .register_extension_internal(ctor);
         self
     }
 
@@ -344,25 +340,13 @@ impl ExtensionAppExt for App {
         &mut self,
         ctor: impl Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
     ) -> &mut Self {
-        let sample = ctor();
-        let id = sample.dyn_id();
-        let label = sample.dyn_label();
-        let description = sample.dyn_description();
-        let kind = sample.dyn_kind();
-        sample.dyn_register_input_context(self);
-        drop(sample);
+        let ext = ctor();
+        ext.register_input_context(self);
+        drop(ext);
 
         self.world_mut()
             .resource_mut::<ExtensionCatalog>()
-            .register(
-                id,
-                CatalogEntry {
-                    ctor: Arc::new(ctor),
-                    label,
-                    description,
-                    kind,
-                },
-            );
+            .register_extension_internal(ctor);
         self
     }
 }
@@ -410,7 +394,7 @@ pub fn load_static_extension(
     world: &mut World,
     extension: Box<dyn crate::JackdawExtension>,
 ) -> Entity {
-    let name = extension.dyn_id();
+    let name = extension.id();
     info!("Loading extension: {}", name);
 
     let extension_entity = world.spawn(Extension { name }).id();
@@ -450,26 +434,13 @@ pub(crate) struct StoredExtension(pub(crate) Box<dyn crate::JackdawExtension>);
 /// Register a dylib-loaded extension into a running editor's catalog.
 /// The dylib loader uses this after reading the dylib's entry metadata.
 /// Operates on `&mut World` (not `&mut App`) because installs happen post-startup.
-pub fn register_dylib_extension<F>(
-    world: &mut World,
-    id: impl Into<String>,
-    label: impl Into<String>,
-    description: impl Into<String>,
-    kind: ExtensionKind,
-    ctor: F,
-) where
+pub fn register_dylib_extension<F>(world: &mut World, ctor: F)
+where
     F: Fn() -> Box<dyn crate::JackdawExtension> + Send + Sync + 'static,
 {
-    // FIXME: what about BEI contexts? Where are they added?
-    world.resource_mut::<ExtensionCatalog>().register(
-        id,
-        CatalogEntry {
-            ctor: Arc::new(ctor),
-            label: label.into(),
-            description: description.into(),
-            kind,
-        },
-    );
+    world
+        .resource_mut::<ExtensionCatalog>()
+        .register_extension_internal(ctor);
 }
 
 /// Keep `OperatorIndex` in sync when an operator entity is spawned.

--- a/crates/jackdaw_api_internal/src/lifecycle.rs
+++ b/crates/jackdaw_api_internal/src/lifecycle.rs
@@ -39,7 +39,7 @@ pub(super) fn plugin(app: &mut App) {
 /// child-entity despawns.
 #[derive(Component, Debug)]
 pub struct Extension {
-    pub name: String,
+    pub id: String,
 }
 
 /// [`Resource`]s attached to a specific [`Extension`].
@@ -329,7 +329,7 @@ impl ExtensionAppExt for App {
 pub fn unload_extension(world: &mut World, ext_entity: Entity) {
     let ext_name = world
         .get::<Extension>(ext_entity)
-        .map(|e| e.name.clone())
+        .map(|e| e.id.clone())
         .unwrap_or_default();
     info!("Unloading extension: {}", ext_name);
 
@@ -343,15 +343,15 @@ pub fn unload_extension(world: &mut World, ext_entity: Entity) {
 
 /// Enable a named extension via the catalog. Returns the new extension
 /// entity, or `None` if the name is unknown or already loaded.
-pub fn enable_extension(world: &mut World, name: &str) -> Option<Entity> {
+pub fn enable_extension(world: &mut World, id: &str) -> Option<Entity> {
     {
         let mut query = world.query::<&Extension>();
-        if query.iter(world).any(|e| e.name == name) {
+        if query.iter(world).any(|e| e.id == id) {
             return None;
         }
     }
 
-    let extension = world.resource::<ExtensionCatalog>().construct(name)?;
+    let extension = world.resource::<ExtensionCatalog>().construct(id)?;
     Some(load_static_extension(world, extension))
 }
 
@@ -367,10 +367,10 @@ pub fn load_static_extension(
     world: &mut World,
     extension: Box<dyn crate::JackdawExtension>,
 ) -> Entity {
-    let name = extension.id();
-    info!("Loading extension: {}", name);
+    let id = extension.id();
+    info!("Loading extension: {id}");
 
-    let extension_entity = world.spawn(Extension { name }).id();
+    let extension_entity = world.spawn(Extension { id }).id();
 
     let mut ctx = crate::ExtensionContext::new(world, extension_entity);
     extension.register(&mut ctx);
@@ -385,13 +385,9 @@ pub fn load_static_extension(
 }
 
 /// Disable a named extension by despawning its root entity.
-pub fn disable_extension(world: &mut World, name: &str) -> bool {
+pub fn disable_extension(world: &mut World, id: &str) -> bool {
     let mut query = world.query::<(Entity, &Extension)>();
-    let Some(ext_entity) = query
-        .iter(world)
-        .find(|(_, e)| e.name == name)
-        .map(|(e, _)| e)
-    else {
+    let Some(ext_entity) = query.iter(world).find(|(_, e)| e.id == id).map(|(e, _)| e) else {
         return false;
     };
     unload_extension(world, ext_entity);

--- a/crates/jackdaw_loader/src/compat.rs
+++ b/crates/jackdaw_loader/src/compat.rs
@@ -53,31 +53,20 @@ impl std::error::Error for CompatError {}
 /// Verify every embedded version tag against the host's values and
 /// sanity-check that pointer fields are non-null.
 pub fn verify_compat(entry: &ExtensionEntry) -> Result<(), CompatError> {
-    verify_version_fields(
-        entry.api_version,
-        entry.bevy_version,
-        entry.profile,
-        entry.id,
-    )
+    verify_version_fields(entry.api_version, entry.bevy_version, entry.profile)
 }
 
 /// Same as [`verify_compat`] but for a [`GameEntry`]. Both envelopes
 /// share the same version-field layout, so the check itself is
 /// structurally identical.
 pub fn verify_game_compat(entry: &GameEntry) -> Result<(), CompatError> {
-    verify_version_fields(
-        entry.api_version,
-        entry.bevy_version,
-        entry.profile,
-        entry.name,
-    )
+    verify_version_fields(entry.api_version, entry.bevy_version, entry.profile)
 }
 
 fn verify_version_fields(
     api_version: u32,
     bevy_version: *const c_char,
     profile: *const c_char,
-    name: *const c_char,
 ) -> Result<(), CompatError> {
     if api_version != API_VERSION {
         return Err(CompatError::ApiVersionMismatch {
@@ -102,10 +91,6 @@ fn verify_version_fields(
             host: host_profile,
             extension: ext_profile,
         });
-    }
-
-    if name.is_null() {
-        return Err(CompatError::NullPointer { field: "name" });
     }
 
     Ok(())

--- a/crates/jackdaw_loader/src/lib.rs
+++ b/crates/jackdaw_loader/src/lib.rs
@@ -49,7 +49,10 @@ use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 
 use bevy::prelude::*;
-use jackdaw_api_internal::ffi::{ENTRY_SYMBOL, ExtensionEntry, GAME_ENTRY_SYMBOL, GameEntry};
+use jackdaw_api_internal::JackdawExtension;
+use jackdaw_api_internal::ffi::{
+    ENTRY_SYMBOL, ExtensionEntry, GAME_ENTRY_SYMBOL, GameEntry, JackdawExtensionPtr,
+};
 
 pub use compat::CompatError;
 
@@ -250,7 +253,7 @@ impl LoadedKind {
 /// gets reopened from its final destination.
 pub fn peek_kind(path: &Path) -> Result<LoadedKind, LoadError> {
     match open_and_verify(path)? {
-        OpenedDylib::Extension { id: name, .. } => Ok(LoadedKind::Extension(name)),
+        OpenedDylib::Extension { ctor, .. } => Ok(LoadedKind::Extension(ctor().id())),
         OpenedDylib::Game { name, .. } => Ok(LoadedKind::Game(name)),
     }
 }
@@ -382,17 +385,15 @@ fn is_dylib(path: &Path) -> bool {
 /// Result of a successfully-verified dylib open. The loader keeps
 /// each variant's `Library` handle alive for the duration of the
 /// `App`; dropping it while the entry code is still reachable is UB.
-#[expect(
-    improper_ctypes_definitions,
-    reason = "This is wrong, but I'll fix it in the next PR"
-)]
 enum OpenedDylib {
     Extension {
         lib: libloading::Library,
-        id: String,
-        label: String,
-        description: String,
-        ctor: unsafe extern "C" fn() -> Box<dyn jackdaw_api_internal::JackdawExtension>,
+        ctor: Box<dyn Fn() -> Box<dyn JackdawExtension> + Send + Sync>,
+        #[expect(
+            dead_code,
+            reason = "Ideally we should clean up after ourselves, but the extension is a ZST anyways, so there's not really any data to leak anyways. Still, feel free to implement the destructor!"
+        )]
+        dtor: Box<dyn Fn(Box<dyn JackdawExtension>) + Send + Sync>,
     },
     Game {
         lib: libloading::Library,
@@ -405,10 +406,6 @@ enum OpenedDylib {
 /// Try to open `path`, dispatching on which entry symbol it
 /// exposes. Game symbol wins if both somehow exist (a cdylib
 /// should only `export_game!` or `export_extension!`, not both).
-#[expect(
-    improper_ctypes_definitions,
-    reason = "This is wrong, but I'll fix it in the next PR"
-)]
 fn open_and_verify(path: &Path) -> Result<OpenedDylib, LoadError> {
     // SAFETY: libloading's standard contract. Caller trusts `path`
     // is a well-formed dynamic library; if not, the call returns
@@ -464,23 +461,45 @@ fn open_and_verify(path: &Path) -> Result<OpenedDylib, LoadError> {
 
     compat::verify_compat(&entry)?;
 
-    let read_cstr = |field| -> Result<String, LoadError> {
-        // SAFETY: `verify_compat` rejected null; the library stays
-        // alive at least until `lib` is dropped by the caller.
-        let id_ctstr = unsafe { CStr::from_ptr(field) };
-        let owned = id_ctstr
-            .to_str()
-            .map_err(|_| LoadError::InvalidName)?
-            .to_owned();
-        Ok(owned)
+    let construct_extension = move || -> Box<dyn JackdawExtension> {
+        // SAFETY: the dylib stays loaded because its
+        // Library handle is kept in LoadedDylibs;
+        // `verify_compat` asserted the ABI contract at
+        // load time mooore or less (see next comment),
+        //  and the ctor pointer itself is just a plain function pointer.
+        let raw = unsafe { (entry.ctor)() };
+        // SAFETY: we control the export site, which exports the pointer of
+        // a `dyn JackdawExtension` trait object, so we can "safely" transmute
+        // the pointer. This is not really safe, since there's no guarantee
+        // that the ABI is preserved across compiler invocations, but good enough for now
+        unsafe {
+            let ptr: *mut dyn JackdawExtension = std::mem::transmute(raw);
+            Box::from_raw(ptr)
+        }
+    };
+
+    let destruct_extension = move |ext: Box<dyn JackdawExtension>| {
+        // SAFETY: we control the export site, which exports the pointer of
+        // a `dyn JackdawExtension` trait object, so we can "safely" transmute
+        // the pointer. This is not really safe, since there's no guarantee
+        // that the ABI is preserved across compiler invocations, but good enough for now
+        let raw = unsafe {
+            std::mem::transmute::<*mut dyn JackdawExtension, JackdawExtensionPtr>(Box::into_raw(
+                ext,
+            ))
+        };
+        // SAFETY: the dylib stays loaded because its
+        // Library handle is kept in LoadedDylibs;
+        // `verify_compat` asserted the ABI contract at
+        // load time mooore or less (see next comment),
+        //  and the dtor pointer itself is just a plain function pointer.
+        unsafe { (entry.dtor)(raw) }
     };
 
     Ok(OpenedDylib::Extension {
         lib,
-        id: read_cstr(entry.id)?,
-        label: read_cstr(entry.label)?,
-        description: read_cstr(entry.description)?,
-        ctor: entry.ctor,
+        ctor: Box::new(construct_extension),
+        dtor: Box::new(destruct_extension),
     })
 }
 
@@ -491,15 +510,7 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
     // while still holding it on our side of ownership.
     let lib_and_kind = open_and_verify_keep_lib(path)?;
     match lib_and_kind {
-        (
-            lib,
-            OpenedKind::Extension {
-                id,
-                label,
-                description,
-                ctor,
-            },
-        ) => {
+        (lib, OpenedKind::Extension { ctor }) => {
             // Run the per-dylib reflect registrar against our registry
             // BEFORE handing the library off. Uses the exported
             // `REFLECT_REGISTER_SYMBOL` (if present); absent on older
@@ -510,26 +521,12 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
             // input-context registration; then store the ctor in the
             // catalog so subsequent enable/disable cycles rebuild the
             // extension fresh each time.
-            let sample = unsafe { ctor() };
-            let kind = sample.dyn_kind();
-            sample.dyn_register_input_context(app);
-            drop(sample);
+            let ext = ctor();
+            ext.register_input_context(app);
+            let id = ext.id();
+            drop(ext);
 
-            jackdaw_api_internal::lifecycle::register_dylib_extension(
-                app.world_mut(),
-                &id,
-                label,
-                description,
-                kind,
-                move || {
-                    // SAFETY: the dylib stays loaded because its
-                    // Library handle is kept in LoadedDylibs;
-                    // `verify_compat` asserted the ABI contract at
-                    // load time, and the ctor pointer itself is just a
-                    // plain function pointer.
-                    unsafe { ctor() }
-                },
-            );
+            jackdaw_api_internal::lifecycle::register_dylib_extension(app.world_mut(), ctor);
 
             app.world_mut()
                 .resource_mut::<LoadedDylibs>()
@@ -626,15 +623,9 @@ fn try_load(app: &mut App, path: &Path) -> Result<LoadedKind, LoadError> {
 pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, LoadError> {
     let lib_and_kind = open_and_verify_keep_lib(path)?;
     match lib_and_kind {
-        (
-            lib,
-            OpenedKind::Extension {
-                id: name,
-                label,
-                description,
-                ctor,
-            },
-        ) => {
+        (lib, OpenedKind::Extension { ctor }) => {
+            let ext = ctor();
+            let id = ext.id();
             // Already-registered extensions come through this path
             // when the user re-installs a rebuild. Don't double-
             // register; registering the same extension twice produces
@@ -642,10 +633,10 @@ pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, Load
             // catalog entry.
             if world
                 .resource::<jackdaw_api_internal::ExtensionCatalog>()
-                .contains(&name)
+                .contains(&id)
             {
                 info!(
-                    "Extension `{name}` already registered; keeping the new library handle \
+                    "Extension `{id}` already registered; keeping the new library handle \
                      alive but skipping re-registration."
                 );
                 // Re-run reflect register in case the rebuild added
@@ -653,31 +644,19 @@ pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, Load
                 call_reflect_register_symbol(world, &lib);
                 register_derived_component_ids(world);
                 world.resource_mut::<LoadedDylibs>().libs.push(lib);
-                return Ok(LoadedKind::Extension(name));
+                return Ok(LoadedKind::Extension(id));
             }
 
             call_reflect_register_symbol(world, &lib);
             register_derived_component_ids(world);
 
-            let sample = unsafe { ctor() };
-            let kind = sample.dyn_kind();
-            drop(sample);
+            jackdaw_api_internal::lifecycle::register_dylib_extension(world, ctor);
 
-            jackdaw_api_internal::lifecycle::register_dylib_extension(
-                world,
-                &name,
-                label,
-                description,
-                kind,
-                move || unsafe { ctor() },
-            );
-
-            let extension = unsafe { ctor() };
-            jackdaw_api_internal::lifecycle::load_static_extension(world, extension);
+            jackdaw_api_internal::lifecycle::load_static_extension(world, ext);
 
             world.resource_mut::<LoadedDylibs>().libs.push(lib);
 
-            Ok(LoadedKind::Extension(name))
+            Ok(LoadedKind::Extension(id))
         }
         (
             lib,
@@ -738,16 +717,9 @@ pub fn load_from_path(world: &mut World, path: &Path) -> Result<LoadedKind, Load
 /// with the handle at the call site so the caller can both move the
 /// library into `LoadedDylibs` at the right moment and look up symbols
 /// on it in the meantime.
-#[expect(
-    improper_ctypes_definitions,
-    reason = "This is wrong, but I'll fix it in the next PR"
-)]
 enum OpenedKind {
     Extension {
-        id: String,
-        label: String,
-        description: String,
-        ctor: unsafe extern "C" fn() -> Box<dyn jackdaw_api_internal::JackdawExtension>,
+        ctor: Box<dyn Fn() -> Box<dyn JackdawExtension> + Send + Sync>,
     },
     Game {
         name: String,
@@ -762,21 +734,7 @@ enum OpenedKind {
 /// into `LoadedDylibs`.
 fn open_and_verify_keep_lib(path: &Path) -> Result<(libloading::Library, OpenedKind), LoadError> {
     match open_and_verify(path)? {
-        OpenedDylib::Extension {
-            lib,
-            id,
-            label,
-            description,
-            ctor,
-        } => Ok((
-            lib,
-            OpenedKind::Extension {
-                id,
-                label,
-                description,
-                ctor,
-            },
-        )),
+        OpenedDylib::Extension { lib, ctor, .. } => Ok((lib, OpenedKind::Extension { ctor })),
         OpenedDylib::Game {
             lib,
             name,

--- a/crates/jackdaw_sdk/src/lib.rs
+++ b/crates/jackdaw_sdk/src/lib.rs
@@ -42,9 +42,9 @@ pub use jackdaw_api::export_game;
 pub use jackdaw_api::operator;
 
 pub use jackdaw_api::{
-    DynJackdawExtension, ExtensionContext, ExtensionKind, ExtensionPoint, HierarchyWindow,
-    InspectorWindow, JackdawExtension, MenuEntryDescriptor, PanelContext, SectionBuildFn,
-    WindowDescriptor, jsn, op, pie, runtime,
+    ExtensionContext, ExtensionKind, ExtensionPoint, HierarchyWindow, InspectorWindow,
+    JackdawExtension, MenuEntryDescriptor, PanelContext, SectionBuildFn, WindowDescriptor, jsn, op,
+    pie, runtime,
 };
 
 /// Bevy root surface for extension code walking bevy paths beyond

--- a/examples/embedded_game.rs
+++ b/examples/embedded_game.rs
@@ -38,7 +38,7 @@ fn main() -> AppExit {
 struct MyGameExtension;
 
 impl JackdawExtension for MyGameExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "my_game".into()
     }
 

--- a/examples/sample_extension/src/lib.rs
+++ b/examples/sample_extension/src/lib.rs
@@ -20,19 +20,19 @@ use jackdaw_api::prelude::*;
 pub struct SampleExtension;
 
 impl JackdawExtension for SampleExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "sample".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Example Extension".to_string()
     }
 
-    fn description() -> String {
+    fn description(&self) -> String {
         "Just a tiny example extension :)".to_string()
     }
 
-    fn register_input_context(app: &mut App) {
+    fn register_input_context(&self, app: &mut App) {
         app.add_input_context::<SampleContext>();
     }
 
@@ -103,9 +103,4 @@ fn hello_time(_: In<OperatorParameters>, time: Res<Time>) -> OperatorResult {
 // cdylib output needs it; the rlib output that's statically
 // linked into the prebuilt binary just carries a dead symbol,
 // which is harmless.
-jackdaw_api::export_extension!(
-    "sample",
-    "Example Extension",
-    "Just a tiny example extension :)",
-    || Box::new(SampleExtension)
-);
+jackdaw_api::export_extension!(SampleExtension);

--- a/examples/viewable_camera_extension/src/lib.rs
+++ b/examples/viewable_camera_extension/src/lib.rs
@@ -17,15 +17,15 @@ use jackdaw_api::prelude::*;
 pub struct ViewableCameraExtension;
 
 impl JackdawExtension for ViewableCameraExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "viewable_camera".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Viewable Camera".to_string()
     }
 
-    fn register_input_context(app: &mut App) {
+    fn register_input_context(&self, app: &mut App) {
         app.add_input_context::<ViewableCameraContext>();
     }
 

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -136,7 +136,7 @@ pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
     for (ext_entity, action, label) in ext_entries {
         let category = world
             .get::<jackdaw_api_internal::lifecycle::Extension>(ext_entity)
-            .map(|e| e.name.clone())
+            .map(|e| e.id.clone())
             .unwrap_or_else(|| "Extensions".to_string());
         items.push(AddMenuItem {
             action,

--- a/src/builtin_extensions.rs
+++ b/src/builtin_extensions.rs
@@ -14,15 +14,15 @@ use jackdaw_feathers::icons::Icon;
 pub struct CoreWindowsExtension;
 
 impl JackdawExtension for CoreWindowsExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "jackdaw.core_windows".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Core Windows".to_string()
     }
 
-    fn kind() -> ExtensionKind {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -93,15 +93,15 @@ impl JackdawExtension for CoreWindowsExtension {
 pub struct AssetBrowserExtension;
 
 impl JackdawExtension for AssetBrowserExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "jackdaw.asset_browser".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Asset Browser".to_string()
     }
 
-    fn kind() -> ExtensionKind {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -134,15 +134,15 @@ impl JackdawExtension for AssetBrowserExtension {
 pub struct TimelineExtension;
 
 impl JackdawExtension for TimelineExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "jackdaw.timeline".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Timeline".to_string()
     }
 
-    fn kind() -> ExtensionKind {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -165,15 +165,15 @@ impl JackdawExtension for TimelineExtension {
 pub struct TerminalExtension;
 
 impl JackdawExtension for TerminalExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "jackdaw.terminal".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Terminal".to_string()
     }
 
-    fn kind() -> ExtensionKind {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -213,15 +213,15 @@ impl JackdawExtension for TerminalExtension {
 pub struct InspectorExtension;
 
 impl JackdawExtension for InspectorExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "jackdaw.inspector".to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Inspector".to_string()
     }
 
-    fn kind() -> ExtensionKind {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Builtin
     }
 

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -17,19 +17,19 @@ pub(super) fn plugin(app: &mut App) {
 pub struct JackdawCoreExtension;
 
 impl JackdawExtension for JackdawCoreExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         CORE_EXTENSION_ID.to_string()
     }
 
-    fn label() -> String {
+    fn label(&self) -> String {
         "Jackdaw Core Functionality".to_string()
     }
 
-    fn description() -> String {
+    fn description(&self) -> String {
         "Important functionality for the Jackdaw editor. This extension is always loaded and cannot be disabled.".to_string()
     }
 
-    fn kind() -> ExtensionKind {
+    fn kind(&self) -> ExtensionKind {
         ExtensionKind::Builtin
     }
 
@@ -48,7 +48,7 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::draw_brush::add_to_extension(ctx);
     }
 
-    fn register_input_context(app: &mut App) {
+    fn register_input_context(&self, app: &mut App) {
         app.add_input_context::<CoreExtensionInputContext>();
     }
 }

--- a/src/extensions_config.rs
+++ b/src/extensions_config.rs
@@ -112,6 +112,6 @@ pub fn resolve_enabled_list(world: &World) -> Vec<String> {
 /// and write it to disk.
 pub fn persist_current_enabled(world: &mut World) {
     let mut query = world.query::<&jackdaw_api_internal::lifecycle::Extension>();
-    let enabled: Vec<String> = query.iter(world).map(|e| e.name.clone()).collect();
+    let enabled: Vec<String> = query.iter(world).map(|e| e.id.clone()).collect();
     write_enabled_list(&enabled);
 }

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -120,7 +120,7 @@ fn populate_extensions_dialog(
     // Split catalog entries into Built-in vs. Custom. Membership comes
     // from each extension's declared `ExtensionKind`.
     let enabled_names: std::collections::HashSet<String> =
-        loaded.iter().map(|e| e.name.clone()).collect();
+        loaded.iter().map(|e| e.id.clone()).collect();
     let mut builtin_rows: Vec<(String, String, bool)> = Vec::new();
     let mut custom_rows: Vec<(String, String, bool)> = Vec::new();
     for (id, label, _description, kind) in catalog.iter_with_content() {

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -129,13 +129,13 @@ fn populate_extensions_dialog(
         // from the dialog entirely rather than rendering a locked
         // checkbox — they're implementation detail, not a user
         // choice.
-        if extensions_config::is_required(id) {
+        if extensions_config::is_required(&id) {
             continue;
         }
         let row = (
             id.to_string(),
             label.to_string(),
-            enabled_names.contains(id),
+            enabled_names.contains(&id),
         );
         match kind {
             ExtensionKind::Builtin => builtin_rows.push(row),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,18 +348,11 @@ impl ExtensionPlugin {
 
     /// Register an extension. May be called any number of times.
     pub fn with_extension<T: JackdawExtension + Default>(mut self) -> Self {
+        const {
+            assert!(size_of::<T>() == 0, "Extension type must be zero-sized");
+        }
         self.user_extensions
             .push(std::sync::Arc::new(|| Box::new(T::default())));
-        self
-    }
-
-    /// Like [`ExtensionPlugin::with_extension`], but takes a constructor function
-    /// instead of a type implementing [`JackdawExtension`].
-    pub fn with_extension_ctor<F>(mut self, ctor: F) -> Self
-    where
-        F: Fn() -> Box<dyn JackdawExtension> + Send + Sync + 'static,
-    {
-        self.user_extensions.push(std::sync::Arc::new(ctor));
         self
     }
 
@@ -390,7 +383,7 @@ impl Plugin for ExtensionPlugin {
 
         for ctor in &self.user_extensions {
             let ctor = std::sync::Arc::clone(ctor);
-            app.register_extension_dynamic(move || (*ctor)());
+            app.register_extension_with(move || (*ctor)());
         }
     }
 }

--- a/tests/fixtures/test_fixture_extension/src/lib.rs
+++ b/tests/fixtures/test_fixture_extension/src/lib.rs
@@ -13,7 +13,7 @@ use jackdaw_api::prelude::*;
 pub struct TestFixtureExtension;
 
 impl JackdawExtension for TestFixtureExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "test_fixture".to_string()
     }
 
@@ -28,9 +28,4 @@ fn spawn_marker(_: In<OperatorParameters>, mut commands: Commands) -> OperatorRe
     OperatorResult::Finished
 }
 
-export_extension!(
-    "test_fixture",
-    "Test Fixture",
-    "A good old test fixture",
-    || Box::new(TestFixtureExtension)
-);
+export_extension!(TestFixtureExtension);

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -84,7 +84,7 @@ impl SampleExtension {
 }
 
 impl JackdawExtension for SampleExtension {
-    fn id() -> String {
+    fn id(&self) -> String {
         "sample".to_string()
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,7 @@ impl<T: Operator> Default for IntegrationTestsExtension<T> {
 }
 
 impl<T: Operator + Send + Sync> JackdawExtension for IntegrationTestsExtension<T> {
-    fn id() -> String {
+    fn id(&self) -> String {
         "Integration Tests".to_string()
     }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -56,7 +56,7 @@ pub fn register_and_enable_extension<T: JackdawExtension + Default>(app: &mut Ap
     app.update();
     // Force-enable the test extension; idempotent if it was already enabled
     // (returns `None` in that case).
-    enable_extension(app.world_mut(), &T::id());
+    enable_extension(app.world_mut(), &T::default().id());
     // Let any on-add observers for the operator entities settle before the
     // caller starts asserting.
     app.update();


### PR DESCRIPTION
- Remove trait objects from FFI. This is necessary since we are using the C ABI, and the C ABI does not know what the heck a trait object is supposed to be
  - I don't even *know* what Rust is passing the C ABI to have this work on `main` lol
- Use a manually constructed fat pointer instead
- Sanctify our "sample the extension for some data" pattern by requiring plugins to be ZSTs
  - constructing them is a noop!
  - these guys by definition have no data, so we can leak them without any worries
  - still added a dtor in case we wanna do some proper cleanup later without breaking our interface
    - The unused dtor is not a regression, we didn't clean up (properly) before either. Now it's just more explicit.
- Since our sampling pattern is now essentially free, let's add a `&self` param to the extension trait methods that didn't require it
  - This makes our FFI slimmer since we don't need to pass around these functions / pseudo-constants
    - exporting a dylib is now just `jackdaw_api::export_extension!(SampleExtension);`
  - This also means that we *could* in the future implement `JackdawExtension` for a type that wraps an FFI pointer, e.g. `impl JackdawExtension for JackdawExtensionPtr`. That would require lifting the ZST requirement, but we can do that at any time. 
- Fix our (correct!) clippy warnings about improper ctypes
- Make `ExtensionKind` C ABI safe through repr(u8) and future compatible by being explicit about values

