### PR TITLE
operatorify phase 3: view toggles, grid, gizmo mode, edit mode

### DIFF
--- a/src/brush/interaction.rs
+++ b/src/brush/interaction.rs
@@ -29,6 +29,13 @@ pub(super) struct KeyboardInput<'w> {
     pub keybinds: Res<'w, KeybindRegistry>,
 }
 
+/// Reactive cleanup: when the active brush entity is no longer
+/// selected, drop out of brush-edit mode. Also the single remaining
+/// keybind for this subsystem — Escape exits brush-edit back to
+/// Object, deferring to clip mode's own handler if points are pending.
+/// The digit-key mode switches (1/2/3/4) moved to
+/// [`crate::edit_mode_ops`]; the toolbar buttons there dispatch the
+/// same operators.
 pub(super) fn handle_edit_mode_keys(
     input_focus: Res<InputFocus>,
     input: KeyboardInput,
@@ -36,7 +43,6 @@ pub(super) fn handle_edit_mode_keys(
     mut edit_mode: ResMut<EditMode>,
     mut brush_selection: ResMut<BrushSelection>,
     modal: Res<crate::modal_transform::ModalTransformState>,
-    brushes: Query<(), With<Brush>>,
     face_drag: Res<BrushDragState>,
     vertex_drag: Res<VertexDragState>,
     edge_drag: Res<EdgeDragState>,
@@ -70,48 +76,6 @@ pub(super) fn handle_edit_mode_keys(
         return;
     }
     if face_drag.pending.is_some() || vertex_drag.pending.is_some() || edge_drag.pending.is_some() {
-        return;
-    }
-
-    // 1/2/3/4 toggle brush sub-element modes
-    let pressed_mode = if keybinds.just_pressed(EditorAction::VertexMode, keyboard) {
-        Some(BrushEditMode::Vertex)
-    } else if keybinds.just_pressed(EditorAction::EdgeMode, keyboard) {
-        Some(BrushEditMode::Edge)
-    } else if keybinds.just_pressed(EditorAction::FaceMode, keyboard) {
-        Some(BrushEditMode::Face)
-    } else if keybinds.just_pressed(EditorAction::ClipMode, keyboard) {
-        Some(BrushEditMode::Clip)
-    } else {
-        None
-    };
-
-    if let Some(target_mode) = pressed_mode {
-        if let EditMode::BrushEdit(current) = *edit_mode {
-            if current == target_mode {
-                // Same key again: toggle off to Object
-                *edit_mode = EditMode::Object;
-                brush_selection.entity = None;
-                brush_selection.faces.clear();
-                brush_selection.vertices.clear();
-                brush_selection.edges.clear();
-            } else {
-                // Switch sub-mode, clear sub-element selections
-                *edit_mode = EditMode::BrushEdit(target_mode);
-                brush_selection.faces.clear();
-                brush_selection.vertices.clear();
-                brush_selection.edges.clear();
-            }
-        } else {
-            // From Object mode: enter edit on primary if it's a brush
-            if let Some(entity) = selection.primary().filter(|&e| brushes.contains(e)) {
-                *edit_mode = EditMode::BrushEdit(target_mode);
-                brush_selection.entity = Some(entity);
-                brush_selection.faces.clear();
-                brush_selection.vertices.clear();
-                brush_selection.edges.clear();
-            }
-        }
         return;
     }
 

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -107,6 +107,10 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::scene_ops::add_to_extension(ctx, &modifiers);
         crate::history_ops::add_to_extension(ctx, &modifiers);
         crate::app_ops::add_to_extension(ctx);
+        crate::view_ops::add_to_extension(ctx, &modifiers);
+        crate::grid_ops::add_to_extension(ctx);
+        crate::gizmo_ops::add_to_extension(ctx);
+        crate::edit_mode_ops::add_to_extension(ctx);
     }
 
     fn register_input_context(app: &mut App) {

--- a/src/edit_mode_ops.rs
+++ b/src/edit_mode_ops.rs
@@ -1,0 +1,260 @@
+//! Edit-mode switch operators: Object / Vertex / Edge / Face / Clip /
+//! Physics. Each one either enters the named mode or, if already in
+//! it, toggles back out to Object.
+//!
+//! These replace what `handle_edit_mode_keys` and the toolbar's
+//! per-variant `.observe(...)` closures did before. All `allows_undo =
+//! false` because edit-mode is a UI state, not a scene mutation.
+//!
+//! Default keybinds: `1` vertex, `2` edge, `3` face, `4` clip.
+
+use bevy::{input_focus::InputFocus, prelude::*};
+use bevy_enhanced_input::prelude::{Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::brush::{
+    BrushDragState, BrushEditMode, BrushSelection, EdgeDragState, EditMode, VertexDragState,
+};
+use crate::core_extension::CoreExtensionInputContext;
+use crate::draw_brush::DrawBrushState;
+use crate::selection::Selection;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<EditModeObjectOp>()
+        .register_operator::<EditModeVertexOp>()
+        .register_operator::<EditModeEdgeOp>()
+        .register_operator::<EditModeFaceOp>()
+        .register_operator::<EditModeClipOp>()
+        .register_operator::<EditModePhysicsOp>();
+
+    let ext = ctx.id();
+    ctx.entity_mut().world_scope(|world| {
+        world.spawn((
+            Action::<EditModeVertexOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::Digit1, Press::default())],
+        ));
+        world.spawn((
+            Action::<EditModeEdgeOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::Digit2, Press::default())],
+        ));
+        world.spawn((
+            Action::<EditModeFaceOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::Digit3, Press::default())],
+        ));
+        world.spawn((
+            Action::<EditModeClipOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::Digit4, Press::default())],
+        ));
+    });
+}
+
+/// True when switching edit modes is safe — no text field has focus,
+/// no modal is running, and no brush sub-element drag is in flight or
+/// pending. Keybind-triggered mode changes would otherwise yank the
+/// drag target out from under the active system.
+fn can_change_edit_mode(
+    input_focus: Res<InputFocus>,
+    active: ActiveModalQuery,
+    face_drag: Res<BrushDragState>,
+    vertex_drag: Res<VertexDragState>,
+    edge_drag: Res<EdgeDragState>,
+) -> bool {
+    if input_focus.0.is_some() || active.is_modal_running() {
+        return false;
+    }
+    if face_drag.active || vertex_drag.active || edge_drag.active {
+        return false;
+    }
+    if face_drag.pending.is_some() || vertex_drag.pending.is_some() || edge_drag.pending.is_some() {
+        return false;
+    }
+    true
+}
+
+#[operator(
+    id = "edit_mode.object",
+    label = "Object Mode",
+    allows_undo = false,
+    is_available = can_change_edit_mode
+)]
+fn edit_mode_object(
+    _: In<OperatorParameters>,
+    mut edit_mode: ResMut<EditMode>,
+    mut brush_selection: ResMut<BrushSelection>,
+    mut draw_state: ResMut<DrawBrushState>,
+) -> OperatorResult {
+    *edit_mode = EditMode::Object;
+    clear_brush_selection(&mut brush_selection);
+    draw_state.active = None;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "edit_mode.vertex",
+    label = "Vertex Mode",
+    allows_undo = false,
+    is_available = can_change_edit_mode
+)]
+fn edit_mode_vertex(
+    _: In<OperatorParameters>,
+    edit_mode: ResMut<EditMode>,
+    brush_selection: ResMut<BrushSelection>,
+    draw_state: ResMut<DrawBrushState>,
+    selection: Res<Selection>,
+    brushes: Query<(), With<jackdaw_jsn::Brush>>,
+) -> OperatorResult {
+    switch_brush_edit_mode(
+        BrushEditMode::Vertex,
+        edit_mode,
+        brush_selection,
+        draw_state,
+        selection,
+        brushes,
+    )
+}
+
+#[operator(
+    id = "edit_mode.edge",
+    label = "Edge Mode",
+    allows_undo = false,
+    is_available = can_change_edit_mode
+)]
+fn edit_mode_edge(
+    _: In<OperatorParameters>,
+    edit_mode: ResMut<EditMode>,
+    brush_selection: ResMut<BrushSelection>,
+    draw_state: ResMut<DrawBrushState>,
+    selection: Res<Selection>,
+    brushes: Query<(), With<jackdaw_jsn::Brush>>,
+) -> OperatorResult {
+    switch_brush_edit_mode(
+        BrushEditMode::Edge,
+        edit_mode,
+        brush_selection,
+        draw_state,
+        selection,
+        brushes,
+    )
+}
+
+#[operator(
+    id = "edit_mode.face",
+    label = "Face Mode",
+    allows_undo = false,
+    is_available = can_change_edit_mode
+)]
+fn edit_mode_face(
+    _: In<OperatorParameters>,
+    edit_mode: ResMut<EditMode>,
+    brush_selection: ResMut<BrushSelection>,
+    draw_state: ResMut<DrawBrushState>,
+    selection: Res<Selection>,
+    brushes: Query<(), With<jackdaw_jsn::Brush>>,
+) -> OperatorResult {
+    switch_brush_edit_mode(
+        BrushEditMode::Face,
+        edit_mode,
+        brush_selection,
+        draw_state,
+        selection,
+        brushes,
+    )
+}
+
+#[operator(
+    id = "edit_mode.clip",
+    label = "Clip Mode",
+    allows_undo = false,
+    is_available = can_change_edit_mode
+)]
+fn edit_mode_clip(
+    _: In<OperatorParameters>,
+    edit_mode: ResMut<EditMode>,
+    brush_selection: ResMut<BrushSelection>,
+    draw_state: ResMut<DrawBrushState>,
+    selection: Res<Selection>,
+    brushes: Query<(), With<jackdaw_jsn::Brush>>,
+) -> OperatorResult {
+    switch_brush_edit_mode(
+        BrushEditMode::Clip,
+        edit_mode,
+        brush_selection,
+        draw_state,
+        selection,
+        brushes,
+    )
+}
+
+#[operator(
+    id = "edit_mode.physics",
+    label = "Physics Tool",
+    allows_undo = false,
+    is_available = can_change_edit_mode
+)]
+fn edit_mode_physics(
+    _: In<OperatorParameters>,
+    mut edit_mode: ResMut<EditMode>,
+    mut brush_selection: ResMut<BrushSelection>,
+    mut draw_state: ResMut<DrawBrushState>,
+) -> OperatorResult {
+    draw_state.active = None;
+    clear_brush_selection(&mut brush_selection);
+    *edit_mode = if *edit_mode == EditMode::Physics {
+        EditMode::Object
+    } else {
+        EditMode::Physics
+    };
+    OperatorResult::Finished
+}
+
+fn switch_brush_edit_mode(
+    target: BrushEditMode,
+    mut edit_mode: ResMut<EditMode>,
+    mut brush_selection: ResMut<BrushSelection>,
+    mut draw_state: ResMut<DrawBrushState>,
+    selection: Res<Selection>,
+    brushes: Query<(), With<jackdaw_jsn::Brush>>,
+) -> OperatorResult {
+    draw_state.active = None;
+
+    match *edit_mode {
+        EditMode::BrushEdit(current) if current == target => {
+            // Same mode pressed twice: toggle back to Object.
+            *edit_mode = EditMode::Object;
+            clear_brush_selection(&mut brush_selection);
+        }
+        EditMode::BrushEdit(_) => {
+            // Switching between brush sub-modes: swap the mode but
+            // keep the entity selected. Drop any sub-element picks
+            // (indices are per-mode and don't translate across).
+            *edit_mode = EditMode::BrushEdit(target);
+            brush_selection.faces.clear();
+            brush_selection.vertices.clear();
+            brush_selection.edges.clear();
+        }
+        _ => {
+            // Entering from Object / Physics requires a selected
+            // brush; otherwise the op is a no-op.
+            let Some(entity) = selection.primary().filter(|&e| brushes.contains(e)) else {
+                return OperatorResult::Cancelled;
+            };
+            *edit_mode = EditMode::BrushEdit(target);
+            brush_selection.entity = Some(entity);
+            brush_selection.faces.clear();
+            brush_selection.vertices.clear();
+            brush_selection.edges.clear();
+        }
+    }
+    OperatorResult::Finished
+}
+
+fn clear_brush_selection(brush_selection: &mut BrushSelection) {
+    brush_selection.entity = None;
+    brush_selection.faces.clear();
+    brush_selection.vertices.clear();
+    brush_selection.edges.clear();
+}

--- a/src/edit_mode_ops.rs
+++ b/src/edit_mode_ops.rs
@@ -81,7 +81,7 @@ fn can_change_edit_mode(
     allows_undo = false,
     is_available = can_change_edit_mode
 )]
-fn edit_mode_object(
+pub(crate) fn edit_mode_object(
     _: In<OperatorParameters>,
     mut edit_mode: ResMut<EditMode>,
     mut brush_selection: ResMut<BrushSelection>,
@@ -99,7 +99,7 @@ fn edit_mode_object(
     allows_undo = false,
     is_available = can_change_edit_mode
 )]
-fn edit_mode_vertex(
+pub(crate) fn edit_mode_vertex(
     _: In<OperatorParameters>,
     edit_mode: ResMut<EditMode>,
     brush_selection: ResMut<BrushSelection>,
@@ -123,7 +123,7 @@ fn edit_mode_vertex(
     allows_undo = false,
     is_available = can_change_edit_mode
 )]
-fn edit_mode_edge(
+pub(crate) fn edit_mode_edge(
     _: In<OperatorParameters>,
     edit_mode: ResMut<EditMode>,
     brush_selection: ResMut<BrushSelection>,
@@ -147,7 +147,7 @@ fn edit_mode_edge(
     allows_undo = false,
     is_available = can_change_edit_mode
 )]
-fn edit_mode_face(
+pub(crate) fn edit_mode_face(
     _: In<OperatorParameters>,
     edit_mode: ResMut<EditMode>,
     brush_selection: ResMut<BrushSelection>,
@@ -171,7 +171,7 @@ fn edit_mode_face(
     allows_undo = false,
     is_available = can_change_edit_mode
 )]
-fn edit_mode_clip(
+pub(crate) fn edit_mode_clip(
     _: In<OperatorParameters>,
     edit_mode: ResMut<EditMode>,
     brush_selection: ResMut<BrushSelection>,
@@ -195,7 +195,7 @@ fn edit_mode_clip(
     allows_undo = false,
     is_available = can_change_edit_mode
 )]
-fn edit_mode_physics(
+pub(crate) fn edit_mode_physics(
     _: In<OperatorParameters>,
     mut edit_mode: ResMut<EditMode>,
     mut brush_selection: ResMut<BrushSelection>,

--- a/src/gizmo_ops.rs
+++ b/src/gizmo_ops.rs
@@ -1,0 +1,107 @@
+//! Gizmo mode + space operators.
+//!
+//! Mode ops (`gizmo.mode.translate/rotate/scale`) flip the active
+//! transform gizmo. Space op (`gizmo.space.toggle`) flips world/local.
+//! All gated to Object mode so they don't fire while the user is
+//! editing brush sub-elements or mid-modal.
+//!
+//! Default keybinds: R=rotate, T=scale, Escape=translate, X=space
+//! toggle.
+
+use bevy::{input_focus::InputFocus, prelude::*};
+use bevy_enhanced_input::prelude::{Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::core_extension::CoreExtensionInputContext;
+use crate::gizmos::{GizmoMode, GizmoSpace};
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<GizmoModeTranslateOp>()
+        .register_operator::<GizmoModeRotateOp>()
+        .register_operator::<GizmoModeScaleOp>()
+        .register_operator::<GizmoSpaceToggleOp>();
+
+    let ext = ctx.id();
+    ctx.entity_mut().world_scope(|world| {
+        world.spawn((
+            Action::<GizmoModeRotateOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::KeyR, Press::default())],
+        ));
+        world.spawn((
+            Action::<GizmoModeScaleOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::KeyT, Press::default())],
+        ));
+        world.spawn((
+            Action::<GizmoModeTranslateOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::Escape, Press::default())],
+        ));
+        world.spawn((
+            Action::<GizmoSpaceToggleOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::KeyX, Press::default())],
+        ));
+    });
+}
+
+/// Gizmo mode changes are ignored while any overlay is typing into a
+/// text field or a modal operator is in flight — matches the guards
+/// the legacy handler used to apply.
+fn can_change_gizmo(
+    input_focus: Res<InputFocus>,
+    edit_mode: Res<crate::brush::EditMode>,
+    active: ActiveModalQuery,
+) -> bool {
+    input_focus.0.is_none()
+        && !active.is_modal_running()
+        && *edit_mode == crate::brush::EditMode::Object
+}
+
+#[operator(
+    id = "gizmo.mode.translate",
+    label = "Gizmo Translate",
+    allows_undo = false,
+    is_available = can_change_gizmo
+)]
+fn gizmo_mode_translate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+    *mode = GizmoMode::Translate;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "gizmo.mode.rotate",
+    label = "Gizmo Rotate",
+    allows_undo = false,
+    is_available = can_change_gizmo
+)]
+fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+    *mode = GizmoMode::Rotate;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "gizmo.mode.scale",
+    label = "Gizmo Scale",
+    allows_undo = false,
+    is_available = can_change_gizmo
+)]
+fn gizmo_mode_scale(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+    *mode = GizmoMode::Scale;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "gizmo.space.toggle",
+    label = "Toggle Gizmo Space",
+    allows_undo = false,
+    is_available = can_change_gizmo
+)]
+fn gizmo_space_toggle(_: In<OperatorParameters>, mut space: ResMut<GizmoSpace>) -> OperatorResult {
+    *space = match *space {
+        GizmoSpace::World => GizmoSpace::Local,
+        GizmoSpace::Local => GizmoSpace::World,
+    };
+    OperatorResult::Finished
+}

--- a/src/gizmo_ops.rs
+++ b/src/gizmo_ops.rs
@@ -65,7 +65,10 @@ fn can_change_gizmo(
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-pub(crate) fn gizmo_mode_translate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+pub(crate) fn gizmo_mode_translate(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<GizmoMode>,
+) -> OperatorResult {
     *mode = GizmoMode::Translate;
     OperatorResult::Finished
 }
@@ -76,7 +79,10 @@ pub(crate) fn gizmo_mode_translate(_: In<OperatorParameters>, mut mode: ResMut<G
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-pub(crate) fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+pub(crate) fn gizmo_mode_rotate(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<GizmoMode>,
+) -> OperatorResult {
     *mode = GizmoMode::Rotate;
     OperatorResult::Finished
 }
@@ -87,7 +93,10 @@ pub(crate) fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<Gizm
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-pub(crate) fn gizmo_mode_scale(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+pub(crate) fn gizmo_mode_scale(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<GizmoMode>,
+) -> OperatorResult {
     *mode = GizmoMode::Scale;
     OperatorResult::Finished
 }
@@ -98,7 +107,10 @@ pub(crate) fn gizmo_mode_scale(_: In<OperatorParameters>, mut mode: ResMut<Gizmo
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-pub(crate) fn gizmo_space_toggle(_: In<OperatorParameters>, mut space: ResMut<GizmoSpace>) -> OperatorResult {
+pub(crate) fn gizmo_space_toggle(
+    _: In<OperatorParameters>,
+    mut space: ResMut<GizmoSpace>,
+) -> OperatorResult {
     *space = match *space {
         GizmoSpace::World => GizmoSpace::Local,
         GizmoSpace::Local => GizmoSpace::World,

--- a/src/gizmo_ops.rs
+++ b/src/gizmo_ops.rs
@@ -65,7 +65,7 @@ fn can_change_gizmo(
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-fn gizmo_mode_translate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+pub(crate) fn gizmo_mode_translate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
     *mode = GizmoMode::Translate;
     OperatorResult::Finished
 }
@@ -76,7 +76,7 @@ fn gizmo_mode_translate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) 
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+pub(crate) fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
     *mode = GizmoMode::Rotate;
     OperatorResult::Finished
 }
@@ -87,7 +87,7 @@ fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> 
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-fn gizmo_mode_scale(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
+pub(crate) fn gizmo_mode_scale(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
     *mode = GizmoMode::Scale;
     OperatorResult::Finished
 }
@@ -98,7 +98,7 @@ fn gizmo_mode_scale(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> O
     allows_undo = false,
     is_available = can_change_gizmo
 )]
-fn gizmo_space_toggle(_: In<OperatorParameters>, mut space: ResMut<GizmoSpace>) -> OperatorResult {
+pub(crate) fn gizmo_space_toggle(_: In<OperatorParameters>, mut space: ResMut<GizmoSpace>) -> OperatorResult {
     *space = match *space {
         GizmoSpace::World => GizmoSpace::Local,
         GizmoSpace::Local => GizmoSpace::World,

--- a/src/gizmos.rs
+++ b/src/gizmos.rs
@@ -81,11 +81,7 @@ impl Plugin for TransformGizmosPlugin {
             .add_systems(Startup, configure_transform_gizmos)
             .add_systems(
                 Update,
-                (
-                    handle_gizmo_mode_keys,
-                    handle_gizmo_hover,
-                    handle_gizmo_drag,
-                )
+                (handle_gizmo_hover, handle_gizmo_drag)
                     .chain()
                     .in_set(crate::EditorInteractionSystems),
             )
@@ -102,42 +98,6 @@ fn configure_transform_gizmos(mut config_store: ResMut<GizmoConfigStore>) {
     let (config, _) = config_store.config_mut::<TransformGizmoGroup>();
     config.depth_bias = -1.0;
     config.line.width = 3.0;
-}
-
-fn handle_gizmo_mode_keys(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    keybinds: Res<crate::keybinds::KeybindRegistry>,
-    mut mode: ResMut<GizmoMode>,
-    mut space: ResMut<GizmoSpace>,
-    drag_state: Res<GizmoDragState>,
-    modal: Res<ModalTransformState>,
-    edit_mode: Res<crate::brush::EditMode>,
-) {
-    // Don't switch modes while dragging, during modal ops, or in brush edit mode
-    if drag_state.active || modal.active.is_some() {
-        return;
-    }
-    if *edit_mode != crate::brush::EditMode::Object {
-        return;
-    }
-
-    use crate::keybinds::EditorAction;
-
-    if keybinds.just_pressed(EditorAction::GizmoRotate, &keyboard) {
-        *mode = GizmoMode::Rotate;
-    }
-    if keybinds.just_pressed(EditorAction::GizmoScale, &keyboard) {
-        *mode = GizmoMode::Scale;
-    }
-    if keybinds.just_pressed(EditorAction::GizmoTranslate, &keyboard) {
-        *mode = GizmoMode::Translate;
-    }
-    if keybinds.just_pressed(EditorAction::ToggleGizmoSpace, &keyboard) {
-        *space = match *space {
-            GizmoSpace::World => GizmoSpace::Local,
-            GizmoSpace::Local => GizmoSpace::World,
-        };
-    }
 }
 
 pub(crate) fn handle_gizmo_hover(

--- a/src/grid_ops.rs
+++ b/src/grid_ops.rs
@@ -32,14 +32,20 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 }
 
 #[operator(id = "grid.increase", label = "Increase Grid", allows_undo = false)]
-pub(crate) fn grid_increase(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
+pub(crate) fn grid_increase(
+    _: In<OperatorParameters>,
+    mut snap: ResMut<SnapSettings>,
+) -> OperatorResult {
     snap.grid_power = i32::min(snap.grid_power + 1, GRID_POWER_MAX);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished
 }
 
 #[operator(id = "grid.decrease", label = "Decrease Grid", allows_undo = false)]
-pub(crate) fn grid_decrease(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
+pub(crate) fn grid_decrease(
+    _: In<OperatorParameters>,
+    mut snap: ResMut<SnapSettings>,
+) -> OperatorResult {
     snap.grid_power = i32::max(snap.grid_power - 1, GRID_POWER_MIN);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished

--- a/src/grid_ops.rs
+++ b/src/grid_ops.rs
@@ -1,0 +1,46 @@
+//! Grid-size operators: increase / decrease the editor grid by one
+//! power. Flips a resource, no history entry.
+//!
+//! Default keybinds: `]` (increase), `[` (decrease). The scroll-wheel
+//! path for grid resize lives alongside the modifier-gated scroll
+//! handler in [`crate::snapping`].
+
+use bevy::prelude::*;
+use bevy_enhanced_input::prelude::{Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::core_extension::CoreExtensionInputContext;
+use crate::snapping::{GRID_POWER_MAX, GRID_POWER_MIN, SnapSettings};
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<GridIncreaseOp>()
+        .register_operator::<GridDecreaseOp>();
+
+    let ext = ctx.id();
+    ctx.entity_mut().world_scope(|world| {
+        world.spawn((
+            Action::<GridIncreaseOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::BracketRight, Press::default())],
+        ));
+        world.spawn((
+            Action::<GridDecreaseOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::BracketLeft, Press::default())],
+        ));
+    });
+}
+
+#[operator(id = "grid.increase", label = "Increase Grid", allows_undo = false)]
+fn grid_increase(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
+    snap.grid_power = (snap.grid_power + 1).min(GRID_POWER_MAX);
+    snap.translate_increment = snap.grid_size();
+    OperatorResult::Finished
+}
+
+#[operator(id = "grid.decrease", label = "Decrease Grid", allows_undo = false)]
+fn grid_decrease(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
+    snap.grid_power = (snap.grid_power - 1).max(GRID_POWER_MIN);
+    snap.translate_increment = snap.grid_size();
+    OperatorResult::Finished
+}

--- a/src/grid_ops.rs
+++ b/src/grid_ops.rs
@@ -33,14 +33,14 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 
 #[operator(id = "grid.increase", label = "Increase Grid", allows_undo = false)]
 fn grid_increase(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
-    snap.grid_power = (snap.grid_power + 1).min(GRID_POWER_MAX);
+    snap.grid_power = i32::min(snap.grid_power + 1, GRID_POWER_MAX);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished
 }
 
 #[operator(id = "grid.decrease", label = "Decrease Grid", allows_undo = false)]
 fn grid_decrease(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
-    snap.grid_power = (snap.grid_power - 1).max(GRID_POWER_MIN);
+    snap.grid_power = i32::max(snap.grid_power - 1, GRID_POWER_MIN);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished
 }

--- a/src/grid_ops.rs
+++ b/src/grid_ops.rs
@@ -32,14 +32,14 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 }
 
 #[operator(id = "grid.increase", label = "Increase Grid", allows_undo = false)]
-fn grid_increase(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
+pub(crate) fn grid_increase(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
     snap.grid_power = i32::min(snap.grid_power + 1, GRID_POWER_MAX);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished
 }
 
 #[operator(id = "grid.decrease", label = "Decrease Grid", allows_undo = false)]
-fn grid_decrease(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
+pub(crate) fn grid_decrease(_: In<OperatorParameters>, mut snap: ResMut<SnapSettings>) -> OperatorResult {
     snap.grid_power = i32::max(snap.grid_power - 1, GRID_POWER_MIN);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -15,6 +15,11 @@ use crate::{
     EditorEntity,
     brush::{BrushEditMode, EditMode},
     draw_brush::{ActivateDrawBrushModalOp, DrawBrushState},
+    edit_mode_ops::{
+        EditModeClipOp, EditModeEdgeOp, EditModeFaceOp, EditModeObjectOp, EditModePhysicsOp,
+        EditModeVertexOp,
+    },
+    gizmo_ops::{GizmoModeRotateOp, GizmoModeScaleOp, GizmoModeTranslateOp, GizmoSpaceToggleOp},
     gizmos::{GizmoMode, GizmoSpace},
     hierarchy::{HierarchyPanel, HierarchyShowAllButton, HierarchyTreeContainer},
     inspector::Inspector,
@@ -611,9 +616,9 @@ fn toolbar_button(
 ) -> impl Bundle {
     let label = label.to_string();
     let op_id: &'static str = match mode {
-        GizmoMode::Translate => "gizmo.mode.translate",
-        GizmoMode::Rotate => "gizmo.mode.rotate",
-        GizmoMode::Scale => "gizmo.mode.scale",
+        GizmoMode::Translate => GizmoModeTranslateOp::ID,
+        GizmoMode::Rotate => GizmoModeRotateOp::ID,
+        GizmoMode::Scale => GizmoModeScaleOp::ID,
     };
     (
         GizmoModeButton(mode),
@@ -694,7 +699,7 @@ fn toolbar_space_button(icon_font: Handle<Font>) -> impl Bundle {
         ],
         observe(|_: On<Pointer<Click>>, mut commands: Commands| {
             commands
-                .operator("gizmo.space.toggle")
+                .operator(GizmoSpaceToggleOp::ID)
                 .settings(CallOperatorSettings {
                     execution_context: ExecutionContext::Invoke,
                     creates_history_entry: true,
@@ -733,12 +738,12 @@ fn toolbar_edit_button(
         )],
         observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
             let op_id: Cow<'static, str> = match tool {
-                EditToolButton::Object => "edit_mode.object".into(),
-                EditToolButton::Vertex => "edit_mode.vertex".into(),
-                EditToolButton::Edge => "edit_mode.edge".into(),
-                EditToolButton::Face => "edit_mode.face".into(),
-                EditToolButton::Clip => "edit_mode.clip".into(),
-                EditToolButton::Physics => "edit_mode.physics".into(),
+                EditToolButton::Object => EditModeObjectOp::ID.into(),
+                EditToolButton::Vertex => EditModeVertexOp::ID.into(),
+                EditToolButton::Edge => EditModeEdgeOp::ID.into(),
+                EditToolButton::Face => EditModeFaceOp::ID.into(),
+                EditToolButton::Clip => EditModeClipOp::ID.into(),
+                EditToolButton::Physics => EditModePhysicsOp::ID.into(),
                 EditToolButton::Operator(op) => op.into(),
             };
             commands

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use bevy::{feathers::theme::ThemedText, picking::hover::Hovered, prelude::*, ui_widgets::observe};
 use jackdaw_api::prelude::*;
 use jackdaw_feathers::{
@@ -11,13 +13,12 @@ use jackdaw_feathers::{
 
 use crate::{
     EditorEntity,
-    brush::{BrushEditMode, BrushSelection, EditMode},
+    brush::{BrushEditMode, EditMode},
     draw_brush::{ActivateDrawBrushModalOp, DrawBrushState},
     gizmos::{GizmoMode, GizmoSpace},
     hierarchy::{HierarchyPanel, HierarchyShowAllButton, HierarchyTreeContainer},
     inspector::Inspector,
     remote::ConnectionManager,
-    selection::Selection,
     viewport::SceneViewport,
 };
 
@@ -609,6 +610,11 @@ fn toolbar_button(
     tooltip: &str,
 ) -> impl Bundle {
     let label = label.to_string();
+    let op_id: &'static str = match mode {
+        GizmoMode::Translate => "gizmo.mode.translate",
+        GizmoMode::Rotate => "gizmo.mode.rotate",
+        GizmoMode::Scale => "gizmo.mode.scale",
+    };
     (
         GizmoModeButton(mode),
         Hovered::default(),
@@ -641,11 +647,15 @@ fn toolbar_button(
                 ThemedText,
             )
         ],
-        observe(
-            move |_: On<Pointer<Click>>, mut gizmo_mode: ResMut<GizmoMode>| {
-                *gizmo_mode = mode;
-            },
-        ),
+        observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            commands
+                .operator(op_id)
+                .settings(CallOperatorSettings {
+                    execution_context: ExecutionContext::Invoke,
+                    creates_history_entry: true,
+                })
+                .call();
+        }),
     )
 }
 
@@ -682,11 +692,14 @@ fn toolbar_space_button(icon_font: Handle<Font>) -> impl Bundle {
                 ThemedText,
             )
         ],
-        observe(|_: On<Pointer<Click>>, mut space: ResMut<GizmoSpace>| {
-            *space = match *space {
-                GizmoSpace::World => GizmoSpace::Local,
-                GizmoSpace::Local => GizmoSpace::World,
-            };
+        observe(|_: On<Pointer<Click>>, mut commands: Commands| {
+            commands
+                .operator("gizmo.space.toggle")
+                .settings(CallOperatorSettings {
+                    execution_context: ExecutionContext::Invoke,
+                    creates_history_entry: true,
+                })
+                .call();
         }),
     )
 }
@@ -718,89 +731,24 @@ fn toolbar_edit_button(
             },
             TextColor(tokens::TEXT_SECONDARY),
         )],
-        observe(
-            move |_: On<Pointer<Click>>,
-                  mut commands: Commands,
-                  mut edit_mode: ResMut<EditMode>,
-                  mut brush_selection: ResMut<BrushSelection>,
-                  mut draw_state: ResMut<DrawBrushState>,
-                  selection: Res<Selection>,
-                  brushes: Query<(), With<jackdaw_jsn::Brush>>| {
-                match tool {
-                    EditToolButton::Object => {
-                        *edit_mode = EditMode::Object;
-                        brush_selection.entity = None;
-                        brush_selection.faces.clear();
-                        brush_selection.vertices.clear();
-                        brush_selection.edges.clear();
-                        draw_state.active = None;
-                    }
-                    EditToolButton::Physics => {
-                        draw_state.active = None;
-                        brush_selection.entity = None;
-                        brush_selection.faces.clear();
-                        brush_selection.vertices.clear();
-                        brush_selection.edges.clear();
-                        if *edit_mode == EditMode::Physics {
-                            // Toggle off
-                            *edit_mode = EditMode::Object;
-                        } else {
-                            *edit_mode = EditMode::Physics;
-                        }
-                    }
-                    EditToolButton::Vertex
-                    | EditToolButton::Edge
-                    | EditToolButton::Face
-                    | EditToolButton::Clip => {
-                        // Cancel draw mode if active
-                        draw_state.active = None;
-
-                        let target_mode = match tool {
-                            EditToolButton::Vertex => BrushEditMode::Vertex,
-                            EditToolButton::Edge => BrushEditMode::Edge,
-                            EditToolButton::Face => BrushEditMode::Face,
-                            EditToolButton::Clip => BrushEditMode::Clip,
-                            _ => unreachable!(),
-                        };
-
-                        if let EditMode::BrushEdit(current) = *edit_mode {
-                            if current == target_mode {
-                                // Same mode: toggle off
-                                *edit_mode = EditMode::Object;
-                                brush_selection.entity = None;
-                                brush_selection.faces.clear();
-                                brush_selection.vertices.clear();
-                                brush_selection.edges.clear();
-                            } else {
-                                // Switch sub-mode
-                                *edit_mode = EditMode::BrushEdit(target_mode);
-                                brush_selection.faces.clear();
-                                brush_selection.vertices.clear();
-                                brush_selection.edges.clear();
-                            }
-                        } else {
-                            // Enter edit on primary if it's a brush
-                            if let Some(entity) =
-                                selection.primary().filter(|&e| brushes.contains(e))
-                            {
-                                *edit_mode = EditMode::BrushEdit(target_mode);
-                                brush_selection.entity = Some(entity);
-                                brush_selection.faces.clear();
-                                brush_selection.vertices.clear();
-                                brush_selection.edges.clear();
-                            }
-                        }
-                    }
-                    EditToolButton::Operator(op) => commands
-                        .operator(op)
-                        .settings(CallOperatorSettings {
-                            execution_context: ExecutionContext::Invoke,
-                            creates_history_entry: true,
-                        })
-                        .call(),
-                }
-            },
-        ),
+        observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            let op_id: Cow<'static, str> = match tool {
+                EditToolButton::Object => "edit_mode.object".into(),
+                EditToolButton::Vertex => "edit_mode.vertex".into(),
+                EditToolButton::Edge => "edit_mode.edge".into(),
+                EditToolButton::Face => "edit_mode.face".into(),
+                EditToolButton::Clip => "edit_mode.clip".into(),
+                EditToolButton::Physics => "edit_mode.physics".into(),
+                EditToolButton::Operator(op) => op.into(),
+            };
+            commands
+                .operator(op_id)
+                .settings(CallOperatorSettings {
+                    execution_context: ExecutionContext::Invoke,
+                    creates_history_entry: true,
+                })
+                .call();
+        }),
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,13 @@ pub mod commands;
 pub mod custom_properties;
 pub mod default_style;
 pub mod draw_brush;
+pub mod edit_mode_ops;
 pub mod entity_ops;
 pub mod entity_templates;
 pub mod face_grid;
+pub mod gizmo_ops;
 pub mod gizmos;
+pub mod grid_ops;
 pub mod hierarchy;
 pub mod history_ops;
 pub mod inspector;
@@ -56,6 +59,7 @@ pub mod terrain;
 pub mod texture_browser;
 pub mod undo_snapshot;
 pub mod view_modes;
+pub mod view_ops;
 pub mod viewport;
 pub mod viewport_overlays;
 pub mod viewport_select;
@@ -1934,15 +1938,15 @@ fn populate_menu(
             (
                 "View",
                 vec![
-                    ("view.wireframe", "Toggle Wireframe"),
-                    ("view.bounding_boxes", "Toggle Bounding Boxes"),
-                    ("view.bounding_box_mode", "Cycle Bounding Box Mode"),
-                    ("view.face_grid", "Toggle Face Grid"),
-                    ("view.brush_wireframe", "Toggle Brush Wireframe"),
-                    ("view.show_brush_outline", "Toggle Brush Outline"),
-                    ("view.alignment_guides", "Toggle Alignment Guides"),
-                    ("view.collider_gizmos", "Toggle Collider Gizmos"),
-                    ("view.hierarchy_arrows", "Toggle Hierarchy Arrows"),
+                    ("op:view.toggle_wireframe", "Toggle Wireframe"),
+                    ("op:view.toggle_bounding_boxes", "Toggle Bounding Boxes"),
+                    ("op:view.cycle_bounding_box_mode", "Cycle Bounding Box Mode"),
+                    ("op:view.toggle_face_grid", "Toggle Face Grid"),
+                    ("op:view.toggle_brush_wireframe", "Toggle Brush Wireframe"),
+                    ("op:view.toggle_brush_outline", "Toggle Brush Outline"),
+                    ("op:view.toggle_alignment_guides", "Toggle Alignment Guides"),
+                    ("op:view.toggle_collider_gizmos", "Toggle Collider Gizmos"),
+                    ("op:view.toggle_hierarchy_arrows", "Toggle Hierarchy Arrows"),
                 ],
             ),
             ("Add", add_menu_refs),
@@ -2029,69 +2033,6 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
                     bs.vertices.clear();
                     bs.edges.clear();
                 }
-            });
-        }
-        "view.wireframe" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<view_modes::ViewModeSettings>();
-                settings.wireframe = !settings.wireframe;
-            });
-        }
-        "view.bounding_boxes" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<viewport_overlays::OverlaySettings>();
-                settings.show_bounding_boxes = !settings.show_bounding_boxes;
-            });
-        }
-        "view.bounding_box_mode" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<viewport_overlays::OverlaySettings>();
-                settings.bounding_box_mode = match settings.bounding_box_mode {
-                    viewport_overlays::BoundingBoxMode::Aabb => {
-                        viewport_overlays::BoundingBoxMode::ConvexHull
-                    }
-                    viewport_overlays::BoundingBoxMode::ConvexHull => {
-                        viewport_overlays::BoundingBoxMode::Aabb
-                    }
-                };
-            });
-        }
-        "view.face_grid" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<viewport_overlays::OverlaySettings>();
-                settings.show_face_grid = !settings.show_face_grid;
-            });
-        }
-        "view.brush_wireframe" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<viewport_overlays::OverlaySettings>();
-                settings.show_brush_wireframe = !settings.show_brush_wireframe;
-            });
-        }
-        "view.show_brush_outline" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<viewport_overlays::OverlaySettings>();
-                settings.show_brush_outline = !settings.show_brush_outline;
-            });
-        }
-        "view.alignment_guides" => {
-            commands.queue(|world: &mut World| {
-                let mut settings = world.resource_mut::<viewport_overlays::OverlaySettings>();
-                settings.show_alignment_guides = !settings.show_alignment_guides;
-            });
-        }
-        "view.collider_gizmos" => {
-            commands.queue(|world: &mut World| {
-                let mut config =
-                    world.resource_mut::<jackdaw_avian_integration::PhysicsOverlayConfig>();
-                config.show_colliders = !config.show_colliders;
-            });
-        }
-        "view.hierarchy_arrows" => {
-            commands.queue(|world: &mut World| {
-                let mut config =
-                    world.resource_mut::<jackdaw_avian_integration::PhysicsOverlayConfig>();
-                config.show_hierarchy_arrows = !config.show_hierarchy_arrows;
             });
         }
         "add.cube" => {

--- a/src/snapping.rs
+++ b/src/snapping.rs
@@ -15,12 +15,12 @@ impl Plugin for SnappingPlugin {
             .init_resource::<GridSettings>()
             .add_systems(
                 Update,
-                handle_grid_size_keys.in_set(crate::EditorInteractionSystems),
+                handle_grid_size_scroll.in_set(crate::EditorInteractionSystems),
             )
             .add_systems(
                 Update,
                 sync_grid_settings
-                    .after(handle_grid_size_keys)
+                    .after(handle_grid_size_scroll)
                     .run_if(in_state(crate::AppState::Editor)),
             );
     }
@@ -211,9 +211,11 @@ impl SnapSettings {
     }
 }
 
-fn handle_grid_size_keys(
+/// Scroll-wheel grid size control. Continuous-input, so it stays as a
+/// system rather than an operator. Bracket-key bindings live on
+/// [`crate::grid_ops::GridIncreaseOp`]/[`crate::grid_ops::GridDecreaseOp`].
+fn handle_grid_size_scroll(
     keyboard: Res<ButtonInput<KeyCode>>,
-    keybinds: Res<crate::keybinds::KeybindRegistry>,
     input_focus: Res<InputFocus>,
     modal: Res<crate::modal_transform::ModalTransformState>,
     terrain_edit_mode: Res<crate::terrain::TerrainEditMode>,
@@ -236,33 +238,23 @@ fn handle_grid_size_keys(
             crate::terrain::TerrainEditMode::Sculpt(_)
         );
 
+    if !((ctrl && alt) || shift_grid) {
+        return;
+    }
+
     let mut changed = false;
-
-    // Ctrl+Alt+Scroll or Shift+Scroll (non-sculpt): change grid size
-    if (ctrl && alt) || shift_grid {
-        for event in scroll_events.read() {
-            let delta = match event.unit {
-                MouseScrollUnit::Line => event.y,
-                MouseScrollUnit::Pixel => event.y * 0.01,
-            };
-            if delta > 0.0 {
-                snap.grid_power = (snap.grid_power + 1).min(GRID_POWER_MAX);
-                changed = true;
-            } else if delta < 0.0 {
-                snap.grid_power = (snap.grid_power - 1).max(GRID_POWER_MIN);
-                changed = true;
-            }
+    for event in scroll_events.read() {
+        let delta = match event.unit {
+            MouseScrollUnit::Line => event.y,
+            MouseScrollUnit::Pixel => event.y * 0.01,
+        };
+        if delta > 0.0 {
+            snap.grid_power = (snap.grid_power + 1).min(GRID_POWER_MAX);
+            changed = true;
+        } else if delta < 0.0 {
+            snap.grid_power = (snap.grid_power - 1).max(GRID_POWER_MIN);
+            changed = true;
         }
-    }
-
-    // Bracket keys: alternative grid size control
-    if keybinds.just_pressed(crate::keybinds::EditorAction::DecreaseGrid, &keyboard) {
-        snap.grid_power = (snap.grid_power - 1).max(GRID_POWER_MIN);
-        changed = true;
-    }
-    if keybinds.just_pressed(crate::keybinds::EditorAction::IncreaseGrid, &keyboard) {
-        snap.grid_power = (snap.grid_power + 1).min(GRID_POWER_MAX);
-        changed = true;
     }
     if changed {
         snap.translate_increment = snap.grid_size();

--- a/src/snapping.rs
+++ b/src/snapping.rs
@@ -4,6 +4,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_infinite_grid::{InfiniteGrid, InfiniteGridSettings};
+use jackdaw_api::op::{Operator, OperatorCommandsExt as _};
 
 use crate::default_style;
 
@@ -212,15 +213,17 @@ impl SnapSettings {
 }
 
 /// Scroll-wheel grid size control. Continuous-input, so it stays as a
-/// system rather than an operator. Bracket-key bindings live on
-/// [`crate::grid_ops::GridIncreaseOp`]/[`crate::grid_ops::GridDecreaseOp`].
+/// system rather than an operator. The actual power bump is delegated
+/// to [`crate::grid_ops::GridIncreaseOp`] /
+/// [`crate::grid_ops::GridDecreaseOp`] (also bound to the bracket
+/// keys) so the clamp + translate-increment refresh live in one place.
 fn handle_grid_size_scroll(
     keyboard: Res<ButtonInput<KeyCode>>,
     input_focus: Res<InputFocus>,
     modal: Res<crate::modal_transform::ModalTransformState>,
     terrain_edit_mode: Res<crate::terrain::TerrainEditMode>,
     mut scroll_events: MessageReader<MouseWheel>,
-    mut snap: ResMut<SnapSettings>,
+    mut commands: Commands,
 ) {
     if input_focus.0.is_some() || modal.active.is_some() {
         return;
@@ -242,21 +245,15 @@ fn handle_grid_size_scroll(
         return;
     }
 
-    let mut changed = false;
     for event in scroll_events.read() {
         let delta = match event.unit {
             MouseScrollUnit::Line => event.y,
             MouseScrollUnit::Pixel => event.y * 0.01,
         };
         if delta > 0.0 {
-            snap.grid_power = (snap.grid_power + 1).min(GRID_POWER_MAX);
-            changed = true;
+            commands.operator(crate::grid_ops::GridIncreaseOp::ID).call();
         } else if delta < 0.0 {
-            snap.grid_power = (snap.grid_power - 1).max(GRID_POWER_MIN);
-            changed = true;
+            commands.operator(crate::grid_ops::GridDecreaseOp::ID).call();
         }
-    }
-    if changed {
-        snap.translate_increment = snap.grid_size();
     }
 }

--- a/src/snapping.rs
+++ b/src/snapping.rs
@@ -251,9 +251,13 @@ fn handle_grid_size_scroll(
             MouseScrollUnit::Pixel => event.y * 0.01,
         };
         if delta > 0.0 {
-            commands.operator(crate::grid_ops::GridIncreaseOp::ID).call();
+            commands
+                .operator(crate::grid_ops::GridIncreaseOp::ID)
+                .call();
         } else if delta < 0.0 {
-            commands.operator(crate::grid_ops::GridDecreaseOp::ID).call();
+            commands
+                .operator(crate::grid_ops::GridDecreaseOp::ID)
+                .call();
         }
     }
 }

--- a/src/view_ops.rs
+++ b/src/view_ops.rs
@@ -1,0 +1,123 @@
+//! View-mode toggles: wireframe, bounding boxes, face grid, etc.
+//!
+//! Each op just flips a resource. `allows_undo = false` so they don't
+//! push snapshot diffs to the history stack. Only `view.toggle_wireframe`
+//! has a default keybind (`Ctrl+Shift+W`); the rest are menu-only.
+
+use bevy::prelude::*;
+use bevy_enhanced_input::prelude::{Chord, Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+    ctx.register_operator::<ViewToggleWireframeOp>()
+        .register_operator::<ViewToggleBoundingBoxesOp>()
+        .register_operator::<ViewCycleBoundingBoxModeOp>()
+        .register_operator::<ViewToggleFaceGridOp>()
+        .register_operator::<ViewToggleBrushWireframeOp>()
+        .register_operator::<ViewToggleBrushOutlineOp>()
+        .register_operator::<ViewToggleAlignmentGuidesOp>()
+        .register_operator::<ViewToggleColliderGizmosOp>()
+        .register_operator::<ViewToggleHierarchyArrowsOp>();
+
+    let ext = ctx.id();
+    let ctrl = modifiers.ctrl;
+    let shift = modifiers.shift;
+    ctx.entity_mut().world_scope(|world| {
+        world.spawn((
+            Action::<ViewToggleWireframeOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::new([ctrl, shift]),
+            bindings![(KeyCode::KeyW, Press::default())],
+        ));
+    });
+}
+
+#[operator(id = "view.toggle_wireframe", label = "Toggle Wireframe", allows_undo = false)]
+fn view_toggle_wireframe(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::view_modes::ViewModeSettings>,
+) -> OperatorResult {
+    settings.wireframe = !settings.wireframe;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_bounding_boxes", label = "Toggle Bounding Boxes", allows_undo = false)]
+fn view_toggle_bounding_boxes(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
+) -> OperatorResult {
+    settings.show_bounding_boxes = !settings.show_bounding_boxes;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.cycle_bounding_box_mode", label = "Cycle Bounding Box Mode", allows_undo = false)]
+fn view_cycle_bounding_box_mode(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
+) -> OperatorResult {
+    settings.bounding_box_mode = match settings.bounding_box_mode {
+        crate::viewport_overlays::BoundingBoxMode::Aabb => {
+            crate::viewport_overlays::BoundingBoxMode::ConvexHull
+        }
+        crate::viewport_overlays::BoundingBoxMode::ConvexHull => {
+            crate::viewport_overlays::BoundingBoxMode::Aabb
+        }
+    };
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_face_grid", label = "Toggle Face Grid", allows_undo = false)]
+fn view_toggle_face_grid(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
+) -> OperatorResult {
+    settings.show_face_grid = !settings.show_face_grid;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_brush_wireframe", label = "Toggle Brush Wireframe", allows_undo = false)]
+fn view_toggle_brush_wireframe(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
+) -> OperatorResult {
+    settings.show_brush_wireframe = !settings.show_brush_wireframe;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_brush_outline", label = "Toggle Brush Outline", allows_undo = false)]
+fn view_toggle_brush_outline(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
+) -> OperatorResult {
+    settings.show_brush_outline = !settings.show_brush_outline;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_alignment_guides", label = "Toggle Alignment Guides", allows_undo = false)]
+fn view_toggle_alignment_guides(
+    _: In<OperatorParameters>,
+    mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
+) -> OperatorResult {
+    settings.show_alignment_guides = !settings.show_alignment_guides;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_collider_gizmos", label = "Toggle Collider Gizmos", allows_undo = false)]
+fn view_toggle_collider_gizmos(
+    _: In<OperatorParameters>,
+    mut config: ResMut<jackdaw_avian_integration::PhysicsOverlayConfig>,
+) -> OperatorResult {
+    config.show_colliders = !config.show_colliders;
+    OperatorResult::Finished
+}
+
+#[operator(id = "view.toggle_hierarchy_arrows", label = "Toggle Hierarchy Arrows", allows_undo = false)]
+fn view_toggle_hierarchy_arrows(
+    _: In<OperatorParameters>,
+    mut config: ResMut<jackdaw_avian_integration::PhysicsOverlayConfig>,
+) -> OperatorResult {
+    config.show_hierarchy_arrows = !config.show_hierarchy_arrows;
+    OperatorResult::Finished
+}

--- a/src/view_ops.rs
+++ b/src/view_ops.rs
@@ -34,7 +34,11 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers
     });
 }
 
-#[operator(id = "view.toggle_wireframe", label = "Toggle Wireframe", allows_undo = false)]
+#[operator(
+    id = "view.toggle_wireframe",
+    label = "Toggle Wireframe",
+    allows_undo = false
+)]
 fn view_toggle_wireframe(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::view_modes::ViewModeSettings>,
@@ -43,7 +47,11 @@ fn view_toggle_wireframe(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_bounding_boxes", label = "Toggle Bounding Boxes", allows_undo = false)]
+#[operator(
+    id = "view.toggle_bounding_boxes",
+    label = "Toggle Bounding Boxes",
+    allows_undo = false
+)]
 fn view_toggle_bounding_boxes(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -52,7 +60,11 @@ fn view_toggle_bounding_boxes(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.cycle_bounding_box_mode", label = "Cycle Bounding Box Mode", allows_undo = false)]
+#[operator(
+    id = "view.cycle_bounding_box_mode",
+    label = "Cycle Bounding Box Mode",
+    allows_undo = false
+)]
 fn view_cycle_bounding_box_mode(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -68,7 +80,11 @@ fn view_cycle_bounding_box_mode(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_face_grid", label = "Toggle Face Grid", allows_undo = false)]
+#[operator(
+    id = "view.toggle_face_grid",
+    label = "Toggle Face Grid",
+    allows_undo = false
+)]
 fn view_toggle_face_grid(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -77,7 +93,11 @@ fn view_toggle_face_grid(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_brush_wireframe", label = "Toggle Brush Wireframe", allows_undo = false)]
+#[operator(
+    id = "view.toggle_brush_wireframe",
+    label = "Toggle Brush Wireframe",
+    allows_undo = false
+)]
 fn view_toggle_brush_wireframe(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -86,7 +106,11 @@ fn view_toggle_brush_wireframe(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_brush_outline", label = "Toggle Brush Outline", allows_undo = false)]
+#[operator(
+    id = "view.toggle_brush_outline",
+    label = "Toggle Brush Outline",
+    allows_undo = false
+)]
 fn view_toggle_brush_outline(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -95,7 +119,11 @@ fn view_toggle_brush_outline(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_alignment_guides", label = "Toggle Alignment Guides", allows_undo = false)]
+#[operator(
+    id = "view.toggle_alignment_guides",
+    label = "Toggle Alignment Guides",
+    allows_undo = false
+)]
 fn view_toggle_alignment_guides(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -104,7 +132,11 @@ fn view_toggle_alignment_guides(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_collider_gizmos", label = "Toggle Collider Gizmos", allows_undo = false)]
+#[operator(
+    id = "view.toggle_collider_gizmos",
+    label = "Toggle Collider Gizmos",
+    allows_undo = false
+)]
 fn view_toggle_collider_gizmos(
     _: In<OperatorParameters>,
     mut config: ResMut<jackdaw_avian_integration::PhysicsOverlayConfig>,
@@ -113,7 +145,11 @@ fn view_toggle_collider_gizmos(
     OperatorResult::Finished
 }
 
-#[operator(id = "view.toggle_hierarchy_arrows", label = "Toggle Hierarchy Arrows", allows_undo = false)]
+#[operator(
+    id = "view.toggle_hierarchy_arrows",
+    label = "Toggle Hierarchy Arrows",
+    allows_undo = false
+)]
 fn view_toggle_hierarchy_arrows(
     _: In<OperatorParameters>,
     mut config: ResMut<jackdaw_avian_integration::PhysicsOverlayConfig>,


### PR DESCRIPTION
Phase 3 of #194. Stacked on #197.

Ports view overlay toggles, grid size changes, gizmo mode/space switches, and edit mode switches to operators. All `allows_undo = false`. BEI bindings replace the legacy keybind handlers for these, and toolbar buttons dispatch operators instead of mutating resources inline.