### PR TITLE
operatorify v5: review feedback rework

### DIFF
--- a/crates/jackdaw_api_internal/src/operator.rs
+++ b/crates/jackdaw_api_internal/src/operator.rs
@@ -70,7 +70,7 @@ pub(super) fn plugin(app: &mut App) {
 /// ```
 ///
 /// Buttons in UI code dispatch the operator by attaching a
-/// `CallOperator` component (from `jackdaw_feathers::button`), usually via
+/// `ButtonOperatorCall` component (from `jackdaw_feathers::button`), usually via
 /// `ButtonProps::call_operator("sample.place_cube")`. The editor registers
 /// a global observer that, on `ButtonClickEvent`, calls
 /// [`OperatorWorldExt::operator`] with the stored id — so no per-button

--- a/crates/jackdaw_avian_integration/src/lib.rs
+++ b/crates/jackdaw_avian_integration/src/lib.rs
@@ -36,7 +36,7 @@ pub mod physics_colors {
     pub const COLLIDER_HIERARCHY_ARROW: Color = Color::srgba(0.4, 0.7, 1.0, 0.6);
 }
 
-#[derive(Resource)]
+#[derive(Resource, Clone, PartialEq)]
 pub struct PhysicsOverlayConfig {
     pub show_colliders: bool,
     pub show_hierarchy_arrows: bool,

--- a/crates/jackdaw_feathers/src/button.rs
+++ b/crates/jackdaw_feathers/src/button.rs
@@ -21,9 +21,9 @@ pub struct ButtonClickEvent {
 /// observer; feathers just carries the id so widgets can declare
 /// their intent without depending on the operator API.
 #[derive(Component, Clone, Debug)]
-pub struct CallOperator(pub Cow<'static, str>);
+pub struct ButtonOperatorCall(pub Cow<'static, str>);
 
-impl CallOperator {
+impl ButtonOperatorCall {
     pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
         Self(id.into())
     }
@@ -391,7 +391,7 @@ fn setup_button(
                 return;
             };
             if let Some(id) = call_operator {
-                ec.insert(CallOperator(id));
+                ec.insert(ButtonOperatorCall(id));
             }
             ec.with_children(|parent| {
                 if let Some(icon) = left_icon {
@@ -497,8 +497,8 @@ fn handle_button_click(
 /// Create an icon-only button using lucide icon font.
 ///
 /// To dispatch an operator on click, spawn the returned bundle alongside an
-/// [`CallOperator`] component: `commands.spawn((icon_button(props, font),
-/// CallOperator::new("my.op")))`. A setter isn't provided on
+/// [`ButtonOperatorCall`] component: `commands.spawn((icon_button(props, font),
+/// ButtonOperatorCall::new("my.op")))`. A setter isn't provided on
 /// [`IconButtonProps`] because `icon_button` has no staging/setup system;
 /// the tuple-form keeps the API small.
 pub fn icon_button(props: IconButtonProps, icon_font: &Handle<Font>) -> impl Bundle {

--- a/crates/jackdaw_feathers/src/context_menu.rs
+++ b/crates/jackdaw_feathers/src/context_menu.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use jackdaw_widgets::context_menu::{ContextMenuAction, ContextMenuItem};
 
-use crate::button::{ButtonClickEvent, ButtonProps, ButtonVariant, CallOperator, button};
+use crate::button::{ButtonClickEvent, ButtonOperatorCall, ButtonProps, ButtonVariant, button};
 use crate::menu_bar::OP_ACTION_PREFIX;
 use crate::tokens;
 
@@ -11,16 +11,16 @@ pub fn plugin(app: &mut App) {
 
 fn on_context_menu_item_click(
     event: On<ButtonClickEvent>,
-    items: Query<(&ContextMenuItem, Option<&CallOperator>)>,
+    items: Query<(&ContextMenuItem, Option<&ButtonOperatorCall>)>,
     mut commands: Commands,
 ) {
-    let Ok((item, call_op)) = items.get(event.entity) else {
+    let Ok((item, button_op)) = items.get(event.entity) else {
         return;
     };
     // Items that dispatch an operator are handled by the editor-side
-    // CallOperator observer; firing ContextMenuAction here would
+    // ButtonOperatorCall observer; firing ContextMenuAction here would
     // double-dispatch.
-    if call_op.is_some() {
+    if button_op.is_some() {
         return;
     }
     commands.trigger(ContextMenuAction {
@@ -31,7 +31,7 @@ fn on_context_menu_item_click(
 
 /// Spawn a context menu at the given position with the given items.
 /// Each item is `(action_id, label)`. Actions prefixed with
-/// [`OP_ACTION_PREFIX`] are attached as [`CallOperator`] ids on the item.
+/// [`OP_ACTION_PREFIX`] are attached as [`ButtonOperatorCall`] ids on the item.
 pub fn spawn_context_menu(
     commands: &mut Commands,
     position: Vec2,
@@ -70,9 +70,11 @@ pub fn spawn_context_menu(
         );
 
         if let Some(op_id) = action.strip_prefix(OP_ACTION_PREFIX) {
-            commands
-                .entity(menu)
-                .with_child((item, btn, CallOperator::new(op_id.to_string())));
+            commands.entity(menu).with_child((
+                item,
+                btn,
+                ButtonOperatorCall::new(op_id.to_string()),
+            ));
         } else {
             commands.entity(menu).with_child((item, btn));
         }

--- a/crates/jackdaw_feathers/src/menu_bar.rs
+++ b/crates/jackdaw_feathers/src/menu_bar.rs
@@ -3,12 +3,12 @@ use jackdaw_widgets::menu_bar::{
     MenuAction, MenuBar, MenuBarDropdown, MenuBarDropdownItem, MenuBarItem, MenuBarState,
 };
 
-use crate::button::{ButtonClickEvent, ButtonProps, ButtonVariant, CallOperator, button};
+use crate::button::{ButtonClickEvent, ButtonOperatorCall, ButtonProps, ButtonVariant, button};
 use crate::tokens;
 use crate::tooltip::Tooltip;
 
 /// Action strings in menu entries that start with this prefix are
-/// interpreted as operator ids; the suffix becomes the [`CallOperator`] id
+/// interpreted as operator ids; the suffix becomes the [`ButtonOperatorCall`] id
 /// attached to the dropdown button so the editor dispatches through the
 /// operator API instead of firing a generic [`MenuAction`].
 pub const OP_ACTION_PREFIX: &str = "op:";
@@ -21,18 +21,18 @@ pub fn plugin(app: &mut App) {
 }
 
 /// When a dropdown item is clicked, fire the [`MenuAction`] — unless the
-/// item carries a [`CallOperator`] component, in which case the editor's
+/// item carries a [`ButtonOperatorCall`] component, in which case the editor's
 /// operator observer will handle dispatch and a `MenuAction` would
 /// double-fire.
 fn on_dropdown_item_click(
     event: On<ButtonClickEvent>,
-    items: Query<(&MenuBarDropdownItem, Option<&CallOperator>)>,
+    items: Query<(&MenuBarDropdownItem, Option<&ButtonOperatorCall>)>,
     mut commands: Commands,
 ) {
-    let Ok((item, call_op)) = items.get(event.entity) else {
+    let Ok((item, button_op)) = items.get(event.entity) else {
         return;
     };
-    if call_op.is_some() {
+    if button_op.is_some() {
         return;
     }
     commands.trigger(MenuAction {
@@ -256,7 +256,7 @@ fn spawn_dropdown(commands: &mut Commands, x: f32, y: f32, actions: &[(String, S
                 item,
                 btn,
                 tooltip,
-                CallOperator::new(op_id.to_string()),
+                ButtonOperatorCall::new(op_id.to_string()),
             ));
         } else {
             commands.entity(dropdown).with_child((item, btn, tooltip));

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -6,10 +6,17 @@
 use bevy::feathers::theme::ThemedText;
 use bevy::prelude::*;
 use bevy::ui_widgets::observe;
+use jackdaw_api::prelude::Operator;
 use jackdaw_feathers::text_edit::{self, TextEditProps, TextEditValue};
 use jackdaw_feathers::tokens;
 
 use std::collections::HashSet;
+
+use crate::entity_ops::{
+    EntityAddCameraOp, EntityAddCubeOp, EntityAddDirectionalLightOp, EntityAddEmptyOp,
+    EntityAddNavmeshOp, EntityAddPointLightOp, EntityAddPrefabOp, EntityAddSphereOp,
+    EntityAddSpotLightOp, EntityAddTerrainOp,
+};
 
 /// Marker for the scene-tree Add Entity button.
 #[derive(Component)]
@@ -34,40 +41,53 @@ pub struct AddEntityPickerSectionHeader {
     pub category: String,
 }
 
+/// Build an `op:` action string for the given operator type. Keeps
+/// operator ids out of UI code — callers pass the `Op` type, not a
+/// hand-typed string.
+fn op_action<O: Operator>() -> String {
+    format!("op:{}", O::ID)
+}
+
 /// Built-in Add items grouped by category. Order here is the order in
 /// the picker and in the toolbar Add menu.
-fn builtin_groups() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+fn builtin_groups() -> Vec<(&'static str, Vec<(String, &'static str)>)> {
     vec![
         (
             "Shapes",
             vec![
-                ("op:entity.add.cube", "Cube"),
-                ("op:entity.add.sphere", "Sphere"),
+                (op_action::<EntityAddCubeOp>(), "Cube"),
+                (op_action::<EntityAddSphereOp>(), "Sphere"),
             ],
         ),
         (
             "Lights",
             vec![
-                ("op:entity.add.point_light", "Point Light"),
-                ("op:entity.add.directional_light", "Directional Light"),
-                ("op:entity.add.spot_light", "Spot Light"),
+                (op_action::<EntityAddPointLightOp>(), "Point Light"),
+                (
+                    op_action::<EntityAddDirectionalLightOp>(),
+                    "Directional Light",
+                ),
+                (op_action::<EntityAddSpotLightOp>(), "Spot Light"),
             ],
         ),
         (
             "Cameras & Entities",
             vec![
-                ("op:entity.add.camera", "Camera"),
-                ("op:entity.add.empty", "Empty"),
+                (op_action::<EntityAddCameraOp>(), "Camera"),
+                (op_action::<EntityAddEmptyOp>(), "Empty"),
             ],
         ),
         (
             "Regions",
             vec![
-                ("op:entity.add.navmesh", "Navmesh Region"),
-                ("op:entity.add.terrain", "Terrain"),
+                (op_action::<EntityAddNavmeshOp>(), "Navmesh Region"),
+                (op_action::<EntityAddTerrainOp>(), "Terrain"),
             ],
         ),
-        ("Prefabs", vec![("op:entity.add.prefab", "Prefab...")]),
+        (
+            "Prefabs",
+            vec![(op_action::<EntityAddPrefabOp>(), "Prefab...")],
+        ),
     ]
 }
 
@@ -88,7 +108,7 @@ pub fn collect_add_menu_items(world: &mut World) -> Vec<AddMenuItem> {
         .into_iter()
         .flat_map(|(category, entries)| {
             entries.into_iter().map(move |(action, label)| AddMenuItem {
-                action: action.to_string(),
+                action,
                 label: label.to_string(),
                 category: category.to_string(),
             })

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
-use jackdaw_feathers::button::{ButtonClickEvent, CallOperator};
+use jackdaw_feathers::button::{ButtonClickEvent, ButtonOperatorCall};
 
 /// Catalog name of the Core extension. Exported so
 /// [`crate::extensions_config::REQUIRED_EXTENSIONS`] and the
@@ -12,25 +12,25 @@ pub const CORE_EXTENSION_ID: &str = "jackdaw.core";
 
 pub(super) fn plugin(app: &mut App) {
     app.register_extension::<JackdawCoreExtension>()
-        .add_observer(dispatch_call_operator);
+        .add_observer(dispatch_button_operator_call);
 }
 
-/// When a button carrying an [`CallOperator`] component is clicked,
+/// When a button carrying an [`ButtonOperatorCall`] component is clicked,
 /// dispatch the referenced operator. This is the single editor-wide
 /// glue that makes `ButtonProps::call_operator(id)` and menu/context-menu
-/// `op:`-prefixed entries (which also attach `CallOperator` via feathers)
-/// actually run the operator. Without this, `CallOperator` is inert.
+/// `op:`-prefixed entries (which also attach `ButtonOperatorCall` via feathers)
+/// actually run the operator. Without this, `ButtonOperatorCall` is inert.
 ///
 /// The feathers-level click handlers for menu/context items skip
 /// firing their own `MenuAction`/`ContextMenuAction` events when they
-/// see `CallOperator`, so this observer is the sole dispatch path for
+/// see `ButtonOperatorCall`, so this observer is the sole dispatch path for
 /// those items and won't double-fire.
-fn dispatch_call_operator(
+fn dispatch_button_operator_call(
     event: On<ButtonClickEvent>,
-    call_op: Query<&CallOperator>,
+    button_op: Query<&ButtonOperatorCall>,
     mut commands: Commands,
 ) {
-    let Ok(CallOperator(id)) = call_op.get(event.entity) else {
+    let Ok(ButtonOperatorCall(id)) = button_op.get(event.entity) else {
         return;
     };
     let id = id.clone();
@@ -76,50 +76,19 @@ impl JackdawExtension for JackdawCoreExtension {
             ),
         ));
 
-        // Spawn the three modifier-key input actions once, up front,
-        // so later keybind ports can `Chord::single(ctrl)` /
-        // `Chord::new([ctrl, shift])` / `Chord::single(alt)` without
-        // each module having to re-register them.
-        let ext = ctx.id();
-        let (ctrl, shift, alt) = ctx.entity_mut().world_scope(|world| {
-            let ctrl = world
-                .spawn((
-                    Action::<CtrlHeldAction>::new(),
-                    ActionOf::<CoreExtensionInputContext>::new(ext),
-                    bindings![KeyCode::ControlLeft, KeyCode::ControlRight],
-                ))
-                .id();
-            let shift = world
-                .spawn((
-                    Action::<ShiftHeldAction>::new(),
-                    ActionOf::<CoreExtensionInputContext>::new(ext),
-                    bindings![KeyCode::ShiftLeft, KeyCode::ShiftRight],
-                ))
-                .id();
-            let alt = world
-                .spawn((
-                    Action::<AltHeldAction>::new(),
-                    ActionOf::<CoreExtensionInputContext>::new(ext),
-                    bindings![KeyCode::AltLeft, KeyCode::AltRight],
-                ))
-                .id();
-            (ctrl, shift, alt)
-        });
-        let modifiers = Modifiers { ctrl, shift, alt };
-
         ctx.register_operator::<CancelModalOp>();
         ctx.register_operator::<crate::asset_browser::ApplyTextureOp>();
         crate::draw_brush::add_to_extension(ctx);
 
-        crate::scene_ops::add_to_extension(ctx, &modifiers);
-        crate::history_ops::add_to_extension(ctx, &modifiers);
+        crate::scene_ops::add_to_extension(ctx);
+        crate::history_ops::add_to_extension(ctx);
         crate::app_ops::add_to_extension(ctx);
-        crate::view_ops::add_to_extension(ctx, &modifiers);
+        crate::view_ops::add_to_extension(ctx);
         crate::grid_ops::add_to_extension(ctx);
         crate::gizmo_ops::add_to_extension(ctx);
         crate::edit_mode_ops::add_to_extension(ctx);
-        crate::entity_ops::add_to_extension(ctx, &modifiers);
-        crate::transform_ops::add_to_extension(ctx, &modifiers);
+        crate::entity_ops::add_to_extension(ctx);
+        crate::transform_ops::add_to_extension(ctx);
     }
 
     fn register_input_context(app: &mut App) {
@@ -129,34 +98,6 @@ impl JackdawExtension for JackdawCoreExtension {
 
 #[derive(Component, Default)]
 pub struct CoreExtensionInputContext;
-
-/// BEI input action bound to Ctrl (left or right). Operator bindings
-/// that need Ctrl as a modifier use this as a
-/// `Chord::single(ctrl_entity)` prerequisite so e.g. `Ctrl+S` fires
-/// only while Ctrl is held. The entity id is captured during
-/// `register` and passed to each module via [`Modifiers`].
-#[derive(Component, Debug, Default, Clone, Copy, InputAction)]
-#[action_output(bool)]
-pub struct CtrlHeldAction;
-
-/// BEI input action bound to Shift (left or right). See [`CtrlHeldAction`].
-#[derive(Component, Debug, Default, Clone, Copy, InputAction)]
-#[action_output(bool)]
-pub struct ShiftHeldAction;
-
-/// BEI input action bound to Alt (left or right). See [`CtrlHeldAction`].
-#[derive(Component, Debug, Default, Clone, Copy, InputAction)]
-#[action_output(bool)]
-pub struct AltHeldAction;
-
-/// Entity ids of the Ctrl, Shift, and Alt modifier actions, passed to
-/// each module's `add_to_extension` so chorded keybinds can reference
-/// them.
-pub struct Modifiers {
-    pub ctrl: Entity,
-    pub shift: Entity,
-    pub alt: Entity,
-}
 
 #[operator(
     id = "modal.cancel",

--- a/src/edit_mode_ops.rs
+++ b/src/edit_mode_ops.rs
@@ -78,7 +78,6 @@ fn can_change_edit_mode(
 #[operator(
     id = "edit_mode.object",
     label = "Object Mode",
-    allows_undo = false,
     is_available = can_change_edit_mode
 )]
 pub(crate) fn edit_mode_object(
@@ -96,7 +95,6 @@ pub(crate) fn edit_mode_object(
 #[operator(
     id = "edit_mode.vertex",
     label = "Vertex Mode",
-    allows_undo = false,
     is_available = can_change_edit_mode
 )]
 pub(crate) fn edit_mode_vertex(
@@ -120,7 +118,6 @@ pub(crate) fn edit_mode_vertex(
 #[operator(
     id = "edit_mode.edge",
     label = "Edge Mode",
-    allows_undo = false,
     is_available = can_change_edit_mode
 )]
 pub(crate) fn edit_mode_edge(
@@ -144,7 +141,6 @@ pub(crate) fn edit_mode_edge(
 #[operator(
     id = "edit_mode.face",
     label = "Face Mode",
-    allows_undo = false,
     is_available = can_change_edit_mode
 )]
 pub(crate) fn edit_mode_face(
@@ -168,7 +164,6 @@ pub(crate) fn edit_mode_face(
 #[operator(
     id = "edit_mode.clip",
     label = "Clip Mode",
-    allows_undo = false,
     is_available = can_change_edit_mode
 )]
 pub(crate) fn edit_mode_clip(
@@ -192,7 +187,6 @@ pub(crate) fn edit_mode_clip(
 #[operator(
     id = "edit_mode.physics",
     label = "Physics Tool",
-    allows_undo = false,
     is_available = can_change_edit_mode
 )]
 pub(crate) fn edit_mode_physics(

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -904,12 +904,12 @@ fn get_assets_base_dir() -> Option<std::path::PathBuf> {
 // operator has the scene locked, matching the guards the legacy
 // `handle_entity_keys` applied.
 
-use bevy_enhanced_input::prelude::{Chord, Press, *};
+use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
-use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+use crate::core_extension::CoreExtensionInputContext;
 
-pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<EntityDeleteOp>()
         .register_operator::<EntityDuplicateOp>()
         .register_operator::<EntityCopyComponentsOp>()
@@ -929,48 +929,41 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers
         .register_operator::<EntityAddPrefabOp>();
 
     let ext = ctx.id();
-    let ctrl = modifiers.ctrl;
-    let alt = modifiers.alt;
     ctx.entity_mut().world_scope(|world| {
         world.spawn((
             Action::<EntityDeleteOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::Delete, Press::default())],
+            bindings![KeyCode::Delete],
         ));
         world.spawn((
             Action::<EntityDuplicateOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyD, Press::default())],
+            bindings![KeyCode::KeyD.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<EntityCopyComponentsOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyC, Press::default())],
+            bindings![KeyCode::KeyC.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<EntityPasteComponentsOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyV, Press::default())],
+            bindings![KeyCode::KeyV.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<EntityToggleVisibilityOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::KeyH, Press::default())],
+            bindings![KeyCode::KeyH],
         ));
         world.spawn((
             Action::<EntityUnhideAllOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyH, Press::default())],
+            bindings![KeyCode::KeyH.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<EntityHideUnselectedOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::KeyH, Press::default())],
+            bindings![KeyCode::KeyH.with_mod_keys(ModKeys::ALT)],
         ));
     });
 }
@@ -1083,7 +1076,7 @@ fn entity_unhide_all(_: In<OperatorParameters>, mut commands: Commands) -> Opera
 // ── Add menu ────────────────────────────────────────────────────
 
 #[operator(id = "entity.add.cube", label = "Cube")]
-fn entity_add_cube(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_cube(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(|world: &mut World| {
         create_entity_in_world(world, EntityTemplate::Cube);
     });
@@ -1091,7 +1084,10 @@ fn entity_add_cube(_: In<OperatorParameters>, mut commands: Commands) -> Operato
 }
 
 #[operator(id = "entity.add.sphere", label = "Sphere")]
-fn entity_add_sphere(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_sphere(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         create_entity_in_world(world, EntityTemplate::Sphere);
     });
@@ -1099,7 +1095,10 @@ fn entity_add_sphere(_: In<OperatorParameters>, mut commands: Commands) -> Opera
 }
 
 #[operator(id = "entity.add.point_light", label = "Point Light")]
-fn entity_add_point_light(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_point_light(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         create_entity_in_world(world, EntityTemplate::PointLight);
     });
@@ -1107,7 +1106,7 @@ fn entity_add_point_light(_: In<OperatorParameters>, mut commands: Commands) -> 
 }
 
 #[operator(id = "entity.add.directional_light", label = "Directional Light")]
-fn entity_add_directional_light(
+pub(crate) fn entity_add_directional_light(
     _: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
@@ -1118,7 +1117,10 @@ fn entity_add_directional_light(
 }
 
 #[operator(id = "entity.add.spot_light", label = "Spot Light")]
-fn entity_add_spot_light(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_spot_light(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         create_entity_in_world(world, EntityTemplate::SpotLight);
     });
@@ -1126,7 +1128,10 @@ fn entity_add_spot_light(_: In<OperatorParameters>, mut commands: Commands) -> O
 }
 
 #[operator(id = "entity.add.camera", label = "Camera")]
-fn entity_add_camera(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_camera(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         create_entity_in_world(world, EntityTemplate::Camera3d);
     });
@@ -1134,7 +1139,10 @@ fn entity_add_camera(_: In<OperatorParameters>, mut commands: Commands) -> Opera
 }
 
 #[operator(id = "entity.add.empty", label = "Empty")]
-fn entity_add_empty(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_empty(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         create_entity_in_world(world, EntityTemplate::Empty);
     });
@@ -1142,7 +1150,10 @@ fn entity_add_empty(_: In<OperatorParameters>, mut commands: Commands) -> Operat
 }
 
 #[operator(id = "entity.add.navmesh", label = "Navmesh")]
-fn entity_add_navmesh(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_navmesh(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         crate::spawn_undoable(world, "Add Navmesh Region", |world| {
             let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
@@ -1159,7 +1170,10 @@ fn entity_add_navmesh(_: In<OperatorParameters>, mut commands: Commands) -> Oper
 }
 
 #[operator(id = "entity.add.terrain", label = "Terrain")]
-fn entity_add_terrain(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_terrain(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         crate::spawn_undoable(world, "Add Terrain", |world| {
             let mut system_state: SystemState<(Commands, ResMut<Selection>)> =
@@ -1176,7 +1190,10 @@ fn entity_add_terrain(_: In<OperatorParameters>, mut commands: Commands) -> Oper
 }
 
 #[operator(id = "entity.add.prefab", label = "Prefab")]
-fn entity_add_prefab(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub(crate) fn entity_add_prefab(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
     commands.queue(|world: &mut World| {
         crate::prefab_picker::open_prefab_picker(world);
     });

--- a/src/gizmo_ops.rs
+++ b/src/gizmo_ops.rs
@@ -62,7 +62,6 @@ fn can_change_gizmo(
 #[operator(
     id = "gizmo.mode.translate",
     label = "Gizmo Translate",
-    allows_undo = false,
     is_available = can_change_gizmo
 )]
 pub(crate) fn gizmo_mode_translate(
@@ -76,7 +75,6 @@ pub(crate) fn gizmo_mode_translate(
 #[operator(
     id = "gizmo.mode.rotate",
     label = "Gizmo Rotate",
-    allows_undo = false,
     is_available = can_change_gizmo
 )]
 pub(crate) fn gizmo_mode_rotate(
@@ -90,7 +88,6 @@ pub(crate) fn gizmo_mode_rotate(
 #[operator(
     id = "gizmo.mode.scale",
     label = "Gizmo Scale",
-    allows_undo = false,
     is_available = can_change_gizmo
 )]
 pub(crate) fn gizmo_mode_scale(
@@ -104,7 +101,6 @@ pub(crate) fn gizmo_mode_scale(
 #[operator(
     id = "gizmo.space.toggle",
     label = "Toggle Gizmo Space",
-    allows_undo = false,
     is_available = can_change_gizmo
 )]
 pub(crate) fn gizmo_space_toggle(

--- a/src/grid_ops.rs
+++ b/src/grid_ops.rs
@@ -31,7 +31,7 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     });
 }
 
-#[operator(id = "grid.increase", label = "Increase Grid", allows_undo = false)]
+#[operator(id = "grid.increase", label = "Increase Grid")]
 pub(crate) fn grid_increase(
     _: In<OperatorParameters>,
     mut snap: ResMut<SnapSettings>,
@@ -41,7 +41,7 @@ pub(crate) fn grid_increase(
     OperatorResult::Finished
 }
 
-#[operator(id = "grid.decrease", label = "Decrease Grid", allows_undo = false)]
+#[operator(id = "grid.decrease", label = "Decrease Grid")]
 pub(crate) fn grid_decrease(
     _: In<OperatorParameters>,
     mut snap: ResMut<SnapSettings>,

--- a/src/history_ops.rs
+++ b/src/history_ops.rs
@@ -10,30 +10,26 @@
 //! state stale.
 
 use bevy::prelude::*;
-use bevy_enhanced_input::prelude::{Chord, Press, *};
+use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
-use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+use crate::core_extension::CoreExtensionInputContext;
 
-pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<HistoryUndoOp>()
         .register_operator::<HistoryRedoOp>();
 
     let ext = ctx.id();
-    let ctrl = modifiers.ctrl;
-    let shift = modifiers.shift;
     ctx.entity_mut().world_scope(|world| {
         world.spawn((
             Action::<HistoryUndoOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyZ, Press::default())],
+            bindings![KeyCode::KeyZ.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<HistoryRedoOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::new([ctrl, shift]),
-            bindings![(KeyCode::KeyZ, Press::default())],
+            bindings![KeyCode::KeyZ.with_mod_keys(ModKeys::CONTROL | ModKeys::SHIFT)],
         ));
     });
 }

--- a/src/scene_ops.rs
+++ b/src/scene_ops.rs
@@ -8,12 +8,12 @@
 //! here.
 
 use bevy::prelude::*;
-use bevy_enhanced_input::prelude::{Chord, Press, *};
+use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
-use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+use crate::core_extension::CoreExtensionInputContext;
 
-pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<SceneNewOp>()
         .register_operator::<SceneOpenOp>()
         .register_operator::<SceneSaveOp>()
@@ -22,32 +22,26 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers
         .register_operator::<SceneOpenRecentOp>();
 
     let ext = ctx.id();
-    let ctrl = modifiers.ctrl;
-    let shift = modifiers.shift;
     ctx.entity_mut().world_scope(|world| {
         world.spawn((
             Action::<SceneNewOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::new([ctrl, shift]),
-            bindings![(KeyCode::KeyN, Press::default())],
+            bindings![KeyCode::KeyN.with_mod_keys(ModKeys::CONTROL | ModKeys::SHIFT)],
         ));
         world.spawn((
             Action::<SceneOpenOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyO, Press::default())],
+            bindings![KeyCode::KeyO.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<SceneSaveOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(ctrl),
-            bindings![(KeyCode::KeyS, Press::default())],
+            bindings![KeyCode::KeyS.with_mod_keys(ModKeys::CONTROL)],
         ));
         world.spawn((
             Action::<SceneSaveAsOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::new([ctrl, shift]),
-            bindings![(KeyCode::KeyS, Press::default())],
+            bindings![KeyCode::KeyS.with_mod_keys(ModKeys::CONTROL | ModKeys::SHIFT)],
         ));
     });
 }

--- a/src/snapping.rs
+++ b/src/snapping.rs
@@ -83,7 +83,7 @@ fn sync_grid_settings(
 pub const GRID_POWER_MIN: i32 = -5;
 pub const GRID_POWER_MAX: i32 = 8;
 
-#[derive(Resource)]
+#[derive(Resource, Clone, PartialEq)]
 pub struct SnapSettings {
     pub translate_snap: bool,
     pub translate_increment: f32,

--- a/src/transform_ops.rs
+++ b/src/transform_ops.rs
@@ -11,16 +11,16 @@
 //! plain Arrow and PageUp/Down for nudge.
 
 use bevy::{input_focus::InputFocus, prelude::*};
-use bevy_enhanced_input::prelude::{Chord, Press, *};
+use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
-use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+use crate::core_extension::CoreExtensionInputContext;
 use crate::entity_ops::{
     TransformReset, camera_snapped_rotation_axes, nudge_selected, reset_transform_selected,
     rotate_selected,
 };
 
-pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<TransformResetPositionOp>()
         .register_operator::<TransformResetRotationOp>()
         .register_operator::<TransformResetScaleOp>()
@@ -38,98 +38,88 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers
         .register_operator::<TransformNudgeZPosOp>();
 
     let ext = ctx.id();
-    let alt = modifiers.alt;
     ctx.entity_mut().world_scope(|world| {
         // Reset: Alt + G / R / S
         world.spawn((
             Action::<TransformResetPositionOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::KeyG, Press::default())],
+            bindings![KeyCode::KeyG.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformResetRotationOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::KeyR, Press::default())],
+            bindings![KeyCode::KeyR.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformResetScaleOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::KeyS, Press::default())],
+            bindings![KeyCode::KeyS.with_mod_keys(ModKeys::ALT)],
         ));
 
         // Rotate 90: Alt + Arrow / PageUp / PageDown
         world.spawn((
             Action::<TransformRotate90YawCcwOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::ArrowLeft, Press::default())],
+            bindings![KeyCode::ArrowLeft.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformRotate90YawCwOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::ArrowRight, Press::default())],
+            bindings![KeyCode::ArrowRight.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformRotate90PitchCcwOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::ArrowUp, Press::default())],
+            bindings![KeyCode::ArrowUp.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformRotate90PitchCwOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::ArrowDown, Press::default())],
+            bindings![KeyCode::ArrowDown.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformRotate90RollCcwOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::PageUp, Press::default())],
+            bindings![KeyCode::PageUp.with_mod_keys(ModKeys::ALT)],
         ));
         world.spawn((
             Action::<TransformRotate90RollCwOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::single(alt),
-            bindings![(KeyCode::PageDown, Press::default())],
+            bindings![KeyCode::PageDown.with_mod_keys(ModKeys::ALT)],
         ));
 
-        // Nudge: plain Arrow / PageUp / PageDown. No modifier chord —
-        // but BEI still fires our Alt+Arrow rotate bindings when Alt
-        // is held, so in practice the two don't collide.
+        // Nudge: plain Arrow / PageUp / PageDown. BEI's ModKeys check
+        // excludes held modifiers, so these don't fire when Alt is
+        // held — the Alt+Arrow rotate bindings above claim those.
         world.spawn((
             Action::<TransformNudgeXNegOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::ArrowLeft, Press::default())],
+            bindings![KeyCode::ArrowLeft],
         ));
         world.spawn((
             Action::<TransformNudgeXPosOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::ArrowRight, Press::default())],
+            bindings![KeyCode::ArrowRight],
         ));
         world.spawn((
             Action::<TransformNudgeZNegOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::ArrowUp, Press::default())],
+            bindings![KeyCode::ArrowUp],
         ));
         world.spawn((
             Action::<TransformNudgeZPosOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::ArrowDown, Press::default())],
+            bindings![KeyCode::ArrowDown],
         ));
         world.spawn((
             Action::<TransformNudgeYPosOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::PageUp, Press::default())],
+            bindings![KeyCode::PageUp],
         ));
         world.spawn((
             Action::<TransformNudgeYNegOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::PageDown, Press::default())],
+            bindings![KeyCode::PageDown],
         ));
     });
 }

--- a/src/undo_snapshot.rs
+++ b/src/undo_snapshot.rs
@@ -1,12 +1,27 @@
 //! `SceneJsnAst`-backed implementation of the snapshotter traits.
 //!
 //! Swapped out for a BSN-backed implementation on BSN migration day.
+//!
+//! The snapshot captures both the scene AST and a set of editor-state
+//! resources (edit mode, gizmo mode/space, grid, view overlays, physics
+//! overlay). That way Ctrl+Z also reverts "I toggled wireframe" or "I
+//! switched to Face mode", matching user expectations. Entity-ref
+//! resources (`Selection`, `BrushSelection`) are deliberately excluded
+//! because entity ids are re-minted by `apply_ast_to_world` and would
+//! dangle.
 
 use std::any::Any;
 
 use bevy::prelude::*;
 use jackdaw_api_internal::snapshot::{ActiveSnapshotter, SceneSnapshot, SceneSnapshotter};
+use jackdaw_avian_integration::PhysicsOverlayConfig;
 use jackdaw_jsn::SceneJsnAst;
+
+use crate::brush::EditMode;
+use crate::gizmos::{GizmoMode, GizmoSpace};
+use crate::snapping::SnapSettings;
+use crate::view_modes::ViewModeSettings;
+use crate::viewport_overlays::OverlaySettings;
 
 pub(super) fn plugin(app: &mut App) {
     app.insert_resource(ActiveSnapshotter(Box::new(JsnAstSnapshotter)));
@@ -27,33 +42,74 @@ impl SceneSnapshotter for JsnAstSnapshotter {
         // alongside their serialized data.
         Box::new(JsnAstSnapshot {
             ast: crate::scene_io::build_snapshot_ast(world),
+            editor_state: EditorStateSnapshot::capture(world),
         })
     }
 }
 
 pub struct JsnAstSnapshot {
     ast: SceneJsnAst,
+    editor_state: EditorStateSnapshot,
 }
 
 impl SceneSnapshot for JsnAstSnapshot {
     fn apply(&self, world: &mut World) {
         crate::scene_io::apply_ast_to_world(world, &self.ast);
+        self.editor_state.apply(world);
     }
 
     fn equals(&self, other: &dyn SceneSnapshot) -> bool {
         other
             .as_any()
             .downcast_ref::<Self>()
-            .is_some_and(|o| self.ast == o.ast)
+            .is_some_and(|o| self.ast == o.ast && self.editor_state == o.editor_state)
     }
 
     fn clone_box(&self) -> Box<dyn SceneSnapshot> {
         Box::new(Self {
             ast: self.ast.clone(),
+            editor_state: self.editor_state.clone(),
         })
     }
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+/// Snapshot of the editor-state resources that should round-trip
+/// through undo/redo alongside the scene AST.
+#[derive(Clone, PartialEq)]
+struct EditorStateSnapshot {
+    edit_mode: EditMode,
+    gizmo_mode: GizmoMode,
+    gizmo_space: GizmoSpace,
+    snap_settings: SnapSettings,
+    view_mode: ViewModeSettings,
+    overlays: OverlaySettings,
+    physics_overlays: PhysicsOverlayConfig,
+}
+
+impl EditorStateSnapshot {
+    fn capture(world: &World) -> Self {
+        Self {
+            edit_mode: *world.resource::<EditMode>(),
+            gizmo_mode: *world.resource::<GizmoMode>(),
+            gizmo_space: *world.resource::<GizmoSpace>(),
+            snap_settings: world.resource::<SnapSettings>().clone(),
+            view_mode: world.resource::<ViewModeSettings>().clone(),
+            overlays: world.resource::<OverlaySettings>().clone(),
+            physics_overlays: world.resource::<PhysicsOverlayConfig>().clone(),
+        }
+    }
+
+    fn apply(&self, world: &mut World) {
+        *world.resource_mut::<EditMode>() = self.edit_mode;
+        *world.resource_mut::<GizmoMode>() = self.gizmo_mode;
+        *world.resource_mut::<GizmoSpace>() = self.gizmo_space;
+        *world.resource_mut::<SnapSettings>() = self.snap_settings.clone();
+        *world.resource_mut::<ViewModeSettings>() = self.view_mode.clone();
+        *world.resource_mut::<OverlaySettings>() = self.overlays.clone();
+        *world.resource_mut::<PhysicsOverlayConfig>() = self.physics_overlays.clone();
     }
 }

--- a/src/view_modes.rs
+++ b/src/view_modes.rs
@@ -11,7 +11,7 @@ impl Plugin for ViewModesPlugin {
     }
 }
 
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Clone, PartialEq)]
 pub struct ViewModeSettings {
     pub wireframe: bool,
 }

--- a/src/view_ops.rs
+++ b/src/view_ops.rs
@@ -1,16 +1,15 @@
 //! View-mode toggles: wireframe, bounding boxes, face grid, etc.
 //!
-//! Each op just flips a resource. `allows_undo = false` so they don't
-//! push snapshot diffs to the history stack. Only `view.toggle_wireframe`
-//! has a default keybind (`Ctrl+Shift+W`); the rest are menu-only.
+//! Each op just flips a resource. Only `view.toggle_wireframe` has a
+//! default keybind (`Ctrl+Shift+W`); the rest are menu-only.
 
 use bevy::prelude::*;
-use bevy_enhanced_input::prelude::{Chord, Press, *};
+use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
 
-use crate::core_extension::{CoreExtensionInputContext, Modifiers};
+use crate::core_extension::CoreExtensionInputContext;
 
-pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers) {
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<ViewToggleWireframeOp>()
         .register_operator::<ViewToggleBoundingBoxesOp>()
         .register_operator::<ViewCycleBoundingBoxModeOp>()
@@ -22,23 +21,16 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext, modifiers: &Modifiers
         .register_operator::<ViewToggleHierarchyArrowsOp>();
 
     let ext = ctx.id();
-    let ctrl = modifiers.ctrl;
-    let shift = modifiers.shift;
     ctx.entity_mut().world_scope(|world| {
         world.spawn((
             Action::<ViewToggleWireframeOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
-            Chord::new([ctrl, shift]),
-            bindings![(KeyCode::KeyW, Press::default())],
+            bindings![KeyCode::KeyW.with_mod_keys(ModKeys::CONTROL | ModKeys::SHIFT)],
         ));
     });
 }
 
-#[operator(
-    id = "view.toggle_wireframe",
-    label = "Toggle Wireframe",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_wireframe", label = "Toggle Wireframe")]
 fn view_toggle_wireframe(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::view_modes::ViewModeSettings>,
@@ -47,11 +39,7 @@ fn view_toggle_wireframe(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_bounding_boxes",
-    label = "Toggle Bounding Boxes",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_bounding_boxes", label = "Toggle Bounding Boxes")]
 fn view_toggle_bounding_boxes(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -60,11 +48,7 @@ fn view_toggle_bounding_boxes(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.cycle_bounding_box_mode",
-    label = "Cycle Bounding Box Mode",
-    allows_undo = false
-)]
+#[operator(id = "view.cycle_bounding_box_mode", label = "Cycle Bounding Box Mode")]
 fn view_cycle_bounding_box_mode(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -80,11 +64,7 @@ fn view_cycle_bounding_box_mode(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_face_grid",
-    label = "Toggle Face Grid",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_face_grid", label = "Toggle Face Grid")]
 fn view_toggle_face_grid(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -93,11 +73,7 @@ fn view_toggle_face_grid(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_brush_wireframe",
-    label = "Toggle Brush Wireframe",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_brush_wireframe", label = "Toggle Brush Wireframe")]
 fn view_toggle_brush_wireframe(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -106,11 +82,7 @@ fn view_toggle_brush_wireframe(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_brush_outline",
-    label = "Toggle Brush Outline",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_brush_outline", label = "Toggle Brush Outline")]
 fn view_toggle_brush_outline(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -119,11 +91,7 @@ fn view_toggle_brush_outline(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_alignment_guides",
-    label = "Toggle Alignment Guides",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_alignment_guides", label = "Toggle Alignment Guides")]
 fn view_toggle_alignment_guides(
     _: In<OperatorParameters>,
     mut settings: ResMut<crate::viewport_overlays::OverlaySettings>,
@@ -132,11 +100,7 @@ fn view_toggle_alignment_guides(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_collider_gizmos",
-    label = "Toggle Collider Gizmos",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_collider_gizmos", label = "Toggle Collider Gizmos")]
 fn view_toggle_collider_gizmos(
     _: In<OperatorParameters>,
     mut config: ResMut<jackdaw_avian_integration::PhysicsOverlayConfig>,
@@ -145,11 +109,7 @@ fn view_toggle_collider_gizmos(
     OperatorResult::Finished
 }
 
-#[operator(
-    id = "view.toggle_hierarchy_arrows",
-    label = "Toggle Hierarchy Arrows",
-    allows_undo = false
-)]
+#[operator(id = "view.toggle_hierarchy_arrows", label = "Toggle Hierarchy Arrows")]
 fn view_toggle_hierarchy_arrows(
     _: In<OperatorParameters>,
     mut config: ResMut<jackdaw_avian_integration::PhysicsOverlayConfig>,

--- a/src/viewport_overlays.rs
+++ b/src/viewport_overlays.rs
@@ -57,7 +57,7 @@ pub enum BoundingBoxMode {
     ConvexHull,
 }
 
-#[derive(Resource)]
+#[derive(Resource, Clone, PartialEq)]
 pub struct OverlaySettings {
     pub show_bounding_boxes: bool,
     pub show_coordinate_indicator: bool,

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -66,6 +66,50 @@ fn can_pass_params_to_operator() {
         .assert_finished();
 }
 
+/// Verifies that the snapshot mechanism notices changes to editor-state
+/// resources (`EditMode`, `GizmoMode`, `ViewModeSettings`, ...). Two
+/// snapshots taken either side of a resource mutation must compare
+/// unequal — if they compared equal, the operator dispatcher would
+/// silently drop the undo entry and Ctrl+Z wouldn't restore the old
+/// state. The restore-via-`apply` half of the contract goes through
+/// `apply_ast_to_world`, which drives editor UI systems that can't run
+/// headless; that half is covered by manual smoke testing in the
+/// editor.
+#[test]
+fn snapshot_notices_editor_state_changes() {
+    use jackdaw::brush::{BrushEditMode, EditMode};
+    use jackdaw::gizmos::{GizmoMode, GizmoSpace};
+    use jackdaw::snapping::SnapSettings;
+    use jackdaw::view_modes::ViewModeSettings;
+    use jackdaw::viewport_overlays::OverlaySettings;
+    use jackdaw_api_internal::snapshot::ActiveSnapshotter;
+    use jackdaw_avian_integration::PhysicsOverlayConfig;
+
+    let mut app = util::headless_app();
+    app.finish();
+    app.update();
+
+    let world = app.world_mut();
+    let before = world
+        .resource_scope(|world, snapshotter: Mut<ActiveSnapshotter>| snapshotter.0.capture(world));
+
+    // Flip each editor-state resource the snapshot should cover.
+    *world.resource_mut::<ViewModeSettings>() = ViewModeSettings { wireframe: true };
+    *world.resource_mut::<EditMode>() = EditMode::BrushEdit(BrushEditMode::Face);
+    *world.resource_mut::<GizmoMode>() = GizmoMode::Rotate;
+    *world.resource_mut::<GizmoSpace>() = GizmoSpace::Local;
+    world.resource_mut::<SnapSettings>().grid_power = 3;
+    world.resource_mut::<OverlaySettings>().show_bounding_boxes = true;
+    world.resource_mut::<PhysicsOverlayConfig>().show_colliders = false;
+
+    let after = world
+        .resource_scope(|world, snapshotter: Mut<ActiveSnapshotter>| snapshotter.0.capture(world));
+    assert!(
+        !before.equals(&*after),
+        "snapshotter should observe the mutated editor-state resources"
+    );
+}
+
 #[derive(Default)]
 struct SampleExtension;
 


### PR DESCRIPTION
Addresses Jan's review on discord for (#194).

Renames `CallOperator` to `ButtonOperatorCall` to disambiguate from `OperatorCallBuilder`. Replaces the three modifier-action shims and chord bindings with BEI's native `ModKeys`. Extends the snapshotter to round-trip editor-state resources (`EditMode`, `GizmoMode`, `GizmoSpace`, `SnapSettings`, `ViewModeSettings`, `OverlaySettings`, `PhysicsOverlayConfig`) alongside the scene AST, and flips `allows_undo = true` on the v3 mode/view/grid/gizmo toggles so Ctrl+Z actually reverts them. Replaces hand-typed `"op:..."` strings in `add_entity_picker::builtin_groups` with values derived from `<Op>::ID`.