### PR TITLE
operatorify v7: physics, rename, box-select modal operators

### DIFF
--- a/src/brush/mod.rs
+++ b/src/brush/mod.rs
@@ -70,6 +70,18 @@ pub struct BrushSelection {
     pub last_face_index: Option<usize>,
 }
 
+impl BrushSelection {
+    /// Clear the active selection (entity + faces + vertices + edges).
+    /// Leaves `last_face_*` untouched so the extend-to-brush fallback
+    /// still works after deselecting.
+    pub fn clear(&mut self) {
+        self.entity = None;
+        self.faces.clear();
+        self.vertices.clear();
+        self.edges.clear();
+    }
+}
+
 /// Intent for face hover highlight color.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum HoverIntent {

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -89,6 +89,9 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::edit_mode_ops::add_to_extension(ctx);
         crate::entity_ops::add_to_extension(ctx);
         crate::transform_ops::add_to_extension(ctx);
+        crate::physics_tool::add_to_extension(ctx);
+        crate::hierarchy::add_to_extension(ctx);
+        crate::viewport_select::add_to_extension(ctx);
     }
 
     fn register_input_context(&self, app: &mut App) {

--- a/src/edit_mode_ops.rs
+++ b/src/edit_mode_ops.rs
@@ -24,8 +24,7 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<EditModeVertexOp>()
         .register_operator::<EditModeEdgeOp>()
         .register_operator::<EditModeFaceOp>()
-        .register_operator::<EditModeClipOp>()
-        .register_operator::<EditModePhysicsOp>();
+        .register_operator::<EditModeClipOp>();
 
     let ext = ctx.id();
     ctx.entity_mut().world_scope(|world| {
@@ -87,7 +86,7 @@ pub(crate) fn edit_mode_object(
     mut draw_state: ResMut<DrawBrushState>,
 ) -> OperatorResult {
     *edit_mode = EditMode::Object;
-    clear_brush_selection(&mut brush_selection);
+    brush_selection.clear();
     draw_state.active = None;
     OperatorResult::Finished
 }
@@ -184,27 +183,6 @@ pub(crate) fn edit_mode_clip(
     )
 }
 
-#[operator(
-    id = "edit_mode.physics",
-    label = "Physics Tool",
-    is_available = can_change_edit_mode
-)]
-pub(crate) fn edit_mode_physics(
-    _: In<OperatorParameters>,
-    mut edit_mode: ResMut<EditMode>,
-    mut brush_selection: ResMut<BrushSelection>,
-    mut draw_state: ResMut<DrawBrushState>,
-) -> OperatorResult {
-    draw_state.active = None;
-    clear_brush_selection(&mut brush_selection);
-    *edit_mode = if *edit_mode == EditMode::Physics {
-        EditMode::Object
-    } else {
-        EditMode::Physics
-    };
-    OperatorResult::Finished
-}
-
 fn switch_brush_edit_mode(
     target: BrushEditMode,
     mut edit_mode: ResMut<EditMode>,
@@ -219,7 +197,7 @@ fn switch_brush_edit_mode(
         EditMode::BrushEdit(current) if current == target => {
             // Same mode pressed twice: toggle back to Object.
             *edit_mode = EditMode::Object;
-            clear_brush_selection(&mut brush_selection);
+            brush_selection.clear();
         }
         EditMode::BrushEdit(_) => {
             // Switching between brush sub-modes: swap the mode but
@@ -244,11 +222,4 @@ fn switch_brush_edit_mode(
         }
     }
     OperatorResult::Finished
-}
-
-fn clear_brush_selection(brush_selection: &mut BrushSelection) {
-    brush_selection.entity = None;
-    brush_selection.faces.clear();
-    brush_selection.vertices.clear();
-    brush_selection.edges.clear();
 }

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -6,6 +6,7 @@ use bevy::{
 };
 use bevy_monitors::prelude::{Mutation, NotifyChanged};
 use jackdaw_api::prelude::*;
+use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 use jackdaw_feathers::{
     context_menu::spawn_context_menu,
     icons::IconFont,
@@ -65,13 +66,13 @@ impl Plugin for HierarchyPlugin {
         app.init_resource::<ContextMenuState>()
             .init_resource::<PendingTemplateDefaultName>()
             .init_resource::<HierarchyShowAll>()
+            .init_resource::<PendingRenameTarget>()
             .add_systems(Startup, setup_tree_node_expanded_watcher)
             .add_systems(OnEnter(crate::AppState::Editor), setup_name_watcher)
             .add_systems(
                 Update,
                 (
                     apply_hierarchy_filter,
-                    cancel_inline_rename,
                     auto_focus_inline_rename,
                     handle_hierarchy_right_click.after(ContextMenuCloseSystems),
                     populate_template_dialog,
@@ -1079,6 +1080,10 @@ fn on_visibility_toggled(
     });
 }
 
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<RenameBeginOp>();
+}
+
 /// Marker for inline rename `text_edit` entity, linking back to the label entity and source entity.
 #[derive(Component)]
 struct InlineRenameInput {
@@ -1086,93 +1091,114 @@ struct InlineRenameInput {
     source_entity: Entity,
 }
 
-/// Cancel inline rename on Escape key.
-fn cancel_inline_rename(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut commands: Commands,
-    rename_query: Query<(Entity, &InlineRenameInput)>,
-    names: Query<&Name>,
-    mut input_focus: ResMut<InputFocus>,
-) {
-    if !keyboard.just_pressed(KeyCode::Escape) {
-        return;
-    }
-    for (rename_entity, inline_rename) in &rename_query {
-        input_focus.clear();
+/// Entity to rename on the next `hierarchy.rename_begin` invoke.
+#[derive(Resource, Default)]
+struct PendingRenameTarget(Option<Entity>);
 
-        let original_name = names
-            .get(inline_rename.source_entity)
-            .map(|n| n.as_str().to_string())
-            .unwrap_or_default();
-
-        // Unhide the label and restore its text
-        commands
-            .entity(inline_rename.label_entity)
-            .remove::<TreeRowInlineRename>();
-        if let Ok(mut ec) = commands.get_entity(inline_rename.label_entity) {
-            ec.insert(Text::new(original_name));
-            ec.entry::<Node>().and_modify(|mut node| {
-                node.display = Display::Flex;
-            });
-        }
-
-        // Despawn the rename text_edit entity
-        commands.entity(rename_entity).despawn();
-    }
-}
-
-/// Start inline rename: hide the label and spawn a `text_edit` sibling.
 fn on_tree_row_start_rename(
     event: On<TreeRowStartRename>,
     mut commands: Commands,
+    mut pending: ResMut<PendingRenameTarget>,
+    rename_check: Query<(), With<InlineRenameInput>>,
+) {
+    if !rename_check.is_empty() {
+        return;
+    }
+    pending.0 = Some(event.source_entity);
+    commands.queue(|world: &mut World| {
+        let _ = world
+            .operator(RenameBeginOp::ID)
+            .settings(CallOperatorSettings {
+                execution_context: ExecutionContext::Invoke,
+                creates_history_entry: false,
+            })
+            .call();
+    });
+}
+
+fn entity_name(names: &Query<&Name>, entity: Entity) -> String {
+    names
+        .get(entity)
+        .map(|n| n.as_str().to_string())
+        .unwrap_or_default()
+}
+
+/// Resolve the label entity and its containing row for a scene entity's tree node.
+fn find_rename_targets(
+    source: Entity,
+    tree_index: &TreeIndex,
+    tree_nodes: &Query<&Children, With<TreeNode>>,
+    content_query: &Query<(Entity, &Children), With<TreeRowContent>>,
+    label_query: &Query<Entity, With<TreeRowLabel>>,
+) -> Option<(Entity, Entity)> {
+    let tree_entity = tree_index.get(source)?;
+    let children = tree_nodes.get(tree_entity).ok()?;
+    for child in children.iter() {
+        if let Ok((content_e, content_children)) = content_query.get(child) {
+            for grandchild in content_children.iter() {
+                if label_query.contains(grandchild) {
+                    return Some((grandchild, content_e));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn restore_label(commands: &mut Commands, label_entity: Entity, text: String) {
+    commands
+        .entity(label_entity)
+        .remove::<TreeRowInlineRename>();
+    if let Ok(mut ec) = commands.get_entity(label_entity) {
+        ec.insert(Text::new(text));
+        ec.entry::<Node>().and_modify(|mut node| {
+            node.display = Display::Flex;
+        });
+    }
+}
+
+#[operator(
+    id = "hierarchy.rename_begin",
+    label = "Rename Entity",
+    description = "Begin inline rename of the entity in `PendingRenameTarget`. \
+                   Modal: commits on Enter, cancels on Escape.",
+    modal = true,
+    allows_undo = false,
+    cancel = cancel_rename_begin,
+)]
+pub(crate) fn rename_begin(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+    mut pending: ResMut<PendingRenameTarget>,
     tree_index: Res<TreeIndex>,
     tree_nodes: Query<&Children, With<TreeNode>>,
     content_query: Query<(Entity, &Children), With<TreeRowContent>>,
     label_query: Query<Entity, With<TreeRowLabel>>,
     names: Query<&Name>,
-    rename_check: Query<(), With<InlineRenameInput>>,
-) {
-    let source = event.source_entity;
-
-    // Don't start a rename if one is already active
-    if !rename_check.is_empty() {
-        return;
+    rename_inputs: Query<(), With<InlineRenameInput>>,
+    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+) -> OperatorResult {
+    if modal.is_some() {
+        return if rename_inputs.is_empty() {
+            OperatorResult::Finished
+        } else {
+            OperatorResult::Running
+        };
     }
 
-    let Some(tree_entity) = tree_index.get(source) else {
-        return;
+    let Some(source) = pending.0.take() else {
+        return OperatorResult::Cancelled;
     };
-    let Ok(children) = tree_nodes.get(tree_entity) else {
-        return;
-    };
-
-    // Find the TreeRowContent entity and the TreeRowLabel entity within it
-    let mut label_entity = None;
-    let mut content_entity = None;
-    for child in children.iter() {
-        if let Ok((content_e, content_children)) = content_query.get(child) {
-            for grandchild in content_children.iter() {
-                if label_query.contains(grandchild) {
-                    label_entity = Some(grandchild);
-                    content_entity = Some(content_e);
-                    break;
-                }
-            }
-        }
-    }
-    let Some(label_entity) = label_entity else {
-        return;
-    };
-    let Some(content_entity) = content_entity else {
-        return;
+    let Some((label_entity, content_entity)) = find_rename_targets(
+        source,
+        &tree_index,
+        &tree_nodes,
+        &content_query,
+        &label_query,
+    ) else {
+        return OperatorResult::Cancelled;
     };
 
-    let current_name = names
-        .get(source)
-        .map(|n| n.as_str().to_string())
-        .unwrap_or_default();
-
-    // Hide the label and mark it so we can restore later
     commands.entity(label_entity).insert(TreeRowInlineRename);
     commands
         .entity(label_entity)
@@ -1181,7 +1207,6 @@ fn on_tree_row_start_rename(
             node.display = Display::None;
         });
 
-    // Spawn the text_edit as a sibling inside the content entity
     commands.spawn((
         InlineRenameInput {
             label_entity,
@@ -1189,11 +1214,26 @@ fn on_tree_row_start_rename(
         },
         text_edit::text_edit(
             TextEditProps::default()
-                .with_default_value(current_name)
+                .with_default_value(entity_name(&names, source))
                 .allow_empty(),
         ),
         ChildOf(content_entity),
     ));
+    OperatorResult::Running
+}
+
+fn cancel_rename_begin(
+    mut commands: Commands,
+    rename_query: Query<(Entity, &InlineRenameInput)>,
+    names: Query<&Name>,
+    mut input_focus: ResMut<InputFocus>,
+) {
+    for (rename_entity, inline_rename) in &rename_query {
+        input_focus.clear();
+        let original = entity_name(&names, inline_rename.source_entity);
+        restore_label(&mut commands, inline_rename.label_entity, original);
+        commands.entity(rename_entity).despawn();
+    }
 }
 
 /// Auto-focus inline rename `text_edit` inputs one frame after spawn.
@@ -1259,22 +1299,7 @@ fn handle_inline_rename_commit(
     };
 
     input_focus.clear();
-
-    // Restore label
-    commands
-        .entity(label_entity)
-        .remove::<TreeRowInlineRename>();
-    commands
-        .entity(label_entity)
-        .insert(Text::new(event.text.clone()));
-    commands
-        .entity(label_entity)
-        .entry::<Node>()
-        .and_modify(|mut node| {
-            node.display = Display::Flex;
-        });
-
-    // Despawn the rename text_edit entity
+    restore_label(&mut commands, label_entity, event.text.clone());
     commands.entity(rename_entity).despawn();
 
     // Trigger the rename

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -16,13 +16,13 @@ use crate::{
     brush::{BrushEditMode, EditMode},
     draw_brush::{ActivateDrawBrushModalOp, DrawBrushState},
     edit_mode_ops::{
-        EditModeClipOp, EditModeEdgeOp, EditModeFaceOp, EditModeObjectOp, EditModePhysicsOp,
-        EditModeVertexOp,
+        EditModeClipOp, EditModeEdgeOp, EditModeFaceOp, EditModeObjectOp, EditModeVertexOp,
     },
     gizmo_ops::{GizmoModeRotateOp, GizmoModeScaleOp, GizmoModeTranslateOp, GizmoSpaceToggleOp},
     gizmos::{GizmoMode, GizmoSpace},
     hierarchy::{HierarchyPanel, HierarchyShowAllButton, HierarchyTreeContainer},
     inspector::Inspector,
+    physics_tool::PhysicsActivateOp,
     remote::ConnectionManager,
     viewport::SceneViewport,
 };
@@ -737,13 +737,31 @@ fn toolbar_edit_button(
             TextColor(tokens::TEXT_SECONDARY),
         )],
         observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            // Clicking the Physics button while active cancels the
+            // modal; re-dispatching would fail with ModalAlreadyActive.
+            if matches!(tool, EditToolButton::Physics) {
+                commands.queue(|world: &mut World| {
+                    if *world.resource::<EditMode>() == EditMode::Physics {
+                        let _ = world.operator("modal.cancel").call();
+                    } else {
+                        let _ = world
+                            .operator(PhysicsActivateOp::ID)
+                            .settings(CallOperatorSettings {
+                                execution_context: ExecutionContext::Invoke,
+                                creates_history_entry: true,
+                            })
+                            .call();
+                    }
+                });
+                return;
+            }
             let op_id: Cow<'static, str> = match tool {
                 EditToolButton::Object => EditModeObjectOp::ID.into(),
                 EditToolButton::Vertex => EditModeVertexOp::ID.into(),
                 EditToolButton::Edge => EditModeEdgeOp::ID.into(),
                 EditToolButton::Face => EditModeFaceOp::ID.into(),
                 EditToolButton::Clip => EditModeClipOp::ID.into(),
-                EditToolButton::Physics => EditModePhysicsOp::ID.into(),
+                EditToolButton::Physics => unreachable!("handled above"),
                 EditToolButton::Operator(op) => op.into(),
             };
             commands

--- a/src/physics_tool.rs
+++ b/src/physics_tool.rs
@@ -15,8 +15,14 @@ use bevy::{
     window::SystemCursorIcon,
 };
 
-use crate::brush::EditMode;
+use bevy_enhanced_input::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::lifecycle::ActiveModalOperator;
+
+use crate::brush::{BrushSelection, EditMode};
 use crate::commands::{CommandGroup, CommandHistory, EditorCommand, SetJsnField};
+use crate::core_extension::CoreExtensionInputContext;
+use crate::draw_brush::DrawBrushState;
 use crate::selection::Selection;
 use jackdaw_avian_integration::simulation::{PhysicsDrag, PhysicsToolState};
 
@@ -32,15 +38,64 @@ impl Plugin for PhysicsToolPlugin {
         );
         app.add_systems(
             Update,
-            (
-                sync_selection_disable_state,
-                physics_tool_drag,
-                physics_tool_keys,
-            )
+            (sync_selection_disable_state, physics_tool_drag)
                 .chain()
                 .after(on_edit_mode_transition)
                 .run_if(in_state(crate::AppState::Editor)),
         );
+    }
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<PhysicsActivateOp>();
+
+    let ext = ctx.id();
+    ctx.entity_mut().world_scope(|world| {
+        world.spawn((
+            Action::<PhysicsActivateOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            bindings![KeyCode::KeyP.with_mod_keys(ModKeys::SHIFT)],
+        ));
+    });
+}
+
+#[operator(
+    id = "physics.activate",
+    label = "Physics Tool",
+    description = "Hammer-style physics placement tool. Modal: Space commits, Escape cancels.",
+    modal = true,
+    allows_undo = false,
+    cancel = cancel_physics_activate,
+)]
+pub(crate) fn physics_activate(
+    _: In<OperatorParameters>,
+    mut edit_mode: ResMut<EditMode>,
+    mut draw_state: ResMut<DrawBrushState>,
+    mut brush_selection: ResMut<BrushSelection>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+) -> OperatorResult {
+    if modal.is_none() {
+        draw_state.active = None;
+        brush_selection.clear();
+        *edit_mode = EditMode::Physics;
+        return OperatorResult::Running;
+    }
+
+    if keyboard.just_pressed(KeyCode::Space) {
+        *edit_mode = EditMode::Object;
+        return OperatorResult::Finished;
+    }
+    if *edit_mode != EditMode::Physics {
+        return OperatorResult::Finished;
+    }
+
+    OperatorResult::Running
+}
+
+fn cancel_physics_activate(mut edit_mode: ResMut<EditMode>) {
+    if *edit_mode == EditMode::Physics {
+        *edit_mode = EditMode::Object;
     }
 }
 
@@ -325,16 +380,6 @@ fn physics_tool_drag(
                 override_cursor.0 = None;
             }
         }
-    }
-}
-
-/// Space/Escape: commit & exit to Object mode.
-fn physics_tool_keys(mut edit_mode: ResMut<EditMode>, keyboard: Res<ButtonInput<KeyCode>>) {
-    if *edit_mode != EditMode::Physics {
-        return;
-    }
-    if keyboard.just_pressed(KeyCode::Space) || keyboard.just_pressed(KeyCode::Escape) {
-        *edit_mode = EditMode::Object;
     }
 }
 

--- a/src/viewport_select.rs
+++ b/src/viewport_select.rs
@@ -11,6 +11,8 @@ use bevy::{
     picking::prelude::Pickable,
     prelude::*,
 };
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 use jackdaw_jsn::BrushGroup;
 
 /// Marker for the box-select visual overlay node.
@@ -28,13 +30,17 @@ impl Plugin for ViewportSelectPlugin {
                 Update,
                 (
                     handle_viewport_click.after(handle_gizmo_hover),
-                    handle_box_select,
+                    box_select_invoke_trigger,
                     update_box_select_overlay,
                     exit_group_on_escape,
                 )
                     .in_set(crate::EditorInteractionSystems),
             );
     }
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<BoxSelectOp>();
 }
 
 #[derive(Resource, Default)]
@@ -247,88 +253,112 @@ pub(crate) fn handle_viewport_click(
     }
 }
 
-fn handle_box_select(
+/// Shift+LMB in the viewport dispatches [`BoxSelectOp`]. Modifier+mouse
+/// gestures aren't expressible as BEI key actions, so this stays a system.
+fn box_select_invoke_trigger(
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
     vp: ViewportCursor,
-    mut box_state: ResMut<BoxSelectState>,
     guards: InteractionGuards,
-    scene_entities: Query<(Entity, &GlobalTransform), (Without<EditorEntity>, With<Name>)>,
-    mut selection: ResMut<Selection>,
+    box_state: Res<BoxSelectState>,
     mut commands: Commands,
 ) {
-    // Don't box-select during gizmo drag, brush edit mode, or draw mode.
-    // Physics mode is allowed (same as Object for selection purposes).
-    if guards.gizmo_drag.active
+    if box_state.active
+        || !mouse.just_pressed(MouseButton::Left)
+        || !keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight])
+        || guards.gizmo_drag.active
         || matches!(*guards.edit_mode, crate::brush::EditMode::BrushEdit(_))
         || guards.draw_state.active.is_some()
+        || guards.modal.active.is_some()
     {
-        box_state.active = false;
         return;
     }
-
     let Ok(window) = vp.windows.single() else {
         return;
     };
-    let Some(cursor_pos) = window.cursor_position() else {
+    if window.cursor_position().is_none() {
         return;
+    }
+    commands.queue(|world: &mut World| {
+        let _ = world
+            .operator(BoxSelectOp::ID)
+            .settings(CallOperatorSettings {
+                execution_context: ExecutionContext::Invoke,
+                creates_history_entry: false,
+            })
+            .call();
+    });
+}
+
+#[operator(
+    id = "selection.box_select",
+    label = "Box Select",
+    description = "Drag a rectangle to select entities. \
+                   Modal: commits on mouse release, cancels on Escape.",
+    modal = true,
+    allows_undo = false,
+    cancel = cancel_box_select,
+)]
+pub(crate) fn box_select(
+    _: In<OperatorParameters>,
+    mouse: Res<ButtonInput<MouseButton>>,
+    vp: ViewportCursor,
+    mut box_state: ResMut<BoxSelectState>,
+    scene_entities: Query<(Entity, &GlobalTransform), (Without<EditorEntity>, With<Name>)>,
+    mut selection: ResMut<Selection>,
+    mut commands: Commands,
+    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+) -> OperatorResult {
+    let Ok(window) = vp.windows.single() else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(cursor_pos) = window.cursor_position() else {
+        return OperatorResult::Cancelled;
     };
 
-    let shift = keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);
-
-    // Start box select on Shift+LMB drag
-    if shift && mouse.just_pressed(MouseButton::Left) && !box_state.active {
+    if modal.is_none() {
         box_state.active = true;
         box_state.start = cursor_pos;
         box_state.current = cursor_pos;
-        return;
+        return OperatorResult::Running;
     }
 
-    if box_state.active {
-        box_state.current = cursor_pos;
-
-        let released = mouse.just_released(MouseButton::Left);
-
-        if released {
-            box_state.active = false;
-
-            let Ok((camera, cam_tf)) = vp.camera.single() else {
-                return;
-            };
-            let Ok((vp_computed, vp_tf)) = vp.viewport.single() else {
-                return;
-            };
-            let scale = vp_computed.inverse_scale_factor();
-            let vp_pos = vp_tf.translation * scale;
-            let vp_size = vp_computed.size() * scale;
-            let vp_top_left = vp_pos - vp_size / 2.0;
-
-            // Convert box to viewport-local coords, then remap to camera space
-            let target_size = camera.logical_viewport_size().unwrap_or(vp_size);
-            let remap = target_size / vp_size;
-            let min = (box_state.start - vp_top_left).min(box_state.current - vp_top_left) * remap;
-            let max = (box_state.start - vp_top_left).max(box_state.current - vp_top_left) * remap;
-
-            // Find entities within the box
-            let mut selected_entities = Vec::new();
-            for (entity, global_tf) in &scene_entities {
-                let pos = global_tf.translation();
-                if let Ok(screen_pos) = camera.world_to_viewport(cam_tf, pos)
-                    && screen_pos.x >= min.x
-                    && screen_pos.x <= max.x
-                    && screen_pos.y >= min.y
-                    && screen_pos.y <= max.y
-                    && !selected_entities.contains(&entity)
-                {
-                    selected_entities.push(entity);
-                }
-            }
-
-            if !selected_entities.is_empty() {
-                selection.select_multiple(&mut commands, &selected_entities);
-            }
-        }
+    box_state.current = cursor_pos;
+    if !mouse.just_released(MouseButton::Left) {
+        return OperatorResult::Running;
     }
+    box_state.active = false;
+
+    let Ok((camera, cam_tf)) = vp.camera.single() else {
+        return OperatorResult::Finished;
+    };
+    let Ok((vp_computed, vp_tf)) = vp.viewport.single() else {
+        return OperatorResult::Finished;
+    };
+    let scale = vp_computed.inverse_scale_factor();
+    let vp_size = vp_computed.size() * scale;
+    let vp_top_left = vp_tf.translation * scale - vp_size / 2.0;
+    let remap = camera.logical_viewport_size().unwrap_or(vp_size) / vp_size;
+    let min = (box_state.start - vp_top_left).min(box_state.current - vp_top_left) * remap;
+    let max = (box_state.start - vp_top_left).max(box_state.current - vp_top_left) * remap;
+
+    let selected: Vec<Entity> = scene_entities
+        .iter()
+        .filter_map(|(entity, tf)| {
+            let screen = camera.world_to_viewport(cam_tf, tf.translation()).ok()?;
+            (screen.x >= min.x && screen.x <= max.x && screen.y >= min.y && screen.y <= max.y)
+                .then_some(entity)
+        })
+        .collect();
+
+    if !selected.is_empty() {
+        selection.select_multiple(&mut commands, &selected);
+    }
+    OperatorResult::Finished
+}
+
+fn cancel_box_select(mut box_state: ResMut<BoxSelectState>) {
+    box_state.active = false;
 }
 
 fn update_box_select_overlay(


### PR DESCRIPTION
Three modal operators ported:

- `physics.activate` — Shift+P, Space commits, Escape cancels.
- `hierarchy.rename_begin` — F2 / context menu rename.
- `selection.box_select` — Shift+LMB drag-rectangle selection.