### PR TITLE
operatorify phase 4: entity ops, transforms, add-entity menu

### DIFF
--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -40,28 +40,34 @@ fn builtin_groups() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
     vec![
         (
             "Shapes",
-            vec![("add.cube", "Cube"), ("add.sphere", "Sphere")],
+            vec![
+                ("op:entity.add.cube", "Cube"),
+                ("op:entity.add.sphere", "Sphere"),
+            ],
         ),
         (
             "Lights",
             vec![
-                ("add.point_light", "Point Light"),
-                ("add.directional_light", "Directional Light"),
-                ("add.spot_light", "Spot Light"),
+                ("op:entity.add.point_light", "Point Light"),
+                ("op:entity.add.directional_light", "Directional Light"),
+                ("op:entity.add.spot_light", "Spot Light"),
             ],
         ),
         (
             "Cameras & Entities",
-            vec![("add.camera", "Camera"), ("add.empty", "Empty")],
+            vec![
+                ("op:entity.add.camera", "Camera"),
+                ("op:entity.add.empty", "Empty"),
+            ],
         ),
         (
             "Regions",
             vec![
-                ("add.navmesh", "Navmesh Region"),
-                ("add.terrain", "Terrain"),
+                ("op:entity.add.navmesh", "Navmesh Region"),
+                ("op:entity.add.terrain", "Terrain"),
             ],
         ),
-        ("Prefabs", vec![("add.prefab", "Prefab...")]),
+        ("Prefabs", vec![("op:entity.add.prefab", "Prefab...")]),
     ]
 }
 

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -76,12 +76,12 @@ impl JackdawExtension for JackdawCoreExtension {
             ),
         ));
 
-        // Spawn the two modifier-key input actions once, up front, so
-        // later keybind ports can `Chord::single(ctrl)` /
-        // `Chord::new([ctrl, shift])` without each module having to
-        // re-register them.
+        // Spawn the three modifier-key input actions once, up front,
+        // so later keybind ports can `Chord::single(ctrl)` /
+        // `Chord::new([ctrl, shift])` / `Chord::single(alt)` without
+        // each module having to re-register them.
         let ext = ctx.id();
-        let (ctrl, shift) = ctx.entity_mut().world_scope(|world| {
+        let (ctrl, shift, alt) = ctx.entity_mut().world_scope(|world| {
             let ctrl = world
                 .spawn((
                     Action::<CtrlHeldAction>::new(),
@@ -96,9 +96,16 @@ impl JackdawExtension for JackdawCoreExtension {
                     bindings![KeyCode::ShiftLeft, KeyCode::ShiftRight],
                 ))
                 .id();
-            (ctrl, shift)
+            let alt = world
+                .spawn((
+                    Action::<AltHeldAction>::new(),
+                    ActionOf::<CoreExtensionInputContext>::new(ext),
+                    bindings![KeyCode::AltLeft, KeyCode::AltRight],
+                ))
+                .id();
+            (ctrl, shift, alt)
         });
-        let modifiers = Modifiers { ctrl, shift };
+        let modifiers = Modifiers { ctrl, shift, alt };
 
         ctx.register_operator::<CancelModalOp>();
         ctx.register_operator::<crate::asset_browser::ApplyTextureOp>();
@@ -111,6 +118,8 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::grid_ops::add_to_extension(ctx);
         crate::gizmo_ops::add_to_extension(ctx);
         crate::edit_mode_ops::add_to_extension(ctx);
+        crate::entity_ops::add_to_extension(ctx, &modifiers);
+        crate::transform_ops::add_to_extension(ctx, &modifiers);
     }
 
     fn register_input_context(app: &mut App) {
@@ -135,11 +144,18 @@ pub struct CtrlHeldAction;
 #[action_output(bool)]
 pub struct ShiftHeldAction;
 
-/// Entity ids of the Ctrl and Shift modifier actions, passed to each
-/// module's `add_to_extension` so chorded keybinds can reference them.
+/// BEI input action bound to Alt (left or right). See [`CtrlHeldAction`].
+#[derive(Component, Debug, Default, Clone, Copy, InputAction)]
+#[action_output(bool)]
+pub struct AltHeldAction;
+
+/// Entity ids of the Ctrl, Shift, and Alt modifier actions, passed to
+/// each module's `add_to_extension` so chorded keybinds can reference
+/// them.
 pub struct Modifiers {
     pub ctrl: Entity,
     pub shift: Entity,
+    pub alt: Entity,
 }
 
 #[operator(

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -53,11 +53,7 @@ impl Plugin for EntityOpsPlugin {
         }
         app.register_type::<EmptyEntity>()
             .register_type::<SceneCamera>()
-            .register_type::<SceneLight>()
-            .add_systems(
-                Update,
-                handle_entity_keys.in_set(crate::EditorInteractionSystems),
-            );
+            .register_type::<SceneLight>();
     }
 }
 
@@ -440,7 +436,7 @@ fn snap_to_nearest_axis(v: Vec3) -> Vec3 {
 ///   world axis, then negated. This is the axis you're "looking along".
 /// - **Pitch** (PageUp/PageDown): camera right snapped to nearest world axis. If it
 ///   collides with the roll axis, use the cross product with Y instead.
-fn camera_snapped_rotation_axes(gt: &GlobalTransform) -> (Vec3, Vec3, Vec3) {
+pub(crate) fn camera_snapped_rotation_axes(gt: &GlobalTransform) -> (Vec3, Vec3, Vec3) {
     let yaw_axis = Vec3::Y;
 
     // Forward projected onto the horizontal plane, snapped to nearest axis
@@ -470,160 +466,13 @@ fn camera_snapped_rotation_axes(gt: &GlobalTransform) -> (Vec3, Vec3, Vec3) {
     (yaw_axis, roll_axis, pitch_axis)
 }
 
-pub fn handle_entity_keys(
-    world: &mut World,
-    cameras: &mut QueryState<&GlobalTransform, With<crate::viewport::MainViewportCamera>>,
-) -> Result {
-    // Don't process entity keys when a text input is focused
-    let has_input_focus = world.resource::<InputFocus>().0.is_some();
-    if has_input_focus {
-        return Ok(());
-    }
-
-    // Don't process entity keys during modal transform operations or draw mode
-    let modal_active = world
-        .resource::<crate::modal_transform::ModalTransformState>()
-        .active
-        .is_some();
-    if modal_active {
-        return Ok(());
-    }
-    let draw_active = world
-        .resource::<crate::draw_brush::DrawBrushState>()
-        .active
-        .is_some();
-    if draw_active {
-        return Ok(());
-    }
-
-    // Don't process entity ops during brush edit mode (Delete etc. handled by brush systems)
-    let in_brush_edit = !matches!(
-        *world.resource::<crate::brush::EditMode>(),
-        crate::brush::EditMode::Object
-    );
-    if in_brush_edit {
-        return Ok(());
-    }
-
-    use crate::keybinds::EditorAction;
-
-    let keyboard = world.resource::<ButtonInput<KeyCode>>();
-    let keybinds = world.resource::<crate::keybinds::KeybindRegistry>();
-
-    let delete = keybinds.just_pressed(EditorAction::Delete, keyboard);
-    let duplicate = keybinds.just_pressed(EditorAction::Duplicate, keyboard);
-    let copy = keybinds.just_pressed(EditorAction::CopyComponents, keyboard);
-    let paste = keybinds.just_pressed(EditorAction::PasteComponents, keyboard);
-    let reset_pos = keybinds.just_pressed(EditorAction::ResetPosition, keyboard);
-    let reset_rot = keybinds.just_pressed(EditorAction::ResetRotation, keyboard);
-    let reset_scale = keybinds.just_pressed(EditorAction::ResetScale, keyboard);
-    let do_hide_selected = keybinds.just_pressed(EditorAction::ToggleVisibility, keyboard);
-    let unhide_all = keybinds.just_pressed(EditorAction::UnhideAll, keyboard);
-    let hide_unselected = keybinds.just_pressed(EditorAction::HideAll, keyboard);
-
-    // Rotations (Alt+Arrow/PageUp/Down)
-    let rot_left = keybinds.just_pressed(EditorAction::Rotate90Left, keyboard);
-    let rot_right = keybinds.just_pressed(EditorAction::Rotate90Right, keyboard);
-    let rot_up = keybinds.just_pressed(EditorAction::Rotate90Up, keyboard);
-    let rot_down = keybinds.just_pressed(EditorAction::Rotate90Down, keyboard);
-    let roll_left = keybinds.just_pressed(EditorAction::Roll90Left, keyboard);
-    let roll_right = keybinds.just_pressed(EditorAction::Roll90Right, keyboard);
-    let any_rotation = rot_left || rot_right || rot_up || rot_down || roll_left || roll_right;
-
-    // Nudge: use key_just_pressed since Ctrl+arrow is also valid (duplicate+nudge).
-    let ctrl = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
-    let alt = keyboard.any_pressed([KeyCode::AltLeft, KeyCode::AltRight]);
-    let nudge_left = keybinds.key_just_pressed(EditorAction::NudgeLeft, keyboard) && !alt;
-    let nudge_right = keybinds.key_just_pressed(EditorAction::NudgeRight, keyboard) && !alt;
-    let nudge_fwd = keybinds.key_just_pressed(EditorAction::NudgeForward, keyboard) && !alt;
-    let nudge_back = keybinds.key_just_pressed(EditorAction::NudgeBack, keyboard) && !alt;
-    let nudge_up = keybinds.key_just_pressed(EditorAction::NudgeUp, keyboard) && !alt;
-    let nudge_down = keybinds.key_just_pressed(EditorAction::NudgeDown, keyboard) && !alt;
-    let any_nudge = nudge_left || nudge_right || nudge_fwd || nudge_back || nudge_up || nudge_down;
-
-    if delete {
-        delete_selected(world);
-    } else if duplicate {
-        duplicate_selected(world);
-    } else if copy {
-        copy_components(world);
-    } else if paste {
-        paste_components(world);
-    } else if reset_pos {
-        reset_transform_selected(world, TransformReset::Position);
-    } else if reset_rot {
-        reset_transform_selected(world, TransformReset::Rotation);
-    } else if reset_scale {
-        reset_transform_selected(world, TransformReset::Scale);
-    } else if unhide_all {
-        world.run_system_cached(unhide_all_entities)?;
-    } else if hide_unselected {
-        world.run_system_cached(hide_all_entities)?;
-    } else if do_hide_selected {
-        hide_selected(world);
-    } else if any_rotation {
-        // TrenchBroom-style rotation: snap camera axes to the nearest world axis
-        // so rotations always produce axis-aligned results while still feeling
-        // intuitive from the current viewpoint.
-        let (yaw_axis, roll_axis, pitch_axis) = {
-            cameras
-                .iter(world)
-                .next()
-                .map(camera_snapped_rotation_axes)
-                .unwrap_or((Vec3::Y, Vec3::NEG_Z, Vec3::X))
-        };
-
-        let angle = std::f32::consts::FRAC_PI_2;
-        let rotation = if rot_left {
-            Quat::from_axis_angle(yaw_axis, -angle)
-        } else if rot_right {
-            Quat::from_axis_angle(yaw_axis, angle)
-        } else if rot_up {
-            Quat::from_axis_angle(roll_axis, -angle)
-        } else if rot_down {
-            Quat::from_axis_angle(roll_axis, angle)
-        } else if roll_left {
-            Quat::from_axis_angle(pitch_axis, angle)
-        } else {
-            // roll_right
-            Quat::from_axis_angle(pitch_axis, -angle)
-        };
-        rotate_selected(world, rotation);
-    } else if any_nudge {
-        let grid_size = world
-            .resource::<crate::snapping::SnapSettings>()
-            .grid_size();
-        let offset = if nudge_left {
-            Vec3::new(-grid_size, 0.0, 0.0)
-        } else if nudge_right {
-            Vec3::new(grid_size, 0.0, 0.0)
-        } else if nudge_fwd {
-            Vec3::new(0.0, 0.0, -grid_size)
-        } else if nudge_back {
-            Vec3::new(0.0, 0.0, grid_size)
-        } else if nudge_up {
-            Vec3::new(0.0, grid_size, 0.0)
-        } else {
-            // nudge_down
-            Vec3::new(0.0, -grid_size, 0.0)
-        };
-
-        if ctrl {
-            // Ctrl+arrow: duplicate then nudge
-            duplicate_selected(world);
-        }
-        nudge_selected(world, offset);
-    }
-    Ok(())
-}
-
-enum TransformReset {
+pub(crate) enum TransformReset {
     Position,
     Rotation,
     Scale,
 }
 
-fn reset_transform_selected(world: &mut World, reset: TransformReset) {
+pub(crate) fn reset_transform_selected(world: &mut World, reset: TransformReset) {
     let selection = world.resource::<Selection>();
     let entities: Vec<Entity> = selection.entities.clone();
 
@@ -684,7 +533,7 @@ fn reset_transform_selected(world: &mut World, reset: TransformReset) {
     }
 }
 
-fn nudge_selected(world: &mut World, offset: Vec3) {
+pub(crate) fn nudge_selected(world: &mut World, offset: Vec3) {
     let selection = world.resource::<Selection>();
     let entities: Vec<Entity> = selection.entities.clone();
 
@@ -726,7 +575,7 @@ fn nudge_selected(world: &mut World, offset: Vec3) {
     }
 }
 
-fn rotate_selected(world: &mut World, rotation: Quat) {
+pub(crate) fn rotate_selected(world: &mut World, rotation: Quat) {
     let selection = world.resource::<Selection>();
     let entities: Vec<Entity> = selection.entities.clone();
 
@@ -1044,4 +893,292 @@ fn get_assets_base_dir() -> Option<std::path::PathBuf> {
         std::env::current_exe().ok()?.parent()?.to_path_buf()
     };
     Some(base.join("assets"))
+}
+
+// ─────────────────────── Operators ────────────────────────────
+//
+// Entity-level operators (`entity.*`) and the `Add` menu
+// (`entity.add.*`). Keybind and menu dispatch both arrive here.
+// Operators are gated with `is_available = can_act_on_entities` so
+// they refuse to fire while a brush sub-element drag or modal
+// operator has the scene locked, matching the guards the legacy
+// `handle_entity_keys` applied.
+
+use bevy_enhanced_input::prelude::{Chord, Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+    ctx.register_operator::<EntityDeleteOp>()
+        .register_operator::<EntityDuplicateOp>()
+        .register_operator::<EntityCopyComponentsOp>()
+        .register_operator::<EntityPasteComponentsOp>()
+        .register_operator::<EntityToggleVisibilityOp>()
+        .register_operator::<EntityHideUnselectedOp>()
+        .register_operator::<EntityUnhideAllOp>()
+        .register_operator::<EntityAddCubeOp>()
+        .register_operator::<EntityAddSphereOp>()
+        .register_operator::<EntityAddPointLightOp>()
+        .register_operator::<EntityAddDirectionalLightOp>()
+        .register_operator::<EntityAddSpotLightOp>()
+        .register_operator::<EntityAddCameraOp>()
+        .register_operator::<EntityAddEmptyOp>()
+        .register_operator::<EntityAddNavmeshOp>()
+        .register_operator::<EntityAddTerrainOp>()
+        .register_operator::<EntityAddPrefabOp>();
+
+    let ext = ctx.id();
+    let ctrl = modifiers.ctrl;
+    let alt = modifiers.alt;
+    ctx.entity_mut().world_scope(|world| {
+        world.spawn((
+            Action::<EntityDeleteOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::Delete, Press::default())],
+        ));
+        world.spawn((
+            Action::<EntityDuplicateOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(ctrl),
+            bindings![(KeyCode::KeyD, Press::default())],
+        ));
+        world.spawn((
+            Action::<EntityCopyComponentsOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(ctrl),
+            bindings![(KeyCode::KeyC, Press::default())],
+        ));
+        world.spawn((
+            Action::<EntityPasteComponentsOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(ctrl),
+            bindings![(KeyCode::KeyV, Press::default())],
+        ));
+        world.spawn((
+            Action::<EntityToggleVisibilityOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::KeyH, Press::default())],
+        ));
+        world.spawn((
+            Action::<EntityUnhideAllOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(ctrl),
+            bindings![(KeyCode::KeyH, Press::default())],
+        ));
+        world.spawn((
+            Action::<EntityHideUnselectedOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::KeyH, Press::default())],
+        ));
+    });
+}
+
+/// Shared availability check for entity manipulation operators.
+/// Refuses to fire while a text input has focus, while a modal
+/// operator is in flight, while the draw brush modal is active, or
+/// while brush sub-element edit mode is active — matches the guards
+/// the legacy `handle_entity_keys` applied.
+fn can_act_on_entities(
+    input_focus: Res<InputFocus>,
+    active: ActiveModalQuery,
+    modal: Res<crate::modal_transform::ModalTransformState>,
+    draw_state: Res<crate::draw_brush::DrawBrushState>,
+    edit_mode: Res<crate::brush::EditMode>,
+) -> bool {
+    if input_focus.0.is_some() || active.is_modal_running() || modal.active.is_some() {
+        return false;
+    }
+    if draw_state.active.is_some() {
+        return false;
+    }
+    matches!(*edit_mode, crate::brush::EditMode::Object)
+}
+
+// ── Entity lifecycle ────────────────────────────────────────────
+
+#[operator(
+    id = "entity.delete",
+    label = "Delete",
+    is_available = can_act_on_entities
+)]
+fn entity_delete(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(delete_selected);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "entity.duplicate",
+    label = "Duplicate",
+    is_available = can_act_on_entities
+)]
+fn entity_duplicate(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(duplicate_selected);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "entity.copy_components",
+    label = "Copy Components",
+    allows_undo = false,
+    is_available = can_act_on_entities
+)]
+fn entity_copy_components(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(copy_components);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "entity.paste_components",
+    label = "Paste Components",
+    is_available = can_act_on_entities
+)]
+fn entity_paste_components(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(paste_components);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "entity.toggle_visibility",
+    label = "Toggle Visibility",
+    allows_undo = false,
+    is_available = can_act_on_entities
+)]
+fn entity_toggle_visibility(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(hide_selected);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "entity.hide_unselected",
+    label = "Hide Unselected",
+    allows_undo = false,
+    is_available = can_act_on_entities
+)]
+fn entity_hide_unselected(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        if let Err(err) = world.run_system_cached(hide_all_entities) {
+            warn!("hide_all_entities: {err:?}");
+        }
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "entity.unhide_all",
+    label = "Unhide All",
+    allows_undo = false,
+    is_available = can_act_on_entities
+)]
+fn entity_unhide_all(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        if let Err(err) = world.run_system_cached(unhide_all_entities) {
+            warn!("unhide_all_entities: {err:?}");
+        }
+    });
+    OperatorResult::Finished
+}
+
+// ── Add menu ────────────────────────────────────────────────────
+
+#[operator(id = "entity.add.cube", label = "Cube")]
+fn entity_add_cube(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::Cube);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.sphere", label = "Sphere")]
+fn entity_add_sphere(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::Sphere);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.point_light", label = "Point Light")]
+fn entity_add_point_light(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::PointLight);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.directional_light", label = "Directional Light")]
+fn entity_add_directional_light(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::DirectionalLight);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.spot_light", label = "Spot Light")]
+fn entity_add_spot_light(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::SpotLight);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.camera", label = "Camera")]
+fn entity_add_camera(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::Camera3d);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.empty", label = "Empty")]
+fn entity_add_empty(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        create_entity_in_world(world, EntityTemplate::Empty);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.navmesh", label = "Navmesh")]
+fn entity_add_navmesh(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        crate::spawn_undoable(world, "Add Navmesh Region", |world| {
+            let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
+                SystemState::new(world);
+            let (mut commands, mut selection) = system_state.get_mut(world);
+            let entity = crate::navmesh::spawn_navmesh_entity(&mut commands);
+            selection.select_single(&mut commands, entity);
+            system_state.apply(world);
+            crate::scene_io::register_entity_in_ast(world, entity);
+            entity
+        });
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.terrain", label = "Terrain")]
+fn entity_add_terrain(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        crate::spawn_undoable(world, "Add Terrain", |world| {
+            let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
+                SystemState::new(world);
+            let (mut commands, mut selection) = system_state.get_mut(world);
+            let entity = crate::terrain::spawn_terrain_entity(&mut commands);
+            selection.select_single(&mut commands, entity);
+            system_state.apply(world);
+            crate::scene_io::register_entity_in_ast(world, entity);
+            entity
+        });
+    });
+    OperatorResult::Finished
+}
+
+#[operator(id = "entity.add.prefab", label = "Prefab")]
+fn entity_add_prefab(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        crate::prefab_picker::open_prefab_picker(world);
+    });
+    OperatorResult::Finished
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod snapping;
 pub mod status_bar;
 pub mod terrain;
 pub mod texture_browser;
+pub mod transform_ops;
 pub mod undo_snapshot;
 pub mod view_modes;
 pub mod view_ops;
@@ -310,8 +311,8 @@ impl Plugin for EditorCorePlugin {
                     register_animation_entities_in_ast,
                     follow_scene_selection_to_clip,
                     sync_selected_keyframes_from_selection,
-                    handle_keyframe_delete_intercept.before(entity_ops::handle_entity_keys),
-                    handle_timeline_shortcuts.before(entity_ops::handle_entity_keys),
+                    handle_keyframe_delete_intercept,
+                    handle_timeline_shortcuts,
                     auto_save_layout_on_change,
                     add_entity_picker::filter_add_entity_picker,
                     add_entity_picker::close_add_entity_picker_on_escape,
@@ -1926,8 +1927,8 @@ fn populate_menu(
                     ("op:history.undo", "Undo"),
                     ("op:history.redo", "Redo"),
                     ("---", ""),
-                    ("edit.delete", "Delete"),
-                    ("edit.duplicate", "Duplicate"),
+                    ("op:entity.delete", "Delete"),
+                    ("op:entity.duplicate", "Duplicate"),
                     ("---", ""),
                     ("edit.join", "Join (Convex Merge)"),
                     ("edit.csg_subtract", "CSG Subtract"),
@@ -1957,16 +1958,6 @@ fn populate_menu(
 
 fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
     match event.action.as_str() {
-        "edit.delete" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::delete_selected(world);
-            });
-        }
-        "edit.duplicate" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::duplicate_selected(world);
-            });
-        }
         "edit.join" => {
             commands.queue(draw_brush::join_selected_brushes_impl);
         }
@@ -2035,77 +2026,6 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
                 }
             });
         }
-        "add.cube" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(world, entity_ops::EntityTemplate::Cube);
-            });
-        }
-        "add.sphere" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(world, entity_ops::EntityTemplate::Sphere);
-            });
-        }
-        "add.point_light" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(world, entity_ops::EntityTemplate::PointLight);
-            });
-        }
-        "add.directional_light" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(
-                    world,
-                    entity_ops::EntityTemplate::DirectionalLight,
-                );
-            });
-        }
-        "add.spot_light" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(world, entity_ops::EntityTemplate::SpotLight);
-            });
-        }
-        "add.camera" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(world, entity_ops::EntityTemplate::Camera3d);
-            });
-        }
-        "add.empty" => {
-            commands.queue(|world: &mut World| {
-                entity_ops::create_entity_in_world(world, entity_ops::EntityTemplate::Empty);
-            });
-        }
-        "add.navmesh" => {
-            commands.queue(|world: &mut World| {
-                spawn_undoable(world, "Add Navmesh Region", |world| {
-                    let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
-                        SystemState::new(world);
-                    let (mut commands, mut selection) = system_state.get_mut(world);
-                    let entity = navmesh::spawn_navmesh_entity(&mut commands);
-                    selection.select_single(&mut commands, entity);
-                    system_state.apply(world);
-                    scene_io::register_entity_in_ast(world, entity);
-                    entity
-                });
-            });
-        }
-        "add.terrain" => {
-            commands.queue(|world: &mut World| {
-                spawn_undoable(world, "Add Terrain", |world| {
-                    let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
-                        SystemState::new(world);
-                    let (mut commands, mut selection) = system_state.get_mut(world);
-                    let entity = terrain::spawn_terrain_entity(&mut commands);
-                    selection.select_single(&mut commands, entity);
-                    system_state.apply(world);
-                    scene_io::register_entity_in_ast(world, entity);
-                    entity
-                });
-            });
-        }
-        "add.prefab" => {
-            commands.queue(|world: &mut World| {
-                crate::prefab_picker::open_prefab_picker(world);
-            });
-        }
         action if action.starts_with(OP_PREFIX) => {
             // Extension-contributed menu entry. The action id is the
             // operator id with an "op:" prefix. Dispatching through the
@@ -2147,7 +2067,7 @@ fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
 const OP_PREFIX: &str = "op:";
 
 /// Wrap an entity-spawning closure in a `SpawnEntity` command so Ctrl+Z can undo it.
-fn spawn_undoable<F>(world: &mut World, label: &str, spawn: F)
+pub(crate) fn spawn_undoable<F>(world: &mut World, label: &str, spawn: F)
 where
     F: Fn(&mut World) -> Entity + Send + Sync + 'static,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1050,8 +1050,8 @@ impl DespawnKeyframeCmd {
     }
 }
 
-/// Interceptor that runs before [`entity_ops::handle_entity_keys`]
-/// and steals the Delete key for any selected keyframe entities.
+/// Interceptor that runs before the entity-delete operator fires and
+/// steals the Delete key for any selected keyframe entities.
 /// Each keyframe gets wrapped in a [`DespawnKeyframeCmd`], the
 /// commands are grouped and pushed onto the history, and the
 /// keyframes are removed from [`selection::Selection`] so the
@@ -1216,7 +1216,7 @@ impl jackdaw_commands::EditorCommand for SpawnKeyframeCmd {
 }
 
 /// Combined handler for timeline keyboard shortcuts that need to
-/// intercept before [`entity_ops::handle_entity_keys`]:
+/// intercept before the entity-level operator dispatch:
 ///
 /// - **Arrow keys** (Left/Right/Home/End) step the playhead when the
 ///   timeline dock window is active. Consumes the key input via

--- a/src/transform_ops.rs
+++ b/src/transform_ops.rs
@@ -1,0 +1,373 @@
+//! Transform-shortcut operators: reset, 90° rotate, and nudge.
+//!
+//! `reset_*` snap translation / rotation / scale on the selection back
+//! to defaults. `rotate_90_*` rotate the selection by a quarter-turn
+//! around camera-snapped yaw / pitch / roll axes (matches the legacy
+//! TrenchBroom-style rotation shortcut). `nudge_*` translate the
+//! selection by one grid step along a world-space axis.
+//!
+//! Default keybinds follow the editor's long-standing bindings:
+//! Alt+G/R/S for reset, Alt+Arrow and Alt+PageUp/Down for `rotate_90`,
+//! plain Arrow and PageUp/Down for nudge.
+
+use bevy::{input_focus::InputFocus, prelude::*};
+use bevy_enhanced_input::prelude::{Chord, Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+use crate::entity_ops::{
+    TransformReset, camera_snapped_rotation_axes, nudge_selected, reset_transform_selected,
+    rotate_selected,
+};
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+    ctx.register_operator::<TransformResetPositionOp>()
+        .register_operator::<TransformResetRotationOp>()
+        .register_operator::<TransformResetScaleOp>()
+        .register_operator::<TransformRotate90YawCcwOp>()
+        .register_operator::<TransformRotate90YawCwOp>()
+        .register_operator::<TransformRotate90PitchCcwOp>()
+        .register_operator::<TransformRotate90PitchCwOp>()
+        .register_operator::<TransformRotate90RollCcwOp>()
+        .register_operator::<TransformRotate90RollCwOp>()
+        .register_operator::<TransformNudgeXNegOp>()
+        .register_operator::<TransformNudgeXPosOp>()
+        .register_operator::<TransformNudgeYNegOp>()
+        .register_operator::<TransformNudgeYPosOp>()
+        .register_operator::<TransformNudgeZNegOp>()
+        .register_operator::<TransformNudgeZPosOp>();
+
+    let ext = ctx.id();
+    let alt = modifiers.alt;
+    ctx.entity_mut().world_scope(|world| {
+        // Reset: Alt + G / R / S
+        world.spawn((
+            Action::<TransformResetPositionOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::KeyG, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformResetRotationOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::KeyR, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformResetScaleOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::KeyS, Press::default())],
+        ));
+
+        // Rotate 90: Alt + Arrow / PageUp / PageDown
+        world.spawn((
+            Action::<TransformRotate90YawCcwOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::ArrowLeft, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformRotate90YawCwOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::ArrowRight, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformRotate90PitchCcwOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::ArrowUp, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformRotate90PitchCwOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::ArrowDown, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformRotate90RollCcwOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::PageUp, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformRotate90RollCwOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            Chord::single(alt),
+            bindings![(KeyCode::PageDown, Press::default())],
+        ));
+
+        // Nudge: plain Arrow / PageUp / PageDown. No modifier chord —
+        // but BEI still fires our Alt+Arrow rotate bindings when Alt
+        // is held, so in practice the two don't collide.
+        world.spawn((
+            Action::<TransformNudgeXNegOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::ArrowLeft, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformNudgeXPosOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::ArrowRight, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformNudgeZNegOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::ArrowUp, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformNudgeZPosOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::ArrowDown, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformNudgeYPosOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::PageUp, Press::default())],
+        ));
+        world.spawn((
+            Action::<TransformNudgeYNegOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![(KeyCode::PageDown, Press::default())],
+        ));
+    });
+}
+
+/// Shared availability check for transform operators. Matches the
+/// guards the legacy `handle_entity_keys` applied.
+fn can_act_on_entities(
+    input_focus: Res<InputFocus>,
+    active: ActiveModalQuery,
+    modal: Res<crate::modal_transform::ModalTransformState>,
+    draw_state: Res<crate::draw_brush::DrawBrushState>,
+    edit_mode: Res<crate::brush::EditMode>,
+) -> bool {
+    if input_focus.0.is_some() || active.is_modal_running() || modal.active.is_some() {
+        return false;
+    }
+    if draw_state.active.is_some() {
+        return false;
+    }
+    matches!(*edit_mode, crate::brush::EditMode::Object)
+}
+
+// ── Reset ops ───────────────────────────────────────────────────
+
+#[operator(
+    id = "transform.reset_position",
+    label = "Reset Position",
+    is_available = can_act_on_entities
+)]
+fn transform_reset_position(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        reset_transform_selected(world, TransformReset::Position);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.reset_rotation",
+    label = "Reset Rotation",
+    is_available = can_act_on_entities
+)]
+fn transform_reset_rotation(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        reset_transform_selected(world, TransformReset::Rotation);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.reset_scale",
+    label = "Reset Scale",
+    is_available = can_act_on_entities
+)]
+fn transform_reset_scale(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        reset_transform_selected(world, TransformReset::Scale);
+    });
+    OperatorResult::Finished
+}
+
+// ── Rotate 90° ops ──────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum CameraAxis {
+    Yaw,
+    Pitch,
+    Roll,
+}
+
+fn rotate_by_camera_axis(world: &mut World, axis: CameraAxis, direction: f32) {
+    let (yaw_axis, roll_axis, pitch_axis) = {
+        let mut query =
+            world.query_filtered::<&GlobalTransform, With<crate::viewport::MainViewportCamera>>();
+        query
+            .iter(world)
+            .next()
+            .map(camera_snapped_rotation_axes)
+            .unwrap_or((Vec3::Y, Vec3::NEG_Z, Vec3::X))
+    };
+    let angle = std::f32::consts::FRAC_PI_2 * direction;
+    let rotation_axis = match axis {
+        CameraAxis::Yaw => yaw_axis,
+        CameraAxis::Pitch => pitch_axis,
+        CameraAxis::Roll => roll_axis,
+    };
+    let rotation = Quat::from_axis_angle(rotation_axis, angle);
+    rotate_selected(world, rotation);
+}
+
+#[operator(
+    id = "transform.rotate_90_yaw_ccw",
+    label = "Rotate 90° Yaw CCW",
+    is_available = can_act_on_entities
+)]
+fn transform_rotate_90_yaw_ccw(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Yaw, -1.0));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.rotate_90_yaw_cw",
+    label = "Rotate 90° Yaw CW",
+    is_available = can_act_on_entities
+)]
+fn transform_rotate_90_yaw_cw(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Yaw, 1.0));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.rotate_90_pitch_ccw",
+    label = "Rotate 90° Pitch CCW",
+    is_available = can_act_on_entities
+)]
+fn transform_rotate_90_pitch_ccw(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Roll, -1.0));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.rotate_90_pitch_cw",
+    label = "Rotate 90° Pitch CW",
+    is_available = can_act_on_entities
+)]
+fn transform_rotate_90_pitch_cw(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Roll, 1.0));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.rotate_90_roll_ccw",
+    label = "Rotate 90° Roll CCW",
+    is_available = can_act_on_entities
+)]
+fn transform_rotate_90_roll_ccw(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Pitch, 1.0));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.rotate_90_roll_cw",
+    label = "Rotate 90° Roll CW",
+    is_available = can_act_on_entities
+)]
+fn transform_rotate_90_roll_cw(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Pitch, -1.0));
+    OperatorResult::Finished
+}
+
+// ── Nudge ops ───────────────────────────────────────────────────
+
+fn nudge_by_axis(world: &mut World, offset_direction: Vec3) {
+    let grid_size = world
+        .resource::<crate::snapping::SnapSettings>()
+        .grid_size();
+    nudge_selected(world, offset_direction * grid_size);
+}
+
+#[operator(
+    id = "transform.nudge_x_neg",
+    label = "Nudge −X",
+    is_available = can_act_on_entities
+)]
+fn transform_nudge_x_neg(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| nudge_by_axis(world, Vec3::NEG_X));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.nudge_x_pos",
+    label = "Nudge +X",
+    is_available = can_act_on_entities
+)]
+fn transform_nudge_x_pos(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| nudge_by_axis(world, Vec3::X));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.nudge_y_neg",
+    label = "Nudge −Y",
+    is_available = can_act_on_entities
+)]
+fn transform_nudge_y_neg(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| nudge_by_axis(world, Vec3::NEG_Y));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.nudge_y_pos",
+    label = "Nudge +Y",
+    is_available = can_act_on_entities
+)]
+fn transform_nudge_y_pos(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| nudge_by_axis(world, Vec3::Y));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.nudge_z_neg",
+    label = "Nudge −Z",
+    is_available = can_act_on_entities
+)]
+fn transform_nudge_z_neg(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| nudge_by_axis(world, Vec3::NEG_Z));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "transform.nudge_z_pos",
+    label = "Nudge +Z",
+    is_available = can_act_on_entities
+)]
+fn transform_nudge_z_pos(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| nudge_by_axis(world, Vec3::Z));
+    OperatorResult::Finished
+}

--- a/src/transform_ops.rs
+++ b/src/transform_ops.rs
@@ -159,10 +159,7 @@ fn can_act_on_entities(
     label = "Reset Position",
     is_available = can_act_on_entities
 )]
-fn transform_reset_position(
-    _: In<OperatorParameters>,
-    mut commands: Commands,
-) -> OperatorResult {
+fn transform_reset_position(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(|world: &mut World| {
         reset_transform_selected(world, TransformReset::Position);
     });
@@ -174,10 +171,7 @@ fn transform_reset_position(
     label = "Reset Rotation",
     is_available = can_act_on_entities
 )]
-fn transform_reset_rotation(
-    _: In<OperatorParameters>,
-    mut commands: Commands,
-) -> OperatorResult {
+fn transform_reset_rotation(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(|world: &mut World| {
         reset_transform_selected(world, TransformReset::Rotation);
     });
@@ -243,10 +237,7 @@ fn transform_rotate_90_yaw_ccw(
     label = "Rotate 90° Yaw CW",
     is_available = can_act_on_entities
 )]
-fn transform_rotate_90_yaw_cw(
-    _: In<OperatorParameters>,
-    mut commands: Commands,
-) -> OperatorResult {
+fn transform_rotate_90_yaw_cw(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(|world: &mut World| rotate_by_camera_axis(world, CameraAxis::Yaw, 1.0));
     OperatorResult::Finished
 }


### PR DESCRIPTION
Phase 4 of #194. Stacked on #198.

Ports delete, duplicate, component copy/paste, visibility toggles, transform resets, camera-snapped rotations, grid-aligned nudges, and the Add menu to operators. BEI bindings replace the legacy entity-keys handler.

Ctrl+Arrow duplicate-then-nudge and the parameterized `parent: Entity` for hierarchy context-menu Add Child items are deferred; the hierarchy's existing path still handles those.