### PR TITLE
operatorify v9: inspector buttons, browsers, navmesh, terrain, PIE

### DIFF
--- a/crates/jackdaw_api_internal/src/operator.rs
+++ b/crates/jackdaw_api_internal/src/operator.rs
@@ -130,6 +130,47 @@ pub trait Operator: InputAction + 'static {
 #[derive(Debug, Clone, Default, Deref, DerefMut, Reflect)]
 pub struct OperatorParameters(pub BTreeMap<String, PropertyValue>);
 
+impl OperatorParameters {
+    /// Read an `i64` parameter by key.
+    pub fn as_int(&self, key: &str) -> Option<i64> {
+        match self.get(key)? {
+            PropertyValue::Int(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    /// Read an `f64` parameter by key.
+    pub fn as_float(&self, key: &str) -> Option<f64> {
+        match self.get(key)? {
+            PropertyValue::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    /// Read a `bool` parameter by key.
+    pub fn as_bool(&self, key: &str) -> Option<bool> {
+        match self.get(key)? {
+            PropertyValue::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// Read a `String` parameter by key.
+    pub fn as_str(&self, key: &str) -> Option<&str> {
+        match self.get(key)? {
+            PropertyValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Read an [`Entity`] parameter, decoded from the `i64` bits a
+    /// caller stored via [`Entity::to_bits()`]. Returns `None` if the
+    /// key is missing or not an `Int`.
+    pub fn as_entity(&self, key: &str) -> Option<Entity> {
+        self.as_int(key).map(|bits| Entity::from_bits(bits as u64))
+    }
+}
+
 pub type OperatorSystemId = SystemId<In<OperatorParameters>, OperatorResult>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -1455,10 +1455,20 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<AssetSelectFolderOp>();
 }
 
+fn has_array_preview(preview: Res<AssetPreviewState>) -> bool {
+    preview
+        .selected_info
+        .as_ref()
+        .is_some_and(|info| info.layer_count > 0)
+}
+
 #[operator(
     id = "asset.cycle_array_layer",
     label = "Cycle Array Layer",
-    description = "Step the asset preview's `current_layer` by `direction` (defaults to +1), wrapping at `selected_info.layer_count`.",
+    description = "Step the asset preview's `current_layer` by `direction`, wrapping at `selected_info.layer_count`. \
+                   Availability (`has_array_preview`) requires the asset preview to hold an array texture.\n\
+                   Params: `direction: i64` (signed step, defaults to +1).",
+    is_available = has_array_preview,
     allows_undo = false
 )]
 pub(crate) fn asset_cycle_array_layer(

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -1462,12 +1462,16 @@ fn has_array_preview(preview: Res<AssetPreviewState>) -> bool {
         .is_some_and(|info| info.layer_count > 0)
 }
 
+/// Step the asset preview's selected layer by `direction`, wrapping at
+/// the texture's layer count.
+///
+/// # Parameters
+/// - `direction` (`i64`, default `+1`): how many layers to advance, can
+///   be negative to step backwards.
 #[operator(
     id = "asset.cycle_array_layer",
     label = "Cycle Array Layer",
-    description = "Step the asset preview's `current_layer` by `direction`, wrapping at `selected_info.layer_count`. \
-                   Availability (`has_array_preview`) requires the asset preview to hold an array texture.\n\
-                   Params: `direction: i64` (signed step, defaults to +1).",
+    description = "Step the previewed array texture by one layer.",
     is_available = has_array_preview
 )]
 pub(crate) fn asset_cycle_array_layer(
@@ -1480,23 +1484,18 @@ pub(crate) fn asset_cycle_array_layer(
     if info.layer_count == 0 {
         return OperatorResult::Cancelled;
     }
-    let direction = params
-        .get("direction")
-        .and_then(|v| match v {
-            jackdaw_jsn::PropertyValue::Int(i) => Some(*i),
-            _ => None,
-        })
-        .unwrap_or(1);
+    let direction = params.as_int("direction").unwrap_or(1);
     let count = info.layer_count as i64;
     let next = ((preview.current_layer as i64) + direction).rem_euclid(count);
     preview.current_layer = next as u32;
     OperatorResult::Finished
 }
 
+/// Choose a different folder as the assets directory.
 #[operator(
     id = "asset.select_folder",
     label = "Select Assets Folder",
-    description = "Open an OS folder picker and store the result in `AssetBrowserFolderTask` for the polling system to consume."
+    description = "Choose a different folder as the assets directory."
 )]
 pub(crate) fn asset_select_folder(
     _: In<OperatorParameters>,

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -1129,16 +1129,14 @@ fn update_preview_panel(
             TextColor(tokens::TEXT_PRIMARY),
             ChildOf(prev_btn),
         ));
-        let layer_count = info.layer_count;
-        commands.entity(prev_btn).observe(
-            move |_: On<Pointer<Click>>, mut ps: ResMut<AssetPreviewState>| {
-                if ps.current_layer > 0 {
-                    ps.current_layer -= 1;
-                } else {
-                    ps.current_layer = layer_count.saturating_sub(1);
-                }
-            },
-        );
+        commands
+            .entity(prev_btn)
+            .observe(|_: On<Pointer<Click>>, mut commands: Commands| {
+                commands
+                    .operator(AssetCycleArrayLayerOp::ID)
+                    .param("direction", -1i64)
+                    .call();
+            });
 
         commands.spawn((
             Text::new(layer_text),
@@ -1171,12 +1169,14 @@ fn update_preview_panel(
             TextColor(tokens::TEXT_PRIMARY),
             ChildOf(next_btn),
         ));
-        let layer_count2 = info.layer_count;
-        commands.entity(next_btn).observe(
-            move |_: On<Pointer<Click>>, mut ps: ResMut<AssetPreviewState>| {
-                ps.current_layer = (ps.current_layer + 1) % layer_count2;
-            },
-        );
+        commands
+            .entity(next_btn)
+            .observe(|_: On<Pointer<Click>>, mut commands: Commands| {
+                commands
+                    .operator(AssetCycleArrayLayerOp::ID)
+                    .param("direction", 1i64)
+                    .call();
+            });
     }
 
     // Apply button (only for 2D textures)
@@ -1232,20 +1232,6 @@ fn update_preview_panel(
             },
         );
     }
-}
-
-fn spawn_asset_folder_dialog(
-    _: On<Pointer<Click>>,
-    mut commands: Commands,
-    raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
-) {
-    let mut dialog = AsyncFileDialog::new().set_title("Select assets directory");
-    if let Ok(rh) = raw_handle.single() {
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
-    let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
-    commands.insert_resource(AssetBrowserFolderTask(task));
 }
 
 fn poll_asset_browser_folder(world: &mut World) {
@@ -1436,7 +1422,9 @@ fn asset_folder_button(icon_font: Handle<Font>) -> impl Bundle {
             icon_font,
             tokens::TEXT_SECONDARY,
         ),
-        observe(spawn_asset_folder_dialog),
+        observe(|_: On<Pointer<Click>>, mut commands: Commands| {
+            commands.operator(AssetSelectFolderOp::ID).call();
+        }),
     )
 }
 
@@ -1458,4 +1446,61 @@ fn check_watcher_events(
         browser.needs_refresh = true;
         material_browser.needs_rescan = true;
     }
+}
+
+// ── Operators ──────────────────────────────────────────────────────────────
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<AssetCycleArrayLayerOp>()
+        .register_operator::<AssetSelectFolderOp>();
+}
+
+#[operator(
+    id = "asset.cycle_array_layer",
+    label = "Cycle Array Layer",
+    description = "Step the asset preview's `current_layer` by `direction` (defaults to +1), wrapping at `selected_info.layer_count`.",
+    allows_undo = false
+)]
+pub(crate) fn asset_cycle_array_layer(
+    params: In<OperatorParameters>,
+    mut preview: ResMut<AssetPreviewState>,
+) -> OperatorResult {
+    let Some(info) = preview.selected_info.as_ref() else {
+        return OperatorResult::Cancelled;
+    };
+    if info.layer_count == 0 {
+        return OperatorResult::Cancelled;
+    }
+    let direction = params
+        .get("direction")
+        .and_then(|v| match v {
+            jackdaw_jsn::PropertyValue::Int(i) => Some(*i),
+            _ => None,
+        })
+        .unwrap_or(1);
+    let count = info.layer_count as i64;
+    let next = ((preview.current_layer as i64) + direction).rem_euclid(count);
+    preview.current_layer = next as u32;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "asset.select_folder",
+    label = "Select Assets Folder",
+    description = "Open an OS folder picker and store the result in `AssetBrowserFolderTask` for the polling system to consume.",
+    allows_undo = false
+)]
+pub(crate) fn asset_select_folder(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+    raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
+) -> OperatorResult {
+    let mut dialog = AsyncFileDialog::new().set_title("Select assets directory");
+    if let Ok(rh) = raw_handle.single() {
+        let handle = unsafe { rh.get_handle() };
+        dialog = dialog.set_parent(&handle);
+    }
+    let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
+    commands.insert_resource(AssetBrowserFolderTask(task));
+    OperatorResult::Finished
 }

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -1468,8 +1468,7 @@ fn has_array_preview(preview: Res<AssetPreviewState>) -> bool {
     description = "Step the asset preview's `current_layer` by `direction`, wrapping at `selected_info.layer_count`. \
                    Availability (`has_array_preview`) requires the asset preview to hold an array texture.\n\
                    Params: `direction: i64` (signed step, defaults to +1).",
-    is_available = has_array_preview,
-    allows_undo = false
+    is_available = has_array_preview
 )]
 pub(crate) fn asset_cycle_array_layer(
     params: In<OperatorParameters>,
@@ -1497,8 +1496,7 @@ pub(crate) fn asset_cycle_array_layer(
 #[operator(
     id = "asset.select_folder",
     label = "Select Assets Folder",
-    description = "Open an OS folder picker and store the result in `AssetBrowserFolderTask` for the polling system to consume.",
-    allows_undo = false
+    description = "Open an OS folder picker and store the result in `AssetBrowserFolderTask` for the polling system to consume."
 )]
 pub(crate) fn asset_select_folder(
     _: In<OperatorParameters>,
@@ -1507,6 +1505,9 @@ pub(crate) fn asset_select_folder(
 ) -> OperatorResult {
     let mut dialog = AsyncFileDialog::new().set_title("Select assets directory");
     if let Ok(rh) = raw_handle.single() {
+        // SAFETY: the primary window is open, so its `RawHandleWrapper`
+        // points to a live OS handle. We use the returned wrapper only
+        // to parent the modal dialog within this scope.
         let handle = unsafe { rh.get_handle() };
         dialog = dialog.set_parent(&handle);
     }

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -97,6 +97,12 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::brush_drag_ops::add_to_extension(ctx);
         crate::gizmos::add_to_extension(ctx);
         crate::terrain::sculpt::add_to_extension(ctx);
+        crate::navmesh::ops::add_to_extension(ctx);
+        crate::pie::add_to_extension(ctx);
+        crate::terrain::ops::add_to_extension(ctx);
+        crate::asset_browser::add_to_extension(ctx);
+        crate::material_browser::add_to_extension(ctx);
+        crate::inspector::ops::add_to_extension(ctx);
     }
 
     fn register_input_context(&self, app: &mut App) {

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -2,7 +2,24 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ExtensionAppExt as _;
-use jackdaw_feathers::button::{ButtonClickEvent, ButtonOperatorCall};
+use jackdaw_feathers::button::{ButtonClickEvent, ButtonOperatorCall, ButtonProps};
+
+/// Build a [`ButtonProps`] from an operator type, filling in the
+/// label and the click dispatch in one step.
+///
+/// `ButtonProps::from_operator::<MyOp>()` is the preferred form for
+/// editor toolbars and menus when the button text matches the
+/// operator's `LABEL`. For anything custom (icon-only buttons, a
+/// non-`LABEL` caption), keep using `ButtonProps::new(...).call_operator(id)`.
+pub trait ButtonPropsOpExt {
+    fn from_operator<Op: Operator>() -> Self;
+}
+
+impl ButtonPropsOpExt for ButtonProps {
+    fn from_operator<Op: Operator>() -> Self {
+        Self::new(Op::LABEL).call_operator(Op::ID)
+    }
+}
 
 /// Catalog name of the Core extension. Exported so
 /// [`crate::extension_resolution::REQUIRED_EXTENSIONS`] and the

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -6,7 +6,6 @@ use bevy::{
 };
 use bevy_monitors::prelude::{Mutation, NotifyChanged};
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 use jackdaw_feathers::{
     context_menu::spawn_context_menu,
     icons::IconFont,
@@ -66,7 +65,6 @@ impl Plugin for HierarchyPlugin {
         app.init_resource::<ContextMenuState>()
             .init_resource::<PendingTemplateDefaultName>()
             .init_resource::<HierarchyShowAll>()
-            .init_resource::<PendingRenameTarget>()
             .add_systems(Startup, setup_tree_node_expanded_watcher)
             .add_systems(OnEnter(crate::AppState::Editor), setup_name_watcher)
             .add_systems(
@@ -938,10 +936,10 @@ fn on_context_menu_action(
         }
         "hierarchy.rename" => {
             if let Some(target) = target_entity {
-                commands.trigger(TreeRowStartRename {
-                    entity: Entity::PLACEHOLDER,
-                    source_entity: target,
-                });
+                commands
+                    .operator(RenameBeginOp::ID)
+                    .param("entity", target.to_bits() as i64)
+                    .call();
             }
         }
         "hierarchy.duplicate" => {
@@ -1091,29 +1089,18 @@ struct InlineRenameInput {
     source_entity: Entity,
 }
 
-/// Entity to rename on the next `hierarchy.rename_begin` invoke.
-#[derive(Resource, Default)]
-struct PendingRenameTarget(Option<Entity>);
+fn on_tree_row_start_rename(event: On<TreeRowStartRename>, mut commands: Commands) {
+    let target = event.source_entity;
+    commands
+        .operator(RenameBeginOp::ID)
+        .param("entity", target.to_bits() as i64)
+        .call();
+}
 
-fn on_tree_row_start_rename(
-    event: On<TreeRowStartRename>,
-    mut commands: Commands,
-    mut pending: ResMut<PendingRenameTarget>,
-    rename_check: Query<(), With<InlineRenameInput>>,
-) {
-    if !rename_check.is_empty() {
-        return;
-    }
-    pending.0 = Some(event.source_entity);
-    commands.queue(|world: &mut World| {
-        let _ = world
-            .operator(RenameBeginOp::ID)
-            .settings(CallOperatorSettings {
-                execution_context: ExecutionContext::Invoke,
-                creates_history_entry: false,
-            })
-            .call();
-    });
+/// `is_available` for `hierarchy.rename_begin`: only fires when no
+/// inline rename is already in progress.
+fn no_rename_in_progress(rename_check: Query<(), With<InlineRenameInput>>) -> bool {
+    rename_check.is_empty()
 }
 
 fn entity_name(names: &Query<&Name>, entity: Entity) -> String {
@@ -1145,40 +1132,51 @@ fn find_rename_targets(
     None
 }
 
-fn restore_label(commands: &mut Commands, label_entity: Entity, text: String) {
-    commands
-        .entity(label_entity)
-        .remove::<TreeRowInlineRename>();
-    if let Ok(mut ec) = commands.get_entity(label_entity) {
-        ec.insert(Text::new(text));
-        ec.entry::<Node>().and_modify(|mut node| {
+/// Custom command: drop the inline-rename marker from a tree-row label
+/// and restore its displayed text + visibility. Issued from rename
+/// commit/cancel paths so the queue boundary is explicit.
+struct RestoreLabel {
+    label_entity: Entity,
+    text: String,
+}
+
+impl Command for RestoreLabel {
+    fn apply(self, world: &mut World) {
+        let Ok(mut ec) = world.get_entity_mut(self.label_entity) else {
+            return;
+        };
+        ec.remove::<TreeRowInlineRename>();
+        ec.insert(Text::new(self.text));
+        if let Some(mut node) = ec.get_mut::<Node>() {
             node.display = Display::Flex;
-        });
+        }
     }
 }
 
+/// Begin inline rename of an entity in the hierarchy tree.
+///
+/// # Parameters
+/// - `entity`: the scene entity to rename, encoded via [`Entity::to_bits()`].
 #[operator(
     id = "hierarchy.rename_begin",
     label = "Rename Entity",
-    description = "Begin inline rename of the entity in `PendingRenameTarget`. \
-                   Modal: commits on Enter, cancels on Escape.",
+    description = "Rename the selected entity in the hierarchy.",
     modal = true,
-    allows_undo = false,
     cancel = cancel_rename_begin,
+    is_available = no_rename_in_progress,
 )]
 pub(crate) fn rename_begin(
-    _: In<OperatorParameters>,
+    params: In<OperatorParameters>,
     mut commands: Commands,
-    mut pending: ResMut<PendingRenameTarget>,
     tree_index: Res<TreeIndex>,
     tree_nodes: Query<&Children, With<TreeNode>>,
     content_query: Query<(Entity, &Children), With<TreeRowContent>>,
     label_query: Query<Entity, With<TreeRowLabel>>,
     names: Query<&Name>,
     rename_inputs: Query<(), With<InlineRenameInput>>,
-    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+    active: ActiveModalQuery,
 ) -> OperatorResult {
-    if modal.is_some() {
+    if active.is_modal_running() {
         return if rename_inputs.is_empty() {
             OperatorResult::Finished
         } else {
@@ -1186,7 +1184,7 @@ pub(crate) fn rename_begin(
         };
     }
 
-    let Some(source) = pending.0.take() else {
+    let Some(source) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
     let Some((label_entity, content_entity)) = find_rename_targets(
@@ -1231,7 +1229,10 @@ fn cancel_rename_begin(
     for (rename_entity, inline_rename) in &rename_query {
         input_focus.clear();
         let original = entity_name(&names, inline_rename.source_entity);
-        restore_label(&mut commands, inline_rename.label_entity, original);
+        commands.queue(RestoreLabel {
+            label_entity: inline_rename.label_entity,
+            text: original,
+        });
         commands.entity(rename_entity).despawn();
     }
 }
@@ -1299,7 +1300,10 @@ fn handle_inline_rename_commit(
     };
 
     input_focus.clear();
-    restore_label(&mut commands, label_entity, event.text.clone());
+    commands.queue(RestoreLabel {
+        label_entity,
+        text: event.text.clone(),
+    });
     commands.entity(rename_entity).despawn();
 
     // Trigger the rename

--- a/src/inspector/anim_diamond.rs
+++ b/src/inspector/anim_diamond.rs
@@ -127,14 +127,12 @@ pub fn on_diamond_click(
 }
 
 /// Spawn (or replace) a keyframe at the current cursor time on the
-/// given entity's clip/track for the named property. Shared between
-/// the diamond click observer and the `animation.toggle_keyframe`
-/// operator.
+/// given entity's clip/track for the named property. Shared exclusive
+/// system; call via `world.run_system_cached_with(toggle_keyframe,
+/// (entity, type_path, field_path))`.
 pub(crate) fn toggle_keyframe(
+    In((source_entity, component_type_path, field_path)): In<(Entity, String, String)>,
     world: &mut World,
-    source_entity: Entity,
-    component_type_path: &str,
-    field_path: &str,
 ) {
     let cursor_time = world
         .get_resource::<TimelineCursor>()
@@ -150,13 +148,13 @@ pub(crate) fn toggle_keyframe(
         return;
     };
 
-    let track_entity = find_or_create_track(world, clip_entity, component_type_path, field_path);
+    let track_entity = find_or_create_track(world, clip_entity, &component_type_path, &field_path);
     spawn_typed_keyframe(
         world,
         source_entity,
         track_entity,
-        component_type_path,
-        field_path,
+        &component_type_path,
+        &field_path,
         cursor_time,
     );
 

--- a/src/inspector/anim_diamond.rs
+++ b/src/inspector/anim_diamond.rs
@@ -149,14 +149,18 @@ pub(crate) fn toggle_keyframe(
     };
 
     let track_entity = find_or_create_track(world, clip_entity, &component_type_path, &field_path);
-    spawn_typed_keyframe(
-        world,
-        source_entity,
-        track_entity,
-        &component_type_path,
-        &field_path,
-        cursor_time,
-    );
+    world
+        .run_system_cached_with(
+            spawn_typed_keyframe,
+            (
+                source_entity,
+                track_entity,
+                component_type_path.clone(),
+                field_path.clone(),
+                cursor_time,
+            ),
+        )
+        .ok();
 
     if let Some(mut clip) = world.get_mut::<Clip>(clip_entity)
         && cursor_time > clip.duration
@@ -241,20 +245,23 @@ fn find_or_create_track(
 /// new animatable property means a new arm here plus a new arm
 /// there. Keep them in sync.
 fn spawn_typed_keyframe(
-    world: &mut World,
-    source_entity: Entity,
-    track_entity: Entity,
-    component_type_path: &str,
-    field_path: &str,
-    time: f32,
+    In((source_entity, track_entity, component_type_path, field_path, time)): In<(
+        Entity,
+        Entity,
+        String,
+        String,
+        f32,
+    )>,
+    transforms: Query<&Transform>,
+    mut commands: Commands,
 ) {
-    match (component_type_path, field_path) {
+    match (component_type_path.as_str(), field_path.as_str()) {
         (TRANSFORM, "translation") => {
-            let Some(transform) = world.get::<Transform>(source_entity).copied() else {
+            let Ok(&transform) = transforms.get(source_entity) else {
                 warn!("Diamond click: source has no Transform");
                 return;
             };
-            world.spawn((
+            commands.spawn((
                 Vec3Keyframe {
                     time,
                     value: transform.translation,
@@ -263,11 +270,11 @@ fn spawn_typed_keyframe(
             ));
         }
         (TRANSFORM, "rotation") => {
-            let Some(transform) = world.get::<Transform>(source_entity).copied() else {
+            let Ok(&transform) = transforms.get(source_entity) else {
                 warn!("Diamond click: source has no Transform");
                 return;
             };
-            world.spawn((
+            commands.spawn((
                 QuatKeyframe {
                     time,
                     value: transform.rotation,
@@ -276,11 +283,11 @@ fn spawn_typed_keyframe(
             ));
         }
         (TRANSFORM, "scale") => {
-            let Some(transform) = world.get::<Transform>(source_entity).copied() else {
+            let Ok(&transform) = transforms.get(source_entity) else {
                 warn!("Diamond click: source has no Transform");
                 return;
             };
-            world.spawn((
+            commands.spawn((
                 Vec3Keyframe {
                     time,
                     value: transform.scale,

--- a/src/inspector/anim_diamond.rs
+++ b/src/inspector/anim_diamond.rs
@@ -15,6 +15,7 @@ use jackdaw_feathers::button::{ButtonClickEvent, ButtonProps, ButtonSize, Button
 use jackdaw_feathers::icons::Icon;
 
 use super::InspectorFieldRow;
+use crate::prelude::*;
 
 /// Epsilon for "is the cursor on this keyframe?" (~1 frame at 60fps).
 const CURSOR_ON_KEYFRAME_EPS: f32 = 0.02;
@@ -104,9 +105,8 @@ pub fn decorate_animatable_fields(
     }
 }
 
-/// Observer: when a diamond button is clicked, ensure a clip + track
-/// exist for the bound property and spawn a keyframe at the current
-/// cursor time.
+/// Observer: when a diamond button is clicked, dispatch
+/// `animation.toggle_keyframe` with the bound property's params.
 pub fn on_diamond_click(
     event: On<ButtonClickEvent>,
     buttons: Query<&AnimDiamondButton>,
@@ -115,62 +115,63 @@ pub fn on_diamond_click(
     let Ok(button_ref) = buttons.get(event.entity) else {
         return;
     };
-    let source_entity = button_ref.source_entity;
-    let component_type_path = button_ref.component_type_path.clone();
-    let field_path = button_ref.field_path.clone();
+    commands
+        .operator(super::ops::AnimationToggleKeyframeOp::ID)
+        .param("entity", button_ref.source_entity.to_bits() as i64)
+        .param(
+            "component_type_path",
+            button_ref.component_type_path.clone(),
+        )
+        .param("field_path", button_ref.field_path.clone())
+        .call();
+}
 
-    commands.queue(move |world: &mut World| {
-        let cursor_time = world
-            .get_resource::<TimelineCursor>()
-            .map(|c| c.seek_time)
-            .unwrap_or(0.0);
+/// Spawn (or replace) a keyframe at the current cursor time on the
+/// given entity's clip/track for the named property. Shared between
+/// the diamond click observer and the `animation.toggle_keyframe`
+/// operator.
+pub(crate) fn toggle_keyframe(
+    world: &mut World,
+    source_entity: Entity,
+    component_type_path: &str,
+    field_path: &str,
+) {
+    let cursor_time = world
+        .get_resource::<TimelineCursor>()
+        .map(|c| c.seek_time)
+        .unwrap_or(0.0);
 
-        // Step 1: find or create a Clip as a child of the source
-        // entity. The clip's name reuses the source's Name if set.
-        let clip_entity = find_or_create_clip(world, source_entity);
-        let Some(clip_entity) = clip_entity else {
-            warn!(
-                "Diamond click: source entity {source_entity} has no Name - \
-                 give it one in the inspector first so the clip's target can \
-                 resolve"
-            );
-            return;
-        };
-
-        // Step 2: find or create a track for this property under the
-        // clip.
-        let track_entity =
-            find_or_create_track(world, clip_entity, &component_type_path, &field_path);
-
-        // Step 3: snapshot the current reflected field value and
-        // spawn the right typed keyframe component as a child of the
-        // track.
-        spawn_typed_keyframe(
-            world,
-            source_entity,
-            track_entity,
-            &component_type_path,
-            &field_path,
-            cursor_time,
+    let Some(clip_entity) = find_or_create_clip(world, source_entity) else {
+        warn!(
+            "toggle_keyframe: source entity {source_entity} has no Name - \
+             give it one in the inspector first so the clip's target can \
+             resolve"
         );
+        return;
+    };
 
-        // Step 4: grow the clip's authored duration if needed so the
-        // new keyframe is visible in the timeline view.
-        if let Some(mut clip) = world.get_mut::<Clip>(clip_entity)
-            && cursor_time > clip.duration
-        {
-            clip.duration = cursor_time;
-        }
+    let track_entity = find_or_create_track(world, clip_entity, component_type_path, field_path);
+    spawn_typed_keyframe(
+        world,
+        source_entity,
+        track_entity,
+        component_type_path,
+        field_path,
+        cursor_time,
+    );
 
-        // Step 5: make this the active clip and force a timeline
-        // rebuild so the new diamond/keyframe row appears.
-        if let Some(mut selected) = world.get_resource_mut::<SelectedClip>() {
-            selected.0 = Some(clip_entity);
-        }
-        if let Some(mut dirty) = world.get_resource_mut::<TimelineDirty>() {
-            dirty.0 = true;
-        }
-    });
+    if let Some(mut clip) = world.get_mut::<Clip>(clip_entity)
+        && cursor_time > clip.duration
+    {
+        clip.duration = cursor_time;
+    }
+
+    if let Some(mut selected) = world.get_resource_mut::<SelectedClip>() {
+        selected.0 = Some(clip_entity);
+    }
+    if let Some(mut dirty) = world.get_resource_mut::<TimelineDirty>() {
+        dirty.0 = true;
+    }
 }
 
 /// Return an existing `Clip` child of `source_entity`, or spawn one

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -299,13 +299,15 @@ pub(crate) fn build_inspector_displays(
 
         let (display_entity, body_entity) = spawn_component_display(
             commands,
-            name,
-            type_path,
-            source_entity,
-            Some(component_id),
-            &icon_font.0,
-            &editor_font.0,
-            is_overridden,
+            ComponentDisplaySpec {
+                name,
+                type_path,
+                entity: source_entity,
+                component: Some(component_id),
+                is_overridden,
+                icon_font: &icon_font.0,
+                editor_font: &editor_font.0,
+            },
         );
         commands
             .entity(display_entity)
@@ -522,16 +524,32 @@ pub(crate) fn on_inspector_dirty(
     );
 }
 
+/// Inputs to [`spawn_component_display`]. Bundled into a single
+/// struct so the call site is readable as a struct literal instead of
+/// a long positional argument list.
+pub(crate) struct ComponentDisplaySpec<'a> {
+    pub name: &'a str,
+    pub type_path: &'a str,
+    pub entity: Entity,
+    pub component: Option<ComponentId>,
+    pub is_overridden: bool,
+    pub icon_font: &'a Handle<Font>,
+    pub editor_font: &'a Handle<Font>,
+}
+
 pub(crate) fn spawn_component_display(
     commands: &mut Commands,
-    name: &str,
-    type_path: &str,
-    entity: Entity,
-    component: Option<ComponentId>,
-    icon_font: &Handle<Font>,
-    editor_font: &Handle<Font>,
-    is_overridden: bool,
+    spec: ComponentDisplaySpec<'_>,
 ) -> (Entity, Entity) {
+    let ComponentDisplaySpec {
+        name,
+        type_path,
+        entity,
+        component,
+        is_overridden,
+        icon_font,
+        editor_font,
+    } = spec;
     let font = icon_font.clone();
     let body_font = editor_font.clone();
 
@@ -789,10 +807,12 @@ pub(crate) fn filter_inspector_components(
 }
 
 /// Revert a single component on a prefab instance back to its baseline value.
+///
+/// Exclusive system; call via
+/// `world.run_system_cached_with(revert_component_to_baseline, (entity, component_id))`.
 pub(crate) fn revert_component_to_baseline(
+    In((entity, component_id)): In<(Entity, ComponentId)>,
     world: &mut World,
-    entity: Entity,
-    component_id: ComponentId,
 ) {
     use bevy::ecs::reflect::AppTypeRegistry;
     use bevy::reflect::serde::TypedReflectDeserializer;

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -1,6 +1,7 @@
 use crate::EditorEntity;
 use crate::custom_properties::CustomProperties;
 use crate::default_style;
+use crate::prelude::*;
 use crate::selection::{Selected, Selection};
 use std::any::TypeId;
 
@@ -147,9 +148,9 @@ pub(crate) fn build_inspector_displays(
     // Check for prefab baseline (override tracking)
     let baseline = entity_ref.get::<jackdaw_jsn::JsnPrefabBaseline>().cloned();
 
-    // (short_name, module_group, component_id)
+    // (short_name, module_group, component_id, full_type_path)
     let mut custom_groups = std::collections::HashSet::new();
-    let mut comp_list: Vec<(String, String, ComponentId)> = archetype
+    let mut comp_list: Vec<(String, String, ComponentId, String)> = archetype
         .iter_components()
         .filter_map(|component_id| {
             let info = components.get_info(component_id)?;
@@ -189,7 +190,7 @@ pub(crate) fn build_inspector_displays(
                 } else {
                     extract_module_group(table.module_path())
                 };
-                return Some((short, module_group, component_id));
+                return Some((short, module_group, component_id, full_path.to_string()));
             }
 
             // Fallback: use Components name
@@ -201,10 +202,12 @@ pub(crate) fn build_inspector_displays(
             {
                 return None;
             }
+            let full = name.to_string();
             Some((
                 name.shortname().to_string(),
                 "Other".to_string(),
                 component_id,
+                full,
             ))
         })
         .collect();
@@ -221,7 +224,7 @@ pub(crate) fn build_inspector_displays(
 
     // Spawn components with subtle group dividers
     let mut current_group = String::new();
-    for (name, module_group, component_id) in &comp_list {
+    for (name, module_group, component_id, type_path) in &comp_list {
         // Category group divider with icon
         if *module_group != current_group {
             current_group = module_group.clone();
@@ -297,6 +300,7 @@ pub(crate) fn build_inspector_displays(
         let (display_entity, body_entity) = spawn_component_display(
             commands,
             name,
+            type_path,
             source_entity,
             Some(component_id),
             &icon_font.0,
@@ -521,6 +525,7 @@ pub(crate) fn on_inspector_dirty(
 pub(crate) fn spawn_component_display(
     commands: &mut Commands,
     name: &str,
+    type_path: &str,
     entity: Entity,
     component: Option<ComponentId>,
     icon_font: &Handle<Font>,
@@ -655,10 +660,13 @@ pub(crate) fn spawn_component_display(
             commands.trigger(ToggleCollapsible { entity: section });
         });
 
-    if let Some(component) = component {
+    if component.is_some() {
+        let type_path_owned = type_path.to_string();
+        let entity_bits = entity.to_bits() as i64;
+
         // Revert button (only shown for overridden prefab components)
         if is_overridden {
-            let source_entity = entity;
+            let revert_type_path = type_path_owned.clone();
             commands.spawn((
                 Text::new(String::from(Icon::RotateCcw.unicode())),
                 TextFont {
@@ -669,9 +677,11 @@ pub(crate) fn spawn_component_display(
                 TextColor(default_style::INSPECTOR_OVERRIDE),
                 ChildOf(header),
                 bevy::ui_widgets::observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-                    commands.queue(move |world: &mut World| {
-                        revert_component_to_baseline(world, source_entity, component);
-                    });
+                    commands
+                        .operator(super::ops::ComponentRevertBaselineOp::ID)
+                        .param("entity", entity_bits)
+                        .param("type_path", revert_type_path.clone())
+                        .call();
                 }),
             ));
         }
@@ -688,9 +698,10 @@ pub(crate) fn spawn_component_display(
             ChildOf(header),
             bevy::ui_widgets::observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
                 commands
-                    .entity(entity)
-                    .remove_by_id(component)
-                    .insert(InspectorDirty);
+                    .operator(super::ops::ComponentRemoveOp::ID)
+                    .param("entity", entity_bits)
+                    .param("type_path", type_path_owned.clone())
+                    .call();
             }),
         ));
     }
@@ -778,7 +789,11 @@ pub(crate) fn filter_inspector_components(
 }
 
 /// Revert a single component on a prefab instance back to its baseline value.
-fn revert_component_to_baseline(world: &mut World, entity: Entity, component_id: ComponentId) {
+pub(crate) fn revert_component_to_baseline(
+    world: &mut World,
+    entity: Entity,
+    component_id: ComponentId,
+) {
     use bevy::ecs::reflect::AppTypeRegistry;
     use bevy::reflect::serde::TypedReflectDeserializer;
     use serde::de::DeserializeSeed;

--- a/src/inspector/component_picker.rs
+++ b/src/inspector/component_picker.rs
@@ -1,14 +1,13 @@
 use crate::EditorEntity;
+use crate::prelude::*;
 use crate::selection::{Selected, Selection};
 use std::any::TypeId;
 use std::collections::{BTreeMap, HashSet};
 
-use super::InspectorDirty;
-
 use bevy::{
     ecs::{
         archetype::Archetype,
-        component::{ComponentId, Components},
+        component::Components,
         reflect::{AppTypeRegistry, ReflectComponent},
     },
     feathers::theme::ThemedText,
@@ -36,8 +35,6 @@ struct ComponentInfo {
     module_path: String,
     category: String,
     description: String,
-    type_id: TypeId,
-    component_id: ComponentId,
     type_path_full: String,
 }
 
@@ -107,10 +104,10 @@ pub(crate) fn on_add_component_button_click(
             continue;
         }
 
-        // Get component ID
-        let Some(component_id) = components.get_id(type_id) else {
+        // Skip if no component ID is registered for this type
+        if components.get_id(type_id).is_none() {
             continue;
-        };
+        }
 
         let short_name = table.short_path().to_string();
         let module = table.module_path().unwrap_or("").to_string();
@@ -136,8 +133,6 @@ pub(crate) fn on_add_component_button_click(
             module_path: module,
             category,
             description,
-            type_id,
-            component_id,
             type_path_full: full_path.to_string(),
         });
     }
@@ -301,8 +296,6 @@ pub(crate) fn on_add_component_button_click(
 
         // Component entries
         for info in entries {
-            let type_id = info.type_id;
-            let component_id = info.component_id;
             let short_name = info.short_name.clone();
             let category = info.category.clone();
             let description = info.description.clone();
@@ -337,41 +330,19 @@ pub(crate) fn on_add_component_button_click(
                     ChildOf(list),
                     observe({
                         let type_path_full = type_path_full.clone();
-                        move |mut click: On<Pointer<Click>>, mut commands: Commands| {
+                        move |mut click: On<Pointer<Click>>,
+                              mut commands: Commands,
+                              mut pickers: Query<Entity, With<ComponentPicker>>| {
                             click.propagate(false); // Don't let click through to backdrop
-                            let tp = type_path_full.clone();
-                            let cmd = crate::commands::AddComponent::new(
-                                source_entity,
-                                type_id,
-                                component_id,
-                                tp,
-                            );
-                            let cmd = Box::new(cmd);
-                            fn remove_pickers(
-                                In((source_entity, mut cmd)): In<(
-                                    Entity,
-                                    Box<dyn crate::commands::EditorCommand>,
-                                )>,
-                                world: &mut World,
-                                pickers: &mut QueryState<Entity, With<ComponentPicker>>,
-                            ) {
-                                cmd.execute(world);
-                                let mut history =
-                                    world.resource_mut::<crate::commands::CommandHistory>();
-                                history.push_executed(cmd);
-
-                                // Signal the inspector to rebuild
-                                world.entity_mut(source_entity).insert(InspectorDirty);
-
-                                // Close the picker dialog
-                                let pickers: Vec<Entity> = pickers.iter(world).collect();
-                                for picker in pickers {
-                                    if let Ok(ec) = world.get_entity_mut(picker) {
-                                        ec.despawn();
-                                    }
-                                }
+                            commands
+                                .operator(crate::inspector::ops::ComponentAddOp::ID)
+                                .param("entity", source_entity.to_bits() as i64)
+                                .param("type_path", type_path_full.clone())
+                                .call();
+                            // Close the picker dialog
+                            for picker in &mut pickers {
+                                commands.entity(picker).despawn();
                             }
-                            commands.run_system_cached_with(remove_pickers, (source_entity, cmd));
                         }
                     }),
                     observe(

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -1,9 +1,10 @@
-mod anim_diamond;
+pub(crate) mod anim_diamond;
 mod brush_display;
 pub(crate) mod component_display;
 mod component_picker;
 mod custom_props_display;
 mod material_display;
+pub(crate) mod ops;
 pub(crate) mod physics_display;
 pub(crate) mod reflect_fields;
 

--- a/src/inspector/ops.rs
+++ b/src/inspector/ops.rs
@@ -1,16 +1,11 @@
 //! Inspector operators: per-component buttons (add / remove / revert)
 //! and the small set of typed actions (`physics.enable` / `physics.disable`,
 //! `animation.toggle_keyframe`).
-//!
-//! All ops route entity references through `i64` (`Entity::to_bits()`) and
-//! type / field paths through `String`, since `PropertyValue` doesn't carry
-//! `Entity` or `ComponentId` directly.
 
 use bevy::ecs::component::ComponentId;
 use bevy::ecs::reflect::AppTypeRegistry;
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_jsn::PropertyValue;
 
 use super::component_display::revert_component_to_baseline;
 use super::physics_display::{DisablePhysics, enable_physics};
@@ -25,21 +20,6 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<AnimationToggleKeyframeOp>();
 }
 
-fn entity_param(params: &OperatorParameters) -> Option<Entity> {
-    let bits = match params.get("entity")? {
-        PropertyValue::Int(i) => *i as u64,
-        _ => return None,
-    };
-    Some(Entity::from_bits(bits))
-}
-
-fn string_param<'a>(params: &'a OperatorParameters, key: &str) -> Option<&'a str> {
-    match params.get(key)? {
-        PropertyValue::String(s) => Some(s.as_str()),
-        _ => None,
-    }
-}
-
 /// Look up the component id and type id for a fully-qualified type path.
 fn component_id_for_path(
     world: &World,
@@ -52,23 +32,30 @@ fn component_id_for_path(
     Some((component_id, type_id))
 }
 
+/// Add a component to the target entity.
+///
+/// # Parameters
+/// - `entity`: the entity that will receive the component, encoded as
+///   `i64` via [`Entity::to_bits()`] (use [`OperatorParameters::as_entity`]
+///   to read it back).
+/// - `type_path`: the fully-qualified Bevy reflected type path of the
+///   component to add (e.g. `"bevy_transform::components::transform::Transform"`).
+///
+/// Pushes a single undoable history entry that recreates the component
+/// on undo.
 #[operator(
     id = "component.add",
     label = "Add Component",
-    description = "Add a component to the entity. Pushes an `AddComponent` history entry \
-                   and marks the inspector dirty.\n\
-                   Params: `entity: i64` (entity bits), `type_path: String` (fully-qualified \
-                   reflected type path).",
-    allows_undo = false
+    description = "Add a component to the selected entity."
 )]
 pub(crate) fn component_add(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = entity_param(&params) else {
+    let Some(entity) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
-    let Some(type_path) = string_param(&params, "type_path").map(str::to_string) else {
+    let Some(type_path) = params.as_str("type_path").map(str::to_string) else {
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
@@ -86,22 +73,25 @@ pub(crate) fn component_add(
     OperatorResult::Finished
 }
 
+/// Remove a component from the target entity.
+///
+/// # Parameters
+/// - `entity`: the entity to remove the component from.
+/// - `type_path`: the fully-qualified Bevy reflected type path of the
+///   component to remove.
 #[operator(
     id = "component.remove",
     label = "Remove Component",
-    description = "Remove a component from the entity. Marks the inspector dirty so the \
-                   display rebuilds.\n\
-                   Params: `entity: i64`, `type_path: String`.",
-    allows_undo = false
+    description = "Remove a component from the selected entity."
 )]
 pub(crate) fn component_remove(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = entity_param(&params) else {
+    let Some(entity) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
-    let Some(type_path) = string_param(&params, "type_path").map(str::to_string) else {
+    let Some(type_path) = params.as_str("type_path").map(str::to_string) else {
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
@@ -116,22 +106,26 @@ pub(crate) fn component_remove(
     OperatorResult::Finished
 }
 
+/// Restore an overridden component on a prefab instance to the prefab's
+/// baseline value.
+///
+/// # Parameters
+/// - `entity`: the prefab instance entity.
+/// - `type_path`: the fully-qualified Bevy reflected type path of the
+///   component to revert.
 #[operator(
     id = "component.revert_baseline",
     label = "Revert To Prefab",
-    description = "Restore the component's prefab baseline value on the entity. The \
-                   component must be marked as overridden in the AST.\n\
-                   Params: `entity: i64`, `type_path: String`.",
-    allows_undo = false
+    description = "Restore the component to the value it had in the source prefab."
 )]
 pub(crate) fn component_revert_baseline(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = entity_param(&params) else {
+    let Some(entity) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
-    let Some(type_path) = string_param(&params, "type_path").map(str::to_string) else {
+    let Some(type_path) = params.as_str("type_path").map(str::to_string) else {
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
@@ -143,19 +137,22 @@ pub(crate) fn component_revert_baseline(
     OperatorResult::Finished
 }
 
+/// Add `RigidBody` and `AvianCollider` to the entity so it participates
+/// in the physics simulation. No-op if those components are already
+/// present.
+///
+/// # Parameters
+/// - `entity`: the entity to make physical.
 #[operator(
     id = "physics.enable",
     label = "Enable Physics",
-    description = "Add `RigidBody` and `AvianCollider` to the entity (idempotent if already \
-                   present).\n\
-                   Params: `entity: i64`.",
-    allows_undo = false
+    description = "Make the selected entity participate in the physics simulation."
 )]
 pub(crate) fn physics_enable(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = entity_param(&params) else {
+    let Some(entity) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
@@ -167,19 +164,21 @@ pub(crate) fn physics_enable(
     OperatorResult::Finished
 }
 
+/// Remove physics components from the entity, capturing the pre-disable
+/// state so undo restores them.
+///
+/// # Parameters
+/// - `entity`: the entity to make non-physical.
 #[operator(
     id = "physics.disable",
     label = "Disable Physics",
-    description = "Remove physics components from the entity, capturing the pre-disable \
-                   state as a `DisablePhysics` history entry so undo restores them.\n\
-                   Params: `entity: i64`.",
-    allows_undo = false
+    description = "Stop the selected entity from participating in the physics simulation."
 )]
 pub(crate) fn physics_disable(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = entity_param(&params) else {
+    let Some(entity) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
@@ -193,29 +192,42 @@ pub(crate) fn physics_disable(
     OperatorResult::Finished
 }
 
+/// Spawn (or replace) a keyframe at the current timeline cursor for one
+/// of the entity's animatable properties. Creates the clip and track
+/// lazily if they don't exist yet.
+///
+/// # Parameters
+/// - `entity`: the source entity whose property is being animated.
+/// - `component_type_path`: the fully-qualified Bevy reflected type
+///   path of the component that owns the property
+///   (e.g. `"bevy_transform::components::transform::Transform"`).
+/// - `field_path`: the dotted path to the field within that component
+///   (e.g. `"translation"` or `"rotation"`).
 #[operator(
     id = "animation.toggle_keyframe",
     label = "Toggle Keyframe",
-    description = "Spawn (or replace) a keyframe at the current timeline cursor. Creates \
-                   the clip and track lazily if missing.\n\
-                   Params: `entity: i64`, `component_type_path: String`, `field_path: String`.",
-    allows_undo = false
+    description = "Add or replace a keyframe for this property at the current timeline cursor."
 )]
 pub(crate) fn animation_toggle_keyframe(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = entity_param(&params) else {
+    let Some(entity) = params.as_entity("entity") else {
         return OperatorResult::Cancelled;
     };
-    let Some(type_path) = string_param(&params, "component_type_path").map(str::to_string) else {
+    let Some(type_path) = params.as_str("component_type_path").map(str::to_string) else {
         return OperatorResult::Cancelled;
     };
-    let Some(field_path) = string_param(&params, "field_path").map(str::to_string) else {
+    let Some(field_path) = params.as_str("field_path").map(str::to_string) else {
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
-        super::anim_diamond::toggle_keyframe(world, entity, &type_path, &field_path);
+        world
+            .run_system_cached_with(
+                super::anim_diamond::toggle_keyframe,
+                (entity, type_path, field_path),
+            )
+            .ok();
     });
     OperatorResult::Finished
 }

--- a/src/inspector/ops.rs
+++ b/src/inspector/ops.rs
@@ -55,9 +55,10 @@ fn component_id_for_path(
 #[operator(
     id = "component.add",
     label = "Add Component",
-    description = "Add a component (looked up by `type_path`) to the entity in `entity` \
-                   (entity bits). Pushes an `AddComponent` history entry and marks the \
-                   inspector dirty.",
+    description = "Add a component to the entity. Pushes an `AddComponent` history entry \
+                   and marks the inspector dirty.\n\
+                   Params: `entity: i64` (entity bits), `type_path: String` (fully-qualified \
+                   reflected type path).",
     allows_undo = false
 )]
 pub(crate) fn component_add(
@@ -88,8 +89,9 @@ pub(crate) fn component_add(
 #[operator(
     id = "component.remove",
     label = "Remove Component",
-    description = "Remove a component (looked up by `type_path`) from the entity in \
-                   `entity`. Marks the inspector dirty so the display rebuilds.",
+    description = "Remove a component from the entity. Marks the inspector dirty so the \
+                   display rebuilds.\n\
+                   Params: `entity: i64`, `type_path: String`.",
     allows_undo = false
 )]
 pub(crate) fn component_remove(
@@ -117,8 +119,9 @@ pub(crate) fn component_remove(
 #[operator(
     id = "component.revert_baseline",
     label = "Revert To Prefab",
-    description = "Restore the component's prefab baseline value on the entity in \
-                   `entity`. The component must be marked as overridden in the AST.",
+    description = "Restore the component's prefab baseline value on the entity. The \
+                   component must be marked as overridden in the AST.\n\
+                   Params: `entity: i64`, `type_path: String`.",
     allows_undo = false
 )]
 pub(crate) fn component_revert_baseline(
@@ -143,7 +146,9 @@ pub(crate) fn component_revert_baseline(
 #[operator(
     id = "physics.enable",
     label = "Enable Physics",
-    description = "Add `RigidBody` and `AvianCollider` to the entity (no-op if already present).",
+    description = "Add `RigidBody` and `AvianCollider` to the entity (idempotent if already \
+                   present).\n\
+                   Params: `entity: i64`.",
     allows_undo = false
 )]
 pub(crate) fn physics_enable(
@@ -166,7 +171,8 @@ pub(crate) fn physics_enable(
     id = "physics.disable",
     label = "Disable Physics",
     description = "Remove physics components from the entity, capturing the pre-disable \
-                   state as a `DisablePhysics` history entry so undo restores them.",
+                   state as a `DisablePhysics` history entry so undo restores them.\n\
+                   Params: `entity: i64`.",
     allows_undo = false
 )]
 pub(crate) fn physics_disable(
@@ -190,9 +196,9 @@ pub(crate) fn physics_disable(
 #[operator(
     id = "animation.toggle_keyframe",
     label = "Toggle Keyframe",
-    description = "Spawn (or replace) a keyframe at the current timeline cursor for the \
-                   `(entity, component_type_path, field_path)` triple. Creates the clip \
-                   and track lazily if missing.",
+    description = "Spawn (or replace) a keyframe at the current timeline cursor. Creates \
+                   the clip and track lazily if missing.\n\
+                   Params: `entity: i64`, `component_type_path: String`, `field_path: String`.",
     allows_undo = false
 )]
 pub(crate) fn animation_toggle_keyframe(

--- a/src/inspector/ops.rs
+++ b/src/inspector/ops.rs
@@ -2,7 +2,7 @@
 //! and the small set of typed actions (`physics.enable` / `physics.disable`,
 //! `animation.toggle_keyframe`).
 
-use bevy::ecs::component::ComponentId;
+use bevy::ecs::component::{ComponentId, Components};
 use bevy::ecs::reflect::AppTypeRegistry;
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
@@ -10,6 +10,7 @@ use jackdaw_api::prelude::*;
 use super::component_display::revert_component_to_baseline;
 use super::physics_display::{DisablePhysics, enable_physics};
 use crate::commands::{AddComponent, CommandHistory, EditorCommand};
+use crate::selection::Selection;
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<ComponentAddOp>()
@@ -20,15 +21,23 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<AnimationToggleKeyframeOp>();
 }
 
+/// Inspector operators all act on the inspected entity (the primary
+/// selection). Buttons that dispatch them get greyed out when nothing
+/// is selected.
+fn has_primary_selection(selection: Res<Selection>) -> bool {
+    selection.primary().is_some()
+}
+
 /// Look up the component id and type id for a fully-qualified type path.
 fn component_id_for_path(
-    world: &World,
+    type_registry: &AppTypeRegistry,
+    components: &Components,
     type_path: &str,
 ) -> Option<(ComponentId, std::any::TypeId)> {
-    let registry = world.resource::<AppTypeRegistry>().read();
+    let registry = type_registry.read();
     let registration = registry.get_with_type_path(type_path)?;
     let type_id = registration.type_id();
-    let component_id = world.components().get_id(type_id)?;
+    let component_id = components.get_id(type_id)?;
     Some((component_id, type_id))
 }
 
@@ -46,7 +55,8 @@ fn component_id_for_path(
 #[operator(
     id = "component.add",
     label = "Add Component",
-    description = "Add a component to the selected entity."
+    description = "Add a component to the selected entity.",
+    is_available = has_primary_selection
 )]
 pub(crate) fn component_add(
     params: In<OperatorParameters>,
@@ -59,7 +69,10 @@ pub(crate) fn component_add(
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
-        let Some((component_id, type_id)) = component_id_for_path(world, &type_path) else {
+        let registry = world.resource::<AppTypeRegistry>().clone();
+        let Some((component_id, type_id)) =
+            component_id_for_path(&registry, world.components(), &type_path)
+        else {
             return;
         };
         let mut cmd: Box<dyn EditorCommand> =
@@ -82,7 +95,8 @@ pub(crate) fn component_add(
 #[operator(
     id = "component.remove",
     label = "Remove Component",
-    description = "Remove a component from the selected entity."
+    description = "Remove a component from the selected entity.",
+    is_available = has_primary_selection
 )]
 pub(crate) fn component_remove(
     params: In<OperatorParameters>,
@@ -95,7 +109,10 @@ pub(crate) fn component_remove(
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
-        let Some((component_id, _)) = component_id_for_path(world, &type_path) else {
+        let registry = world.resource::<AppTypeRegistry>().clone();
+        let Some((component_id, _)) =
+            component_id_for_path(&registry, world.components(), &type_path)
+        else {
             return;
         };
         if let Ok(mut ec) = world.get_entity_mut(entity) {
@@ -116,7 +133,8 @@ pub(crate) fn component_remove(
 #[operator(
     id = "component.revert_baseline",
     label = "Revert To Prefab",
-    description = "Restore the component to the value it had in the source prefab."
+    description = "Restore the component to the value it had in the source prefab.",
+    is_available = has_primary_selection
 )]
 pub(crate) fn component_revert_baseline(
     params: In<OperatorParameters>,
@@ -129,7 +147,10 @@ pub(crate) fn component_revert_baseline(
         return OperatorResult::Cancelled;
     };
     commands.queue(move |world: &mut World| {
-        let Some((component_id, _)) = component_id_for_path(world, &type_path) else {
+        let registry = world.resource::<AppTypeRegistry>().clone();
+        let Some((component_id, _)) =
+            component_id_for_path(&registry, world.components(), &type_path)
+        else {
             return;
         };
         revert_component_to_baseline(world, entity, component_id);
@@ -146,7 +167,8 @@ pub(crate) fn component_revert_baseline(
 #[operator(
     id = "physics.enable",
     label = "Enable Physics",
-    description = "Make the selected entity participate in the physics simulation."
+    description = "Make the selected entity participate in the physics simulation.",
+    is_available = has_primary_selection
 )]
 pub(crate) fn physics_enable(
     params: In<OperatorParameters>,
@@ -172,7 +194,8 @@ pub(crate) fn physics_enable(
 #[operator(
     id = "physics.disable",
     label = "Disable Physics",
-    description = "Stop the selected entity from participating in the physics simulation."
+    description = "Stop the selected entity from participating in the physics simulation.",
+    is_available = has_primary_selection
 )]
 pub(crate) fn physics_disable(
     params: In<OperatorParameters>,
@@ -206,7 +229,8 @@ pub(crate) fn physics_disable(
 #[operator(
     id = "animation.toggle_keyframe",
     label = "Toggle Keyframe",
-    description = "Add or replace a keyframe for this property at the current timeline cursor."
+    description = "Add or replace a keyframe for this property at the current timeline cursor.",
+    is_available = has_primary_selection
 )]
 pub(crate) fn animation_toggle_keyframe(
     params: In<OperatorParameters>,

--- a/src/inspector/ops.rs
+++ b/src/inspector/ops.rs
@@ -153,7 +153,11 @@ pub(crate) fn component_revert_baseline(
         else {
             return;
         };
-        revert_component_to_baseline(world, entity, component_id);
+        if let Err(err) =
+            world.run_system_cached_with(revert_component_to_baseline, (entity, component_id))
+        {
+            error!("revert_component_to_baseline failed: {err}");
+        }
     });
     OperatorResult::Finished
 }

--- a/src/inspector/ops.rs
+++ b/src/inspector/ops.rs
@@ -1,0 +1,215 @@
+//! Inspector operators: per-component buttons (add / remove / revert)
+//! and the small set of typed actions (`physics.enable` / `physics.disable`,
+//! `animation.toggle_keyframe`).
+//!
+//! All ops route entity references through `i64` (`Entity::to_bits()`) and
+//! type / field paths through `String`, since `PropertyValue` doesn't carry
+//! `Entity` or `ComponentId` directly.
+
+use bevy::ecs::component::ComponentId;
+use bevy::ecs::reflect::AppTypeRegistry;
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_jsn::PropertyValue;
+
+use super::component_display::revert_component_to_baseline;
+use super::physics_display::{DisablePhysics, enable_physics};
+use crate::commands::{AddComponent, CommandHistory, EditorCommand};
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<ComponentAddOp>()
+        .register_operator::<ComponentRemoveOp>()
+        .register_operator::<ComponentRevertBaselineOp>()
+        .register_operator::<PhysicsEnableOp>()
+        .register_operator::<PhysicsDisableOp>()
+        .register_operator::<AnimationToggleKeyframeOp>();
+}
+
+fn entity_param(params: &OperatorParameters) -> Option<Entity> {
+    let bits = match params.get("entity")? {
+        PropertyValue::Int(i) => *i as u64,
+        _ => return None,
+    };
+    Some(Entity::from_bits(bits))
+}
+
+fn string_param<'a>(params: &'a OperatorParameters, key: &str) -> Option<&'a str> {
+    match params.get(key)? {
+        PropertyValue::String(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// Look up the component id and type id for a fully-qualified type path.
+fn component_id_for_path(
+    world: &World,
+    type_path: &str,
+) -> Option<(ComponentId, std::any::TypeId)> {
+    let registry = world.resource::<AppTypeRegistry>().read();
+    let registration = registry.get_with_type_path(type_path)?;
+    let type_id = registration.type_id();
+    let component_id = world.components().get_id(type_id)?;
+    Some((component_id, type_id))
+}
+
+#[operator(
+    id = "component.add",
+    label = "Add Component",
+    description = "Add a component (looked up by `type_path`) to the entity in `entity` \
+                   (entity bits). Pushes an `AddComponent` history entry and marks the \
+                   inspector dirty.",
+    allows_undo = false
+)]
+pub(crate) fn component_add(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(entity) = entity_param(&params) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(type_path) = string_param(&params, "type_path").map(str::to_string) else {
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        let Some((component_id, type_id)) = component_id_for_path(world, &type_path) else {
+            return;
+        };
+        let mut cmd: Box<dyn EditorCommand> =
+            Box::new(AddComponent::new(entity, type_id, component_id, type_path));
+        cmd.execute(world);
+        world.resource_mut::<CommandHistory>().push_executed(cmd);
+        if let Ok(mut ec) = world.get_entity_mut(entity) {
+            ec.insert(super::InspectorDirty);
+        }
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "component.remove",
+    label = "Remove Component",
+    description = "Remove a component (looked up by `type_path`) from the entity in \
+                   `entity`. Marks the inspector dirty so the display rebuilds.",
+    allows_undo = false
+)]
+pub(crate) fn component_remove(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(entity) = entity_param(&params) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(type_path) = string_param(&params, "type_path").map(str::to_string) else {
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        let Some((component_id, _)) = component_id_for_path(world, &type_path) else {
+            return;
+        };
+        if let Ok(mut ec) = world.get_entity_mut(entity) {
+            ec.remove_by_id(component_id);
+            ec.insert(super::InspectorDirty);
+        }
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "component.revert_baseline",
+    label = "Revert To Prefab",
+    description = "Restore the component's prefab baseline value on the entity in \
+                   `entity`. The component must be marked as overridden in the AST.",
+    allows_undo = false
+)]
+pub(crate) fn component_revert_baseline(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(entity) = entity_param(&params) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(type_path) = string_param(&params, "type_path").map(str::to_string) else {
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        let Some((component_id, _)) = component_id_for_path(world, &type_path) else {
+            return;
+        };
+        revert_component_to_baseline(world, entity, component_id);
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "physics.enable",
+    label = "Enable Physics",
+    description = "Add `RigidBody` and `AvianCollider` to the entity (no-op if already present).",
+    allows_undo = false
+)]
+pub(crate) fn physics_enable(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(entity) = entity_param(&params) else {
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        enable_physics(world, entity);
+        if let Ok(mut ec) = world.get_entity_mut(entity) {
+            ec.insert(super::InspectorDirty);
+        }
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "physics.disable",
+    label = "Disable Physics",
+    description = "Remove physics components from the entity, capturing the pre-disable \
+                   state as a `DisablePhysics` history entry so undo restores them.",
+    allows_undo = false
+)]
+pub(crate) fn physics_disable(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(entity) = entity_param(&params) else {
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        let mut cmd: Box<dyn EditorCommand> = Box::new(DisablePhysics::from_world(world, entity));
+        cmd.execute(world);
+        world.resource_mut::<CommandHistory>().push_executed(cmd);
+        if let Ok(mut ec) = world.get_entity_mut(entity) {
+            ec.insert(super::InspectorDirty);
+        }
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "animation.toggle_keyframe",
+    label = "Toggle Keyframe",
+    description = "Spawn (or replace) a keyframe at the current timeline cursor for the \
+                   `(entity, component_type_path, field_path)` triple. Creates the clip \
+                   and track lazily if missing.",
+    allows_undo = false
+)]
+pub(crate) fn animation_toggle_keyframe(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(entity) = entity_param(&params) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(type_path) = string_param(&params, "component_type_path").map(str::to_string) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(field_path) = string_param(&params, "field_path").map(str::to_string) else {
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        super::anim_diamond::toggle_keyframe(world, entity, &type_path, &field_path);
+    });
+    OperatorResult::Finished
+}

--- a/src/inspector/physics_display.rs
+++ b/src/inspector/physics_display.rs
@@ -16,6 +16,7 @@ use jackdaw_widgets::collapsible::{
 
 use crate::commands::{AddComponent, CommandGroup, CommandHistory, EditorCommand};
 use crate::inspector::FieldBinding;
+use crate::prelude::*;
 use crate::selection::Selection;
 
 /// Marker for the Physics section checkbox.
@@ -506,7 +507,8 @@ fn spawn_labeled_row(commands: &mut Commands, parent: Entity, label: &str, font:
     ));
 }
 
-/// Handle the Enable checkbox toggle.
+/// Handle the Enable checkbox toggle by dispatching the matching
+/// `physics.enable` / `physics.disable` operator.
 pub(super) fn on_physics_enable_toggle(
     event: On<CheckboxCommitEvent>,
     checkboxes: Query<&PhysicsEnableCheckbox>,
@@ -515,31 +517,19 @@ pub(super) fn on_physics_enable_toggle(
     let Ok(physics_cb) = checkboxes.get(event.entity) else {
         return;
     };
-    let source_entity = physics_cb.0;
-    let checked = event.checked;
-
-    commands.queue(move |world: &mut World| {
-        if checked {
-            enable_physics(world, source_entity);
-        } else {
-            // Wrap disable in an undoable command. Captures the full
-            // physics-related AST state as a snapshot and restores it on undo.
-            let cmd = DisablePhysics::from_world(world, source_entity);
-            let mut cmd: Box<dyn EditorCommand> = Box::new(cmd);
-            cmd.execute(world);
-            world.resource_mut::<CommandHistory>().push_executed(cmd);
-        }
-        // Rebuild inspector
-        if let Ok(mut ec) = world.get_entity_mut(source_entity) {
-            ec.insert(super::InspectorDirty);
-        }
-    });
+    let entity_bits = physics_cb.0.to_bits() as i64;
+    let op_id = if event.checked {
+        super::ops::PhysicsEnableOp::ID
+    } else {
+        super::ops::PhysicsDisableOp::ID
+    };
+    commands.operator(op_id).param("entity", entity_bits).call();
 }
 
 /// Command that disables physics on an entity. Captures the full pre-disable
 /// state (`RigidBody`, `AvianCollider`, and all derived avian components in the
 /// AST) so undo restores them.
-struct DisablePhysics {
+pub(crate) struct DisablePhysics {
     entity: Entity,
     /// Snapshot of AST components that were removed, keyed by `type_path`.
     removed_components: std::collections::HashMap<String, serde_json::Value>,
@@ -548,7 +538,7 @@ struct DisablePhysics {
 }
 
 impl DisablePhysics {
-    fn from_world(world: &World, entity: Entity) -> Self {
+    pub(crate) fn from_world(world: &World, entity: Entity) -> Self {
         let mut removed_components = std::collections::HashMap::new();
         let mut removed_derived = std::collections::HashSet::new();
         if let Some(node) = world
@@ -649,7 +639,7 @@ impl EditorCommand for DisablePhysics {
     }
 }
 
-fn enable_physics(world: &mut World, entity: Entity) {
+pub(crate) fn enable_physics(world: &mut World, entity: Entity) {
     let registry = world.resource::<AppTypeRegistry>().clone();
     let reg = registry.read();
     let components_res = world.components();

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -741,16 +741,19 @@ fn toolbar_edit_button(
             // modal; re-dispatching would fail with ModalAlreadyActive.
             if matches!(tool, EditToolButton::Physics) {
                 commands.queue(|world: &mut World| {
-                    if *world.resource::<EditMode>() == EditMode::Physics {
-                        let _ = world.operator("modal.cancel").call();
+                    let result = if *world.resource::<EditMode>() == EditMode::Physics {
+                        world.operator("modal.cancel").call()
                     } else {
-                        let _ = world
+                        world
                             .operator(PhysicsActivateOp::ID)
                             .settings(CallOperatorSettings {
                                 execution_context: ExecutionContext::Invoke,
                                 creates_history_entry: true,
                             })
-                            .call();
+                            .call()
+                    };
+                    if let Err(err) = result {
+                        error!("physics tool dispatch failed: {err}");
                     }
                 });
                 return;

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -1699,20 +1699,22 @@ fn pending_texture_slot_set(pending: Res<PendingTextureSlot>) -> bool {
     pending.slot.is_some() && pending.material_handle.is_some()
 }
 
+/// Create a fresh empty material and select it for preview.
 #[operator(
     id = "material.create",
     label = "New Material",
-    description = "Create a fresh `StandardMaterial`, register it with the browser, and select it for preview."
+    description = "Create a fresh empty material."
 )]
 pub(crate) fn material_create(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(CreateNewMaterial);
     OperatorResult::Finished
 }
 
+/// Refresh the material browser from disk.
 #[operator(
     id = "material.rescan",
     label = "Rescan Materials",
-    description = "Schedule a material directory rescan; the browser's polling system picks it up next frame."
+    description = "Refresh the material browser from disk."
 )]
 pub(crate) fn material_rescan(
     _: In<OperatorParameters>,
@@ -1722,10 +1724,11 @@ pub(crate) fn material_rescan(
     OperatorResult::Finished
 }
 
+/// Choose a different folder as the materials directory.
 #[operator(
     id = "material.select_folder",
     label = "Select Materials Folder",
-    description = "Open an OS folder picker for the materials root and store the result in `MaterialBrowserFolderTask` for the polling system."
+    description = "Choose a different folder as the materials directory."
 )]
 pub(crate) fn material_select_folder(
     _: In<OperatorParameters>,
@@ -1746,12 +1749,15 @@ pub(crate) fn material_select_folder(
     OperatorResult::Finished
 }
 
+/// Pick an image from disk for the targeted material's texture slot.
+///
+/// The slot and target material are routed through the
+/// [`PendingTextureSlot`] resource by the inspector button before
+/// dispatch.
 #[operator(
     id = "material.browse_texture_slot",
     label = "Browse Texture",
-    description = "Open a file picker for the texture slot recorded in `PendingTextureSlot` (set by the slot's \
-                   browse button before dispatch). Availability (`pending_texture_slot_set`) requires the slot \
-                   and material handle to be present.",
+    description = "Pick an image to assign to this material's texture slot.",
     is_available = pending_texture_slot_set
 )]
 pub(crate) fn material_browse_texture_slot(
@@ -1772,12 +1778,15 @@ pub(crate) fn material_browse_texture_slot(
     OperatorResult::Finished
 }
 
+/// Remove the image from the targeted material's texture slot.
+///
+/// The slot and target material are routed through the
+/// [`PendingTextureSlot`] resource by the inspector button before
+/// dispatch.
 #[operator(
     id = "material.clear_texture_slot",
     label = "Clear Texture",
-    description = "Clear the texture from the slot recorded in `PendingTextureSlot` (set by the slot's clear \
-                   button before dispatch). Availability (`pending_texture_slot_set`) requires the slot and \
-                   material handle to be present.",
+    description = "Remove the image from this material's texture slot.",
     is_available = pending_texture_slot_set
 )]
 pub(crate) fn material_clear_texture_slot(

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -23,6 +23,7 @@ use crate::{
     brush::{Brush, BrushEditMode, BrushSelection, EditMode, SetBrush},
     commands::CommandHistory,
     material_preview::MaterialPreviewState,
+    prelude::*,
     selection::Selection,
 };
 use jackdaw_commands::{CommandGroup, EditorCommand};
@@ -991,11 +992,12 @@ fn update_preview_area(
             ))
             .id();
         commands.entity(browse_btn).observe(
-            move |_: On<Pointer<Click>>, mut commands: Commands| {
-                commands.trigger(BrowseTextureSlot {
-                    slot,
-                    material_handle: browse_handle.clone(),
-                });
+            move |_: On<Pointer<Click>>,
+                  mut pending: ResMut<PendingTextureSlot>,
+                  mut commands: Commands| {
+                pending.slot = Some(slot);
+                pending.material_handle = Some(browse_handle.clone());
+                commands.operator(MaterialBrowseTextureSlotOp::ID).call();
             },
         );
 
@@ -1019,11 +1021,12 @@ fn update_preview_area(
                 ))
                 .id();
             commands.entity(clear_btn).observe(
-                move |_: On<Pointer<Click>>, mut commands: Commands| {
-                    commands.trigger(ClearTextureSlot {
-                        slot,
-                        material_handle: clear_handle.clone(),
-                    });
+                move |_: On<Pointer<Click>>,
+                      mut pending: ResMut<PendingTextureSlot>,
+                      mut commands: Commands| {
+                    pending.slot = Some(slot);
+                    pending.material_handle = Some(clear_handle.clone());
+                    commands.operator(MaterialClearTextureSlotOp::ID).call();
                 },
             );
         }
@@ -1196,20 +1199,6 @@ fn on_material_param_commit(
     {
         catalog.dirty = true;
     }
-}
-
-fn spawn_material_folder_dialog(
-    _: On<Pointer<Click>>,
-    mut commands: Commands,
-    raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
-) {
-    let mut dialog = AsyncFileDialog::new().set_title("Select materials directory");
-    if let Ok(rh) = raw_handle.single() {
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
-    let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
-    commands.insert_resource(MaterialBrowserFolderTask(task));
 }
 
 fn poll_material_browser_folder(world: &mut World) {
@@ -1641,7 +1630,7 @@ fn new_material_button(icon_font: Handle<Font>) -> impl Bundle {
             tokens::TEXT_SECONDARY,
         ),
         observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-            commands.trigger(CreateNewMaterial);
+            commands.operator(MaterialCreateOp::ID).call();
         }),
     )
 }
@@ -1659,7 +1648,9 @@ fn material_folder_button(icon_font: Handle<Font>) -> impl Bundle {
             icon_font,
             tokens::TEXT_SECONDARY,
         ),
-        observe(spawn_material_folder_dialog),
+        observe(|_: On<Pointer<Click>>, mut commands: Commands| {
+            commands.operator(MaterialSelectFolderOp::ID).call();
+        }),
     )
 }
 
@@ -1676,10 +1667,125 @@ fn rescan_button(icon_font: Handle<Font>) -> impl Bundle {
             icon_font,
             tokens::TEXT_SECONDARY,
         ),
-        observe(
-            |_: On<Pointer<Click>>, mut state: ResMut<MaterialBrowserState>| {
-                state.needs_rescan = true;
-            },
-        ),
+        observe(|_: On<Pointer<Click>>, mut commands: Commands| {
+            commands.operator(MaterialRescanOp::ID).call();
+        }),
     )
+}
+
+// ── Operators ──────────────────────────────────────────────────────────────
+
+/// Resource set by the texture-slot button click before dispatching
+/// `material.browse_texture_slot` / `material.clear_texture_slot`. The
+/// operator reads this and clears it. `Handle<StandardMaterial>` doesn't
+/// fit `PropertyValue`, so we route it through a sidecar resource the
+/// same way `hierarchy.rename_begin` uses `PendingRenameTarget`.
+#[derive(Resource, Default)]
+struct PendingTextureSlot {
+    slot: Option<TextureSlot>,
+    material_handle: Option<Handle<StandardMaterial>>,
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.init_resource::<PendingTextureSlot>()
+        .register_operator::<MaterialCreateOp>()
+        .register_operator::<MaterialRescanOp>()
+        .register_operator::<MaterialSelectFolderOp>()
+        .register_operator::<MaterialBrowseTextureSlotOp>()
+        .register_operator::<MaterialClearTextureSlotOp>();
+}
+
+#[operator(
+    id = "material.create",
+    label = "New Material",
+    description = "Create a fresh `StandardMaterial`, register it with the browser, and select it for preview.",
+    allows_undo = false
+)]
+pub(crate) fn material_create(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.trigger(CreateNewMaterial);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "material.rescan",
+    label = "Rescan Materials",
+    description = "Schedule a material directory rescan; the browser's polling system picks it up next frame.",
+    allows_undo = false
+)]
+pub(crate) fn material_rescan(
+    _: In<OperatorParameters>,
+    mut state: ResMut<MaterialBrowserState>,
+) -> OperatorResult {
+    state.needs_rescan = true;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "material.select_folder",
+    label = "Select Materials Folder",
+    description = "Open an OS folder picker for the materials root and store the result in `MaterialBrowserFolderTask` for the polling system.",
+    allows_undo = false
+)]
+pub(crate) fn material_select_folder(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+    raw_handle: Query<&bevy::window::RawHandleWrapper, With<bevy::window::PrimaryWindow>>,
+) -> OperatorResult {
+    let mut dialog = AsyncFileDialog::new().set_title("Select materials directory");
+    if let Ok(rh) = raw_handle.single() {
+        let handle = unsafe { rh.get_handle() };
+        dialog = dialog.set_parent(&handle);
+    }
+    let task =
+        bevy::tasks::AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
+    commands.insert_resource(MaterialBrowserFolderTask(task));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "material.browse_texture_slot",
+    label = "Browse Texture",
+    description = "Open a file picker for the texture slot recorded in `PendingTextureSlot` (set by the slot's browse button before dispatch).",
+    allows_undo = false
+)]
+pub(crate) fn material_browse_texture_slot(
+    _: In<OperatorParameters>,
+    mut pending: ResMut<PendingTextureSlot>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(slot) = pending.slot.take() else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(material_handle) = pending.material_handle.take() else {
+        return OperatorResult::Cancelled;
+    };
+    commands.trigger(BrowseTextureSlot {
+        slot,
+        material_handle,
+    });
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "material.clear_texture_slot",
+    label = "Clear Texture",
+    description = "Clear the texture from the slot recorded in `PendingTextureSlot` (set by the slot's clear button before dispatch).",
+    allows_undo = false
+)]
+pub(crate) fn material_clear_texture_slot(
+    _: In<OperatorParameters>,
+    mut pending: ResMut<PendingTextureSlot>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(slot) = pending.slot.take() else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(material_handle) = pending.material_handle.take() else {
+        return OperatorResult::Cancelled;
+    };
+    commands.trigger(ClearTextureSlot {
+        slot,
+        material_handle,
+    });
+    OperatorResult::Finished
 }

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -1695,6 +1695,10 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<MaterialClearTextureSlotOp>();
 }
 
+fn pending_texture_slot_set(pending: Res<PendingTextureSlot>) -> bool {
+    pending.slot.is_some() && pending.material_handle.is_some()
+}
+
 #[operator(
     id = "material.create",
     label = "New Material",
@@ -1745,7 +1749,10 @@ pub(crate) fn material_select_folder(
 #[operator(
     id = "material.browse_texture_slot",
     label = "Browse Texture",
-    description = "Open a file picker for the texture slot recorded in `PendingTextureSlot` (set by the slot's browse button before dispatch).",
+    description = "Open a file picker for the texture slot recorded in `PendingTextureSlot` (set by the slot's \
+                   browse button before dispatch). Availability (`pending_texture_slot_set`) requires the slot \
+                   and material handle to be present.",
+    is_available = pending_texture_slot_set,
     allows_undo = false
 )]
 pub(crate) fn material_browse_texture_slot(
@@ -1769,7 +1776,10 @@ pub(crate) fn material_browse_texture_slot(
 #[operator(
     id = "material.clear_texture_slot",
     label = "Clear Texture",
-    description = "Clear the texture from the slot recorded in `PendingTextureSlot` (set by the slot's clear button before dispatch).",
+    description = "Clear the texture from the slot recorded in `PendingTextureSlot` (set by the slot's clear \
+                   button before dispatch). Availability (`pending_texture_slot_set`) requires the slot and \
+                   material handle to be present.",
+    is_available = pending_texture_slot_set,
     allows_undo = false
 )]
 pub(crate) fn material_clear_texture_slot(

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -61,7 +61,6 @@ impl Plugin for MaterialBrowserPlugin {
             .add_observer(handle_apply_material)
             .add_observer(handle_select_material_preview)
             .add_observer(on_material_param_commit)
-            .add_observer(handle_create_new_material)
             .add_observer(handle_browse_texture_slot)
             .add_observer(handle_clear_texture_slot);
     }
@@ -226,9 +225,6 @@ impl TextureSlot {
         }
     }
 }
-
-#[derive(Event)]
-struct CreateNewMaterial;
 
 #[derive(Event)]
 struct BrowseTextureSlot {
@@ -1223,34 +1219,6 @@ fn poll_material_browser_folder(world: &mut World) {
     }
 }
 
-fn handle_create_new_material(
-    _: On<CreateNewMaterial>,
-    mut registry: ResMut<MaterialRegistry>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    mut catalog: ResMut<crate::asset_catalog::AssetCatalog>,
-    mut preview_state: ResMut<MaterialPreviewState>,
-) {
-    // Generate a unique name
-    let mut idx = 1u32;
-    let name = loop {
-        let candidate = format!("Material_{idx}");
-        if registry.get_by_name(&candidate).is_none() {
-            break candidate;
-        }
-        idx += 1;
-    };
-
-    let handle = materials.add(StandardMaterial::default());
-    let catalog_name = format!("@{name}");
-    catalog.insert(catalog_name, handle.clone().untyped());
-    catalog.dirty = true;
-    registry.add(name, handle.clone());
-    preview_state.active_material = Some(handle);
-    preview_state.orbit_yaw = 0.5;
-    preview_state.orbit_pitch = -0.3;
-    preview_state.zoom_distance = 3.0;
-}
-
 fn handle_browse_texture_slot(
     event: On<BrowseTextureSlot>,
     mut commands: Commands,
@@ -1705,8 +1673,31 @@ fn pending_texture_slot_set(pending: Res<PendingTextureSlot>) -> bool {
     label = "New Material",
     description = "Create a fresh empty material."
 )]
-pub(crate) fn material_create(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
-    commands.trigger(CreateNewMaterial);
+pub(crate) fn material_create(
+    _: In<OperatorParameters>,
+    mut registry: ResMut<MaterialRegistry>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut catalog: ResMut<crate::asset_catalog::AssetCatalog>,
+    mut preview_state: ResMut<MaterialPreviewState>,
+) -> OperatorResult {
+    let mut idx = 1u32;
+    let name = loop {
+        let candidate = format!("Material_{idx}");
+        if registry.get_by_name(&candidate).is_none() {
+            break candidate;
+        }
+        idx += 1;
+    };
+
+    let handle = materials.add(StandardMaterial::default());
+    let catalog_name = format!("@{name}");
+    catalog.insert(catalog_name, handle.clone().untyped());
+    catalog.dirty = true;
+    registry.add(name, handle.clone());
+    preview_state.active_material = Some(handle);
+    preview_state.orbit_yaw = 0.5;
+    preview_state.orbit_pitch = -0.3;
+    preview_state.zoom_distance = 3.0;
     OperatorResult::Finished
 }
 

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -1702,8 +1702,7 @@ fn pending_texture_slot_set(pending: Res<PendingTextureSlot>) -> bool {
 #[operator(
     id = "material.create",
     label = "New Material",
-    description = "Create a fresh `StandardMaterial`, register it with the browser, and select it for preview.",
-    allows_undo = false
+    description = "Create a fresh `StandardMaterial`, register it with the browser, and select it for preview."
 )]
 pub(crate) fn material_create(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(CreateNewMaterial);
@@ -1713,8 +1712,7 @@ pub(crate) fn material_create(_: In<OperatorParameters>, mut commands: Commands)
 #[operator(
     id = "material.rescan",
     label = "Rescan Materials",
-    description = "Schedule a material directory rescan; the browser's polling system picks it up next frame.",
-    allows_undo = false
+    description = "Schedule a material directory rescan; the browser's polling system picks it up next frame."
 )]
 pub(crate) fn material_rescan(
     _: In<OperatorParameters>,
@@ -1727,8 +1725,7 @@ pub(crate) fn material_rescan(
 #[operator(
     id = "material.select_folder",
     label = "Select Materials Folder",
-    description = "Open an OS folder picker for the materials root and store the result in `MaterialBrowserFolderTask` for the polling system.",
-    allows_undo = false
+    description = "Open an OS folder picker for the materials root and store the result in `MaterialBrowserFolderTask` for the polling system."
 )]
 pub(crate) fn material_select_folder(
     _: In<OperatorParameters>,
@@ -1737,6 +1734,9 @@ pub(crate) fn material_select_folder(
 ) -> OperatorResult {
     let mut dialog = AsyncFileDialog::new().set_title("Select materials directory");
     if let Ok(rh) = raw_handle.single() {
+        // SAFETY: the primary window is open, so its `RawHandleWrapper`
+        // points to a live OS handle. We use the returned wrapper only
+        // to parent the modal dialog within this scope.
         let handle = unsafe { rh.get_handle() };
         dialog = dialog.set_parent(&handle);
     }
@@ -1752,8 +1752,7 @@ pub(crate) fn material_select_folder(
     description = "Open a file picker for the texture slot recorded in `PendingTextureSlot` (set by the slot's \
                    browse button before dispatch). Availability (`pending_texture_slot_set`) requires the slot \
                    and material handle to be present.",
-    is_available = pending_texture_slot_set,
-    allows_undo = false
+    is_available = pending_texture_slot_set
 )]
 pub(crate) fn material_browse_texture_slot(
     _: In<OperatorParameters>,
@@ -1779,8 +1778,7 @@ pub(crate) fn material_browse_texture_slot(
     description = "Clear the texture from the slot recorded in `PendingTextureSlot` (set by the slot's clear \
                    button before dispatch). Availability (`pending_texture_slot_set`) requires the slot and \
                    material handle to be present.",
-    is_available = pending_texture_slot_set,
-    allows_undo = false
+    is_available = pending_texture_slot_set
 )]
 pub(crate) fn material_clear_texture_slot(
     _: In<OperatorParameters>,

--- a/src/navmesh/brp_client.rs
+++ b/src/navmesh/brp_client.rs
@@ -14,12 +14,12 @@ use bevy_rerecast::editor_integration::{
     },
     transmission::deserialize,
 };
+use jackdaw_api::prelude::*;
 
 use super::{NavmeshHandleRes, NavmeshObstacles, NavmeshState, NavmeshStatus};
 use crate::EditorEntity;
 
 pub(super) fn plugin(app: &mut App) {
-    app.add_observer(on_get_navmesh_input);
     app.add_systems(
         Update,
         (
@@ -30,9 +30,6 @@ pub(super) fn plugin(app: &mut App) {
             .run_if(in_state(crate::AppState::Editor)),
     );
 }
-
-#[derive(Event)]
-pub struct GetNavmeshInput;
 
 #[derive(Resource)]
 enum GetNavmeshInputRequestTask {
@@ -51,19 +48,26 @@ pub struct SceneVisualMesh;
 #[derive(Component)]
 pub struct ObstacleGizmo;
 
-fn on_get_navmesh_input(
-    _: On<GetNavmeshInput>,
+/// Fetch the latest scene mesh from the connected game so the navmesh
+/// can be rebuilt from it.
+#[operator(
+    id = "navmesh.fetch",
+    label = "Fetch Scene",
+    description = "Fetch the latest scene mesh from the connected game."
+)]
+pub(crate) fn navmesh_fetch(
+    _: In<OperatorParameters>,
     mut commands: Commands,
     regions: Query<&jackdaw_jsn::NavmeshRegion>,
     maybe_task: Option<Res<GetNavmeshInputRequestTask>>,
     mut state: ResMut<NavmeshState>,
-) {
+) -> OperatorResult {
     if maybe_task.is_some() {
-        return;
+        return OperatorResult::Cancelled;
     }
     let Some(region) = regions.iter().next() else {
         warn!("No NavmeshRegion entity found");
-        return;
+        return OperatorResult::Cancelled;
     };
 
     let url = region.connection_url.clone();
@@ -106,6 +110,7 @@ fn on_get_navmesh_input(
 
     let task = IoTaskPool::get().spawn(future);
     commands.insert_resource(GetNavmeshInputRequestTask::Generate { task, url });
+    OperatorResult::Finished
 }
 
 fn poll_remote_navmesh_input(

--- a/src/navmesh/build.rs
+++ b/src/navmesh/build.rs
@@ -1,31 +1,31 @@
 use bevy::prelude::*;
 use bevy_rerecast::prelude::*;
+use jackdaw_api::prelude::*;
 
 use super::{NavmeshHandleRes, NavmeshState, NavmeshStatus};
 
-pub(super) fn plugin(app: &mut App) {
-    app.add_observer(on_build_navmesh);
-}
-
-#[derive(Event)]
-pub struct BuildNavmesh;
-
-fn on_build_navmesh(
-    _trigger: On<BuildNavmesh>,
+/// Bake a navmesh for the current scene.
+#[operator(
+    id = "navmesh.build",
+    label = "Build",
+    description = "Bake a navmesh for the current scene."
+)]
+pub(crate) fn navmesh_build(
+    _: In<OperatorParameters>,
     mut commands: Commands,
     regions: Query<&jackdaw_jsn::NavmeshRegion>,
     mut navmesh_generator: NavmeshGenerator,
     mut state: ResMut<NavmeshState>,
-) {
+) -> OperatorResult {
     let Some(region) = regions.iter().next() else {
         warn!("No NavmeshRegion entity found");
-        return;
+        return OperatorResult::Cancelled;
     };
-
     let settings = region_to_settings_without_transform(region);
     let handle = navmesh_generator.generate(settings);
     commands.insert_resource(NavmeshHandleRes(handle));
     state.status = NavmeshStatus::Building;
+    OperatorResult::Finished
 }
 
 /// Convert region settings without AABB (for BRP fetch, the remote app determines bounds).

--- a/src/navmesh/mod.rs
+++ b/src/navmesh/mod.rs
@@ -1,5 +1,6 @@
 mod brp_client;
 mod build;
+pub(crate) mod ops;
 mod save_load;
 pub mod toolbar;
 mod visualization;

--- a/src/navmesh/mod.rs
+++ b/src/navmesh/mod.rs
@@ -28,7 +28,6 @@ impl Plugin for NavmeshPlugin {
             .init_resource::<NavmeshHandleRes>()
             .init_resource::<NavmeshState>();
         app.add_plugins((
-            build::plugin,
             brp_client::plugin,
             save_load::plugin,
             toolbar::plugin,

--- a/src/navmesh/ops.rs
+++ b/src/navmesh/ops.rs
@@ -1,11 +1,15 @@
 //! Operators for the navmesh contextual toolbar.
+//!
+//! Toggle ops live here; the action ops (fetch, build, save, load) are
+//! defined alongside their state in [`super::brp_client`],
+//! [`super::build`], and [`super::save_load`].
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
 
-use super::brp_client::GetNavmeshInput;
-use super::build::BuildNavmesh;
-use super::save_load::{LoadNavmesh, SaveNavmesh};
+use super::brp_client::NavmeshFetchOp;
+use super::build::NavmeshBuildOp;
+use super::save_load::{NavmeshLoadOp, NavmeshSaveOp};
 use super::visualization::NavmeshVizConfig;
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
@@ -17,51 +21,6 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<NavmeshToggleObstaclesOp>()
         .register_operator::<NavmeshToggleDetailOp>()
         .register_operator::<NavmeshTogglePolyOp>();
-}
-
-/// Fetch the latest scene mesh from the connected game so the navmesh
-/// can be rebuilt from it.
-#[operator(
-    id = "navmesh.fetch",
-    label = "Fetch Scene",
-    description = "Fetch the latest scene mesh from the connected game."
-)]
-pub(crate) fn navmesh_fetch(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
-    commands.trigger(GetNavmeshInput);
-    OperatorResult::Finished
-}
-
-/// Bake a navmesh for the current scene.
-#[operator(
-    id = "navmesh.build",
-    label = "Build",
-    description = "Bake a navmesh for the current scene."
-)]
-pub(crate) fn navmesh_build(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
-    commands.trigger(BuildNavmesh);
-    OperatorResult::Finished
-}
-
-/// Save the baked navmesh to disk.
-#[operator(
-    id = "navmesh.save",
-    label = "Save",
-    description = "Save the baked navmesh to disk."
-)]
-pub(crate) fn navmesh_save(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
-    commands.trigger(SaveNavmesh);
-    OperatorResult::Finished
-}
-
-/// Load a navmesh from disk.
-#[operator(
-    id = "navmesh.load",
-    label = "Load",
-    description = "Load a navmesh from disk."
-)]
-pub(crate) fn navmesh_load(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
-    commands.trigger(LoadNavmesh);
-    OperatorResult::Finished
 }
 
 /// Show or hide the navmesh visual mesh.

--- a/src/navmesh/ops.rs
+++ b/src/navmesh/ops.rs
@@ -1,0 +1,122 @@
+//! Operators for the navmesh contextual toolbar. The fetch / build /
+//! save / load ops dispatch existing events; the four viz toggles
+//! flip flags on `NavmeshVizConfig`.
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+
+use super::brp_client::GetNavmeshInput;
+use super::build::BuildNavmesh;
+use super::save_load::{LoadNavmesh, SaveNavmesh};
+use super::visualization::NavmeshVizConfig;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<NavmeshFetchOp>()
+        .register_operator::<NavmeshBuildOp>()
+        .register_operator::<NavmeshSaveOp>()
+        .register_operator::<NavmeshLoadOp>()
+        .register_operator::<NavmeshToggleVisualOp>()
+        .register_operator::<NavmeshToggleObstaclesOp>()
+        .register_operator::<NavmeshToggleDetailOp>()
+        .register_operator::<NavmeshTogglePolyOp>();
+}
+
+#[operator(
+    id = "navmesh.fetch",
+    label = "Fetch Scene",
+    description = "Request the active scene's navmesh input from the connected game.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_fetch(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.trigger(GetNavmeshInput);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.build",
+    label = "Build",
+    description = "Build the navmesh from the current scene input.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_build(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.trigger(BuildNavmesh);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.save",
+    label = "Save",
+    description = "Write the current navmesh to disk.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_save(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.trigger(SaveNavmesh);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.load",
+    label = "Load",
+    description = "Load a navmesh from disk.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_load(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.trigger(LoadNavmesh);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.toggle_visual",
+    label = "Toggle Visual",
+    description = "Toggle the navmesh visual-mesh overlay.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_toggle_visual(
+    _: In<OperatorParameters>,
+    mut config: ResMut<NavmeshVizConfig>,
+) -> OperatorResult {
+    config.show_visual = !config.show_visual;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.toggle_obstacles",
+    label = "Toggle Obstacles",
+    description = "Toggle the navmesh obstacle gizmo overlay.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_toggle_obstacles(
+    _: In<OperatorParameters>,
+    mut config: ResMut<NavmeshVizConfig>,
+) -> OperatorResult {
+    config.show_obstacles = !config.show_obstacles;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.toggle_detail",
+    label = "Toggle Detail Mesh",
+    description = "Toggle the navmesh detail-mesh overlay.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_toggle_detail(
+    _: In<OperatorParameters>,
+    mut config: ResMut<NavmeshVizConfig>,
+) -> OperatorResult {
+    config.show_detail_mesh = !config.show_detail_mesh;
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "navmesh.toggle_poly",
+    label = "Toggle Polygon Mesh",
+    description = "Toggle the navmesh polygon-mesh overlay.",
+    allows_undo = false
+)]
+pub(crate) fn navmesh_toggle_poly(
+    _: In<OperatorParameters>,
+    mut config: ResMut<NavmeshVizConfig>,
+) -> OperatorResult {
+    config.show_polygon_mesh = !config.show_polygon_mesh;
+    OperatorResult::Finished
+}

--- a/src/navmesh/ops.rs
+++ b/src/navmesh/ops.rs
@@ -24,8 +24,7 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 #[operator(
     id = "navmesh.fetch",
     label = "Fetch Scene",
-    description = "Request the active scene's navmesh input from the connected game.",
-    allows_undo = false
+    description = "Request the active scene's navmesh input from the connected game."
 )]
 pub(crate) fn navmesh_fetch(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(GetNavmeshInput);
@@ -35,8 +34,7 @@ pub(crate) fn navmesh_fetch(_: In<OperatorParameters>, mut commands: Commands) -
 #[operator(
     id = "navmesh.build",
     label = "Build",
-    description = "Build the navmesh from the current scene input.",
-    allows_undo = false
+    description = "Build the navmesh from the current scene input."
 )]
 pub(crate) fn navmesh_build(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(BuildNavmesh);
@@ -46,8 +44,7 @@ pub(crate) fn navmesh_build(_: In<OperatorParameters>, mut commands: Commands) -
 #[operator(
     id = "navmesh.save",
     label = "Save",
-    description = "Write the current navmesh to disk.",
-    allows_undo = false
+    description = "Write the current navmesh to disk."
 )]
 pub(crate) fn navmesh_save(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(SaveNavmesh);
@@ -57,8 +54,7 @@ pub(crate) fn navmesh_save(_: In<OperatorParameters>, mut commands: Commands) ->
 #[operator(
     id = "navmesh.load",
     label = "Load",
-    description = "Load a navmesh from disk.",
-    allows_undo = false
+    description = "Load a navmesh from disk."
 )]
 pub(crate) fn navmesh_load(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(LoadNavmesh);
@@ -68,8 +64,7 @@ pub(crate) fn navmesh_load(_: In<OperatorParameters>, mut commands: Commands) ->
 #[operator(
     id = "navmesh.toggle_visual",
     label = "Toggle Visual",
-    description = "Toggle the navmesh visual-mesh overlay.",
-    allows_undo = false
+    description = "Toggle the navmesh visual-mesh overlay."
 )]
 pub(crate) fn navmesh_toggle_visual(
     _: In<OperatorParameters>,
@@ -82,8 +77,7 @@ pub(crate) fn navmesh_toggle_visual(
 #[operator(
     id = "navmesh.toggle_obstacles",
     label = "Toggle Obstacles",
-    description = "Toggle the navmesh obstacle gizmo overlay.",
-    allows_undo = false
+    description = "Toggle the navmesh obstacle gizmo overlay."
 )]
 pub(crate) fn navmesh_toggle_obstacles(
     _: In<OperatorParameters>,
@@ -96,8 +90,7 @@ pub(crate) fn navmesh_toggle_obstacles(
 #[operator(
     id = "navmesh.toggle_detail",
     label = "Toggle Detail Mesh",
-    description = "Toggle the navmesh detail-mesh overlay.",
-    allows_undo = false
+    description = "Toggle the navmesh detail-mesh overlay."
 )]
 pub(crate) fn navmesh_toggle_detail(
     _: In<OperatorParameters>,
@@ -110,8 +103,7 @@ pub(crate) fn navmesh_toggle_detail(
 #[operator(
     id = "navmesh.toggle_poly",
     label = "Toggle Polygon Mesh",
-    description = "Toggle the navmesh polygon-mesh overlay.",
-    allows_undo = false
+    description = "Toggle the navmesh polygon-mesh overlay."
 )]
 pub(crate) fn navmesh_toggle_poly(
     _: In<OperatorParameters>,

--- a/src/navmesh/ops.rs
+++ b/src/navmesh/ops.rs
@@ -1,6 +1,4 @@
-//! Operators for the navmesh contextual toolbar. The fetch / build /
-//! save / load ops dispatch existing events; the four viz toggles
-//! flip flags on `NavmeshVizConfig`.
+//! Operators for the navmesh contextual toolbar.
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
@@ -21,36 +19,41 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<NavmeshTogglePolyOp>();
 }
 
+/// Fetch the latest scene mesh from the connected game so the navmesh
+/// can be rebuilt from it.
 #[operator(
     id = "navmesh.fetch",
     label = "Fetch Scene",
-    description = "Request the active scene's navmesh input from the connected game."
+    description = "Fetch the latest scene mesh from the connected game."
 )]
 pub(crate) fn navmesh_fetch(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(GetNavmeshInput);
     OperatorResult::Finished
 }
 
+/// Bake a navmesh for the current scene.
 #[operator(
     id = "navmesh.build",
     label = "Build",
-    description = "Build the navmesh from the current scene input."
+    description = "Bake a navmesh for the current scene."
 )]
 pub(crate) fn navmesh_build(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(BuildNavmesh);
     OperatorResult::Finished
 }
 
+/// Save the baked navmesh to disk.
 #[operator(
     id = "navmesh.save",
     label = "Save",
-    description = "Write the current navmesh to disk."
+    description = "Save the baked navmesh to disk."
 )]
 pub(crate) fn navmesh_save(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.trigger(SaveNavmesh);
     OperatorResult::Finished
 }
 
+/// Load a navmesh from disk.
 #[operator(
     id = "navmesh.load",
     label = "Load",
@@ -61,10 +64,11 @@ pub(crate) fn navmesh_load(_: In<OperatorParameters>, mut commands: Commands) ->
     OperatorResult::Finished
 }
 
+/// Show or hide the navmesh visual mesh.
 #[operator(
     id = "navmesh.toggle_visual",
     label = "Toggle Visual",
-    description = "Toggle the navmesh visual-mesh overlay."
+    description = "Show or hide the navmesh visual mesh."
 )]
 pub(crate) fn navmesh_toggle_visual(
     _: In<OperatorParameters>,
@@ -74,10 +78,11 @@ pub(crate) fn navmesh_toggle_visual(
     OperatorResult::Finished
 }
 
+/// Show or hide the navmesh obstacle markers.
 #[operator(
     id = "navmesh.toggle_obstacles",
     label = "Toggle Obstacles",
-    description = "Toggle the navmesh obstacle gizmo overlay."
+    description = "Show or hide the navmesh obstacle markers."
 )]
 pub(crate) fn navmesh_toggle_obstacles(
     _: In<OperatorParameters>,
@@ -87,10 +92,11 @@ pub(crate) fn navmesh_toggle_obstacles(
     OperatorResult::Finished
 }
 
+/// Show or hide the navmesh detail mesh.
 #[operator(
     id = "navmesh.toggle_detail",
     label = "Toggle Detail Mesh",
-    description = "Toggle the navmesh detail-mesh overlay."
+    description = "Show or hide the navmesh detail mesh."
 )]
 pub(crate) fn navmesh_toggle_detail(
     _: In<OperatorParameters>,
@@ -100,10 +106,11 @@ pub(crate) fn navmesh_toggle_detail(
     OperatorResult::Finished
 }
 
+/// Show or hide the navmesh polygon mesh.
 #[operator(
     id = "navmesh.toggle_poly",
     label = "Toggle Polygon Mesh",
-    description = "Toggle the navmesh polygon-mesh overlay."
+    description = "Show or hide the navmesh polygon mesh."
 )]
 pub(crate) fn navmesh_toggle_poly(
     _: In<OperatorParameters>,

--- a/src/navmesh/save_load.rs
+++ b/src/navmesh/save_load.rs
@@ -6,6 +6,7 @@ use bevy::{
     window::{PrimaryWindow, RawHandleWrapper},
 };
 use bevy_rerecast::Navmesh;
+use jackdaw_api::prelude::*;
 use rfd::{AsyncFileDialog, FileHandle};
 
 use super::{NavmeshHandleRes, NavmeshState, NavmeshStatus};
@@ -13,8 +14,6 @@ use super::{NavmeshHandleRes, NavmeshState, NavmeshStatus};
 pub(super) fn plugin(app: &mut App) {
     app.init_resource::<WriteTasks>()
         .init_resource::<ReadTasks>();
-    app.add_observer(on_save_navmesh);
-    app.add_observer(on_load_navmesh);
     app.add_systems(
         Update,
         (
@@ -26,14 +25,6 @@ pub(super) fn plugin(app: &mut App) {
             .run_if(in_state(crate::AppState::Editor)),
     );
 }
-
-// -- Events --
-
-#[derive(Event)]
-pub struct SaveNavmesh;
-
-#[derive(Event)]
-pub struct LoadNavmesh;
 
 // -- Save --
 
@@ -70,23 +61,32 @@ impl From<bincode::error::EncodeError> for SaveError {
     }
 }
 
-fn on_save_navmesh(
-    _: On<SaveNavmesh>,
+/// Save the baked navmesh to disk.
+#[operator(
+    id = "navmesh.save",
+    label = "Save",
+    description = "Save the baked navmesh to disk."
+)]
+pub(crate) fn navmesh_save(
+    _: In<OperatorParameters>,
     mut commands: Commands,
     raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
-) {
+) -> OperatorResult {
     let mut dialog = AsyncFileDialog::new()
         .add_filter("Navmesh", &["nav"])
         .set_file_name("navmesh.nav");
 
     if let Ok(rh) = raw_handle.single() {
-        // SAFETY: called on the main thread during an observer
+        // SAFETY: the primary window is open, so its `RawHandleWrapper`
+        // points to a live OS handle. The returned wrapper is only used
+        // to parent the modal dialog within this scope.
         let handle = unsafe { rh.get_handle() };
         dialog = dialog.set_parent(&handle);
     }
 
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.save_file().await });
     commands.insert_resource(SaveTask(task));
+    OperatorResult::Finished
 }
 
 fn poll_save_task(
@@ -173,21 +173,30 @@ impl From<bincode::error::DecodeError> for LoadError {
     }
 }
 
-fn on_load_navmesh(
-    _: On<LoadNavmesh>,
+/// Load a navmesh from disk.
+#[operator(
+    id = "navmesh.load",
+    label = "Load",
+    description = "Load a navmesh from disk."
+)]
+pub(crate) fn navmesh_load(
+    _: In<OperatorParameters>,
     mut commands: Commands,
     raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
-) {
+) -> OperatorResult {
     let mut dialog = AsyncFileDialog::new().add_filter("Navmesh", &["nav"]);
 
     if let Ok(rh) = raw_handle.single() {
-        // SAFETY: called on the main thread during an observer
+        // SAFETY: the primary window is open, so its `RawHandleWrapper`
+        // points to a live OS handle. The returned wrapper is only used
+        // to parent the modal dialog within this scope.
         let handle = unsafe { rh.get_handle() };
         dialog = dialog.set_parent(&handle);
     }
 
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
     commands.insert_resource(LoadTask(task));
+    OperatorResult::Finished
 }
 
 fn poll_load_task(

--- a/src/navmesh/toolbar.rs
+++ b/src/navmesh/toolbar.rs
@@ -5,11 +5,14 @@ use jackdaw_feathers::{
     separator, tokens,
 };
 
+use super::brp_client::NavmeshFetchOp;
+use super::build::NavmeshBuildOp;
 use super::ops::{
-    NavmeshBuildOp, NavmeshFetchOp, NavmeshLoadOp, NavmeshSaveOp, NavmeshToggleDetailOp,
-    NavmeshToggleObstaclesOp, NavmeshTogglePolyOp, NavmeshToggleVisualOp,
+    NavmeshToggleDetailOp, NavmeshToggleObstaclesOp, NavmeshTogglePolyOp, NavmeshToggleVisualOp,
 };
+use super::save_load::{NavmeshLoadOp, NavmeshSaveOp};
 use super::visualization::NavmeshVizConfig;
+use crate::core_extension::ButtonPropsOpExt as _;
 use crate::{EditorEntity, selection::Selection};
 
 pub(super) fn plugin(app: &mut App) {
@@ -61,25 +64,11 @@ pub fn navmesh_toolbar() -> impl Bundle {
                 TextColor(tokens::TEXT_SECONDARY),
             ),
             button::button(
-                ButtonProps::new("Fetch Scene")
-                    .with_variant(ButtonVariant::Primary)
-                    .call_operator(NavmeshFetchOp::ID),
+                ButtonProps::from_operator::<NavmeshFetchOp>().with_variant(ButtonVariant::Primary),
             ),
-            button::button(
-                ButtonProps::new("Build")
-                    .with_variant(ButtonVariant::Default)
-                    .call_operator(NavmeshBuildOp::ID),
-            ),
-            button::button(
-                ButtonProps::new("Save")
-                    .with_variant(ButtonVariant::Default)
-                    .call_operator(NavmeshSaveOp::ID),
-            ),
-            button::button(
-                ButtonProps::new("Load")
-                    .with_variant(ButtonVariant::Default)
-                    .call_operator(NavmeshLoadOp::ID),
-            ),
+            button::button(ButtonProps::from_operator::<NavmeshBuildOp>()),
+            button::button(ButtonProps::from_operator::<NavmeshSaveOp>()),
+            button::button(ButtonProps::from_operator::<NavmeshLoadOp>()),
             // Separator before viz toggles
             separator::separator(separator::SeparatorProps::vertical()),
             // Visualization toggle buttons

--- a/src/navmesh/toolbar.rs
+++ b/src/navmesh/toolbar.rs
@@ -1,15 +1,15 @@
-use bevy::{prelude::*, ui_widgets::observe};
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
 use jackdaw_feathers::{
     button::{self, ButtonProps, ButtonVariant},
     separator, tokens,
 };
 
-use super::{
-    brp_client::GetNavmeshInput,
-    build::BuildNavmesh,
-    save_load::{LoadNavmesh, SaveNavmesh},
-    visualization::NavmeshVizConfig,
+use super::ops::{
+    NavmeshBuildOp, NavmeshFetchOp, NavmeshLoadOp, NavmeshSaveOp, NavmeshToggleDetailOp,
+    NavmeshToggleObstaclesOp, NavmeshTogglePolyOp, NavmeshToggleVisualOp,
 };
+use super::visualization::NavmeshVizConfig;
 use crate::{EditorEntity, selection::Selection};
 
 pub(super) fn plugin(app: &mut App) {
@@ -60,31 +60,25 @@ pub fn navmesh_toolbar() -> impl Bundle {
                 },
                 TextColor(tokens::TEXT_SECONDARY),
             ),
-            (
-                button::button(
-                    ButtonProps::new("Fetch Scene").with_variant(ButtonVariant::Primary),
-                ),
-                observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-                    commands.trigger(GetNavmeshInput);
-                }),
+            button::button(
+                ButtonProps::new("Fetch Scene")
+                    .with_variant(ButtonVariant::Primary)
+                    .call_operator(NavmeshFetchOp::ID),
             ),
-            (
-                button::button(ButtonProps::new("Build").with_variant(ButtonVariant::Default)),
-                observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-                    commands.trigger(BuildNavmesh);
-                }),
+            button::button(
+                ButtonProps::new("Build")
+                    .with_variant(ButtonVariant::Default)
+                    .call_operator(NavmeshBuildOp::ID),
             ),
-            (
-                button::button(ButtonProps::new("Save").with_variant(ButtonVariant::Default)),
-                observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-                    commands.trigger(SaveNavmesh);
-                }),
+            button::button(
+                ButtonProps::new("Save")
+                    .with_variant(ButtonVariant::Default)
+                    .call_operator(NavmeshSaveOp::ID),
             ),
-            (
-                button::button(ButtonProps::new("Load").with_variant(ButtonVariant::Default)),
-                observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-                    commands.trigger(LoadNavmesh);
-                }),
+            button::button(
+                ButtonProps::new("Load")
+                    .with_variant(ButtonVariant::Default)
+                    .call_operator(NavmeshLoadOp::ID),
             ),
             // Separator before viz toggles
             separator::separator(separator::SeparatorProps::vertical()),
@@ -102,18 +96,18 @@ fn viz_toggle_button(
     toggle: NavmeshVizToggle,
     _initially_active: bool,
 ) -> impl Bundle {
+    let op_id = match toggle {
+        NavmeshVizToggle::Visual => NavmeshToggleVisualOp::ID,
+        NavmeshVizToggle::Obstacles => NavmeshToggleObstaclesOp::ID,
+        NavmeshVizToggle::DetailMesh => NavmeshToggleDetailOp::ID,
+        NavmeshVizToggle::PolygonMesh => NavmeshTogglePolyOp::ID,
+    };
     (
         toggle,
-        button::button(ButtonProps::new(label).with_variant(ButtonVariant::Default)),
-        observe(
-            move |_: On<Pointer<Click>>, mut config: ResMut<NavmeshVizConfig>| match toggle {
-                NavmeshVizToggle::Visual => config.show_visual = !config.show_visual,
-                NavmeshVizToggle::Obstacles => config.show_obstacles = !config.show_obstacles,
-                NavmeshVizToggle::DetailMesh => config.show_detail_mesh = !config.show_detail_mesh,
-                NavmeshVizToggle::PolygonMesh => {
-                    config.show_polygon_mesh = !config.show_polygon_mesh;
-                }
-            },
+        button::button(
+            ButtonProps::new(label)
+                .with_variant(ButtonVariant::Default)
+                .call_operator(op_id),
         ),
     )
 }

--- a/src/physics_tool.rs
+++ b/src/physics_tool.rs
@@ -17,7 +17,6 @@ use bevy::{
 
 use bevy_enhanced_input::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 
 use crate::brush::{BrushSelection, EditMode};
 use crate::commands::{CommandGroup, CommandHistory, EditorCommand, SetJsnField};
@@ -50,21 +49,18 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<PhysicsActivateOp>();
 
     let ext = ctx.id();
-    ctx.entity_mut().world_scope(|world| {
-        world.spawn((
-            Action::<PhysicsActivateOp>::new(),
-            ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![KeyCode::KeyP.with_mod_keys(ModKeys::SHIFT)],
-        ));
-    });
+    ctx.spawn((
+        Action::<PhysicsActivateOp>::new(),
+        ActionOf::<CoreExtensionInputContext>::new(ext),
+        bindings![KeyCode::KeyP.with_mod_keys(ModKeys::SHIFT)],
+    ));
 }
 
 #[operator(
     id = "physics.activate",
     label = "Physics Tool",
-    description = "Hammer-style physics placement tool. Modal: Space commits, Escape cancels.",
+    description = "Drop physics-enabled objects into the scene like a hammer.",
     modal = true,
-    allows_undo = false,
     cancel = cancel_physics_activate,
 )]
 pub(crate) fn physics_activate(
@@ -73,9 +69,9 @@ pub(crate) fn physics_activate(
     mut draw_state: ResMut<DrawBrushState>,
     mut brush_selection: ResMut<BrushSelection>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+    active: ActiveModalQuery,
 ) -> OperatorResult {
-    if modal.is_none() {
+    if !active.is_modal_running() {
         draw_state.active = None;
         brush_selection.clear();
         *edit_mode = EditMode::Physics;

--- a/src/pie.rs
+++ b/src/pie.rs
@@ -77,10 +77,24 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<PieStopOp>();
 }
 
+fn play_is_stopped_or_paused(state: Res<State<PlayState>>) -> bool {
+    !matches!(state.get(), PlayState::Playing)
+}
+
+fn play_is_playing(state: Res<State<PlayState>>) -> bool {
+    *state.get() == PlayState::Playing
+}
+
+fn play_is_running(state: Res<State<PlayState>>) -> bool {
+    *state.get() != PlayState::Stopped
+}
+
 #[operator(
     id = "pie.play",
     label = "Play",
-    description = "Enter Play-In-Editor. From Stopped, snapshots the scene first; from Paused, resumes.",
+    description = "Enter Play-In-Editor. From Stopped, snapshots the scene first; from Paused, resumes. \
+                   Availability (`play_is_stopped_or_paused`) excludes the already-Playing state.",
+    is_available = play_is_stopped_or_paused,
     allows_undo = false
 )]
 pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
@@ -91,7 +105,8 @@ pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> Ope
 #[operator(
     id = "pie.pause",
     label = "Pause",
-    description = "Pause Play-In-Editor. No-op outside Playing.",
+    description = "Pause Play-In-Editor. Availability (`play_is_playing`) requires the Playing state.",
+    is_available = play_is_playing,
     allows_undo = false
 )]
 pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
@@ -102,7 +117,9 @@ pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> Op
 #[operator(
     id = "pie.stop",
     label = "Stop",
-    description = "Exit Play-In-Editor and restore the pre-play scene snapshot.",
+    description = "Exit Play-In-Editor and restore the pre-play scene snapshot. \
+                   Availability (`play_is_running`) excludes the already-Stopped state.",
+    is_available = play_is_running,
     allows_undo = false
 )]
 pub(crate) fn pie_stop(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {

--- a/src/pie.rs
+++ b/src/pie.rs
@@ -26,6 +26,7 @@
 
 use bevy::prelude::*;
 use jackdaw_api::pie::PlayState;
+use jackdaw_api::prelude::*;
 use jackdaw_jsn::SceneJsnAst;
 
 /// Frozen AST captured when the user clicks Play from `Stopped`.
@@ -70,6 +71,45 @@ impl Plugin for PiePlugin {
     }
 }
 
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<PiePlayOp>()
+        .register_operator::<PiePauseOp>()
+        .register_operator::<PieStopOp>();
+}
+
+#[operator(
+    id = "pie.play",
+    label = "Play",
+    description = "Enter Play-In-Editor. From Stopped, snapshots the scene first; from Paused, resumes.",
+    allows_undo = false
+)]
+pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(handle_play);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "pie.pause",
+    label = "Pause",
+    description = "Pause Play-In-Editor. No-op outside Playing.",
+    allows_undo = false
+)]
+pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(handle_pause);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "pie.stop",
+    label = "Stop",
+    description = "Exit Play-In-Editor and restore the pre-play scene snapshot.",
+    allows_undo = false
+)]
+pub(crate) fn pie_stop(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(handle_stop);
+    OperatorResult::Finished
+}
+
 /// Observer: tag entities that receive a `Transform` while
 /// `PlayState::Playing` is active with [`GameSpawned`]. Fires once
 /// per entity because `On<Add, Transform>` is a one-shot event.
@@ -89,10 +129,8 @@ fn tag_game_spawned(
     commands.entity(entity).insert(GameSpawned);
 }
 
-/// Spawn a click observer on each `PieButton` as it's added.
-///
-/// The observer captures the button kind by value so there's no
-/// need for a per-variant query at click time.
+/// Spawn a click observer on each `PieButton` as it's added. The
+/// observer dispatches the corresponding `pie.*` operator.
 fn wire_pie_button(
     trigger: On<Add, PieButton>,
     buttons: Query<&PieButton>,
@@ -102,13 +140,22 @@ fn wire_pie_button(
     let Ok(kind) = buttons.get(entity).copied() else {
         return;
     };
-    commands.entity(entity).observe(
-        move |_: On<Pointer<Click>>, mut commands: Commands| match kind {
-            PieButton::Play => commands.queue(handle_play),
-            PieButton::Pause => commands.queue(handle_pause),
-            PieButton::Stop => commands.queue(handle_stop),
-        },
-    );
+    let op_id = match kind {
+        PieButton::Play => PiePlayOp::ID,
+        PieButton::Pause => PiePauseOp::ID,
+        PieButton::Stop => PieStopOp::ID,
+    };
+    commands
+        .entity(entity)
+        .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            commands
+                .operator(op_id)
+                .settings(CallOperatorSettings {
+                    execution_context: ExecutionContext::Invoke,
+                    creates_history_entry: false,
+                })
+                .call();
+        });
 }
 
 /// Transition into `Playing`. If currently `Stopped`, snapshot the

--- a/src/pie.rs
+++ b/src/pie.rs
@@ -89,11 +89,13 @@ fn play_is_running(state: Res<State<PlayState>>) -> bool {
     *state.get() != PlayState::Stopped
 }
 
+/// Start the game running in the editor. From Stopped, captures a
+/// snapshot of the scene first so Stop can restore it; from Paused,
+/// resumes.
 #[operator(
     id = "pie.play",
     label = "Play",
-    description = "Enter Play-In-Editor. From Stopped, snapshots the scene first; from Paused, resumes. \
-                   Availability (`play_is_stopped_or_paused`) excludes the already-Playing state.",
+    description = "Start the game running in the editor.",
     is_available = play_is_stopped_or_paused
 )]
 pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
@@ -101,10 +103,11 @@ pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> Ope
     OperatorResult::Finished
 }
 
+/// Pause the running game.
 #[operator(
     id = "pie.pause",
     label = "Pause",
-    description = "Pause Play-In-Editor. Availability (`play_is_playing`) requires the Playing state.",
+    description = "Pause the running game.",
     is_available = play_is_playing
 )]
 pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
@@ -112,11 +115,12 @@ pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> Op
     OperatorResult::Finished
 }
 
+/// Stop the running game and restore the scene to the state it was in
+/// before Play was pressed.
 #[operator(
     id = "pie.stop",
     label = "Stop",
-    description = "Exit Play-In-Editor and restore the pre-play scene snapshot. \
-                   Availability (`play_is_running`) excludes the already-Stopped state.",
+    description = "Stop the running game and restore the scene.",
     is_available = play_is_running
 )]
 pub(crate) fn pie_stop(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {

--- a/src/pie.rs
+++ b/src/pie.rs
@@ -94,8 +94,7 @@ fn play_is_running(state: Res<State<PlayState>>) -> bool {
     label = "Play",
     description = "Enter Play-In-Editor. From Stopped, snapshots the scene first; from Paused, resumes. \
                    Availability (`play_is_stopped_or_paused`) excludes the already-Playing state.",
-    is_available = play_is_stopped_or_paused,
-    allows_undo = false
+    is_available = play_is_stopped_or_paused
 )]
 pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(handle_play);
@@ -106,8 +105,7 @@ pub(crate) fn pie_play(_: In<OperatorParameters>, mut commands: Commands) -> Ope
     id = "pie.pause",
     label = "Pause",
     description = "Pause Play-In-Editor. Availability (`play_is_playing`) requires the Playing state.",
-    is_available = play_is_playing,
-    allows_undo = false
+    is_available = play_is_playing
 )]
 pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(handle_pause);
@@ -119,8 +117,7 @@ pub(crate) fn pie_pause(_: In<OperatorParameters>, mut commands: Commands) -> Op
     label = "Stop",
     description = "Exit Play-In-Editor and restore the pre-play scene snapshot. \
                    Availability (`play_is_running`) excludes the already-Stopped state.",
-    is_available = play_is_running,
-    allows_undo = false
+    is_available = play_is_running
 )]
 pub(crate) fn pie_stop(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(handle_stop);

--- a/src/remote/remote_inspector.rs
+++ b/src/remote/remote_inspector.rs
@@ -350,13 +350,15 @@ fn spawn_fallback_section(
 
         let (display_entity, body_entity) = component_display::spawn_component_display(
             commands,
-            &short_name,
-            type_path,
-            source_entity,
-            None,
-            &icon_font.0,
-            &editor_font.0,
-            false,
+            component_display::ComponentDisplaySpec {
+                name: &short_name,
+                type_path,
+                entity: source_entity,
+                component: None,
+                is_overridden: false,
+                icon_font: &icon_font.0,
+                editor_font: &editor_font.0,
+            },
         );
         commands.entity(display_entity).insert(ChildOf(group_body));
 

--- a/src/remote/remote_inspector.rs
+++ b/src/remote/remote_inspector.rs
@@ -351,6 +351,7 @@ fn spawn_fallback_section(
         let (display_entity, body_entity) = component_display::spawn_component_display(
             commands,
             &short_name,
+            type_path,
             source_entity,
             None,
             &icon_font.0,

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -1,6 +1,6 @@
 use bevy::input_focus::InputFocus;
 use bevy::prelude::*;
-use bevy::ui_widgets::observe;
+use jackdaw_api::prelude::*;
 use jackdaw_feathers::{
     button::{self, ButtonProps, ButtonVariant},
     combobox::{self, ComboBoxChangeEvent},
@@ -12,8 +12,7 @@ use jackdaw_feathers::{
     tokens,
 };
 
-use super::{TerrainBrushSettings, TerrainDirtyChunks, TerrainEditMode, sculpt::SetTerrainHeights};
-use crate::commands::CommandHistory;
+use super::{TerrainBrushSettings, TerrainEditMode};
 use crate::selection::Selection;
 
 pub(super) fn plugin(app: &mut App) {
@@ -22,18 +21,8 @@ pub(super) fn plugin(app: &mut App) {
             Update,
             (update_terrain_inspector, sync_brush_fields).run_if(in_state(crate::AppState::Editor)),
         )
-        .add_observer(on_generate_clicked)
-        .add_observer(on_erode_clicked)
         .add_observer(on_terrain_text_commit);
 }
-
-// --- Events ---
-
-#[derive(Event)]
-struct GenerateClicked;
-
-#[derive(Event)]
-struct ErodeClicked;
 
 // --- State ---
 
@@ -290,11 +279,12 @@ fn update_terrain_inspector(
 
     // Generate button
     commands.spawn((
-        button::button(ButtonProps::new("Generate").with_variant(ButtonVariant::Primary)),
+        button::button(
+            ButtonProps::new("Generate")
+                .with_variant(ButtonVariant::Primary)
+                .call_operator(crate::terrain::ops::TerrainGenerateOp::ID),
+        ),
         ChildOf(body),
-        observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-            commands.trigger(GenerateClicked);
-        }),
     ));
 
     // --- Erosion section ---
@@ -364,11 +354,12 @@ fn update_terrain_inspector(
 
     // Erode button
     commands.spawn((
-        button::button(ButtonProps::new("Erode").with_variant(ButtonVariant::Primary)),
+        button::button(
+            ButtonProps::new("Erode")
+                .with_variant(ButtonVariant::Primary)
+                .call_operator(crate::terrain::ops::TerrainErodeOp::ID),
+        ),
         ChildOf(ebody),
-        observe(|_: On<Pointer<Click>>, mut commands: Commands| {
-            commands.trigger(ErodeClicked);
-        }),
     ));
 }
 
@@ -650,65 +641,4 @@ fn on_terrain_text_commit(
         }
         current = parent;
     }
-}
-
-// --- Event handlers ---
-
-fn on_generate_clicked(
-    _trigger: On<GenerateClicked>,
-    selection: Res<Selection>,
-    mut terrains: Query<(&mut jackdaw_jsn::Terrain, &mut TerrainDirtyChunks)>,
-    gen_state: Res<TerrainGenerateState>,
-    mut history: ResMut<CommandHistory>,
-) {
-    let Some(entity) = selection.primary() else {
-        return;
-    };
-    let Ok((mut terrain, mut dirty)) = terrains.get_mut(entity) else {
-        return;
-    };
-
-    let old_heights = terrain.heights.clone();
-
-    let new_heights = jackdaw_terrain::generate_heightmap(terrain.resolution, &gen_state.settings);
-    terrain.heights = new_heights.clone();
-    dirty.rebuild_all = true;
-
-    let cmd = SetTerrainHeights {
-        entity,
-        old_heights,
-        new_heights,
-        label: "Generate Terrain".to_string(),
-    };
-    history.push_executed(Box::new(cmd));
-}
-
-fn on_erode_clicked(
-    _trigger: On<ErodeClicked>,
-    selection: Res<Selection>,
-    mut terrains: Query<(&mut jackdaw_jsn::Terrain, &mut TerrainDirtyChunks)>,
-    gen_state: Res<TerrainGenerateState>,
-    mut history: ResMut<CommandHistory>,
-) {
-    let Some(entity) = selection.primary() else {
-        return;
-    };
-    let Ok((mut terrain, mut dirty)) = terrains.get_mut(entity) else {
-        return;
-    };
-
-    let old_heights = terrain.heights.clone();
-
-    let mut heights = terrain.heights.clone();
-    jackdaw_terrain::hydraulic_erosion(&mut heights, terrain.resolution, &gen_state.erosion);
-    terrain.heights = heights.clone();
-    dirty.rebuild_all = true;
-
-    let cmd = SetTerrainHeights {
-        entity,
-        old_heights,
-        new_heights: heights,
-        label: "Erode Terrain".to_string(),
-    };
-    history.push_executed(Box::new(cmd));
 }

--- a/src/terrain/mod.rs
+++ b/src/terrain/mod.rs
@@ -1,5 +1,6 @@
 pub mod inspector;
 pub mod mesh;
+pub mod ops;
 pub mod sculpt;
 pub mod toolbar;
 

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -33,10 +33,20 @@ fn toggle_to(mode: &mut TerrainEditMode, target: TerrainEditMode) {
     };
 }
 
+/// Tool-toggle ops require a terrain to be selected; otherwise the
+/// toolbar that hosts these buttons is hidden anyway.
+fn has_selected_terrain(
+    selection: Res<Selection>,
+    terrains: Query<(), With<jackdaw_jsn::Terrain>>,
+) -> bool {
+    selection.primary().is_some_and(|e| terrains.contains(e))
+}
+
 #[operator(
     id = "terrain.tool.raise",
     label = "Raise",
     description = "Activate the raise sculpt tool, or deactivate if already active.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_tool_raise(
@@ -54,6 +64,7 @@ pub(crate) fn terrain_tool_raise(
     id = "terrain.tool.lower",
     label = "Lower",
     description = "Activate the lower sculpt tool, or deactivate if already active.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_tool_lower(
@@ -71,6 +82,7 @@ pub(crate) fn terrain_tool_lower(
     id = "terrain.tool.flatten",
     label = "Flatten",
     description = "Activate the flatten sculpt tool, or deactivate if already active.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_tool_flatten(
@@ -88,6 +100,7 @@ pub(crate) fn terrain_tool_flatten(
     id = "terrain.tool.smooth",
     label = "Smooth",
     description = "Activate the smooth sculpt tool, or deactivate if already active.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_tool_smooth(
@@ -105,6 +118,7 @@ pub(crate) fn terrain_tool_smooth(
     id = "terrain.tool.noise",
     label = "Noise",
     description = "Activate the noise sculpt tool, or deactivate if already active.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_tool_noise(
@@ -122,6 +136,7 @@ pub(crate) fn terrain_tool_noise(
     id = "terrain.tool.generate",
     label = "Generate",
     description = "Activate the generate-heightmap mode, or deactivate if already active.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_tool_generate(
@@ -138,6 +153,7 @@ pub(crate) fn terrain_tool_generate(
     description = "Replace the selected terrain's heights with a generated heightmap from \
                    `TerrainGenerateState.settings`. Pushes a single `SetTerrainHeights` \
                    history entry.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_generate(
@@ -172,6 +188,7 @@ pub(crate) fn terrain_generate(
     label = "Erode Terrain",
     description = "Run hydraulic erosion in-place on the selected terrain's heights and push \
                    a `SetTerrainHeights` history entry.",
+    is_available = has_selected_terrain,
     allows_undo = false
 )]
 pub(crate) fn terrain_erode(

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -1,0 +1,203 @@
+//! Operators for the terrain contextual toolbar and inspector.
+//!
+//! Six tool-toggle ops flip `TerrainEditMode` between `Sculpt(tool)` /
+//! `Generate` and `None`; `terrain.generate` and `terrain.erode`
+//! apply the corresponding heightmap transform and push a single
+//! [`SetTerrainHeights`] history entry.
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+
+use super::inspector::TerrainGenerateState;
+use super::sculpt::SetTerrainHeights;
+use super::{TerrainDirtyChunks, TerrainEditMode};
+use crate::commands::CommandHistory;
+use crate::selection::Selection;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<TerrainToolRaiseOp>()
+        .register_operator::<TerrainToolLowerOp>()
+        .register_operator::<TerrainToolFlattenOp>()
+        .register_operator::<TerrainToolSmoothOp>()
+        .register_operator::<TerrainToolNoiseOp>()
+        .register_operator::<TerrainToolGenerateOp>()
+        .register_operator::<TerrainGenerateOp>()
+        .register_operator::<TerrainErodeOp>();
+}
+
+fn toggle_to(mode: &mut TerrainEditMode, target: TerrainEditMode) {
+    *mode = if *mode == target {
+        TerrainEditMode::None
+    } else {
+        target
+    };
+}
+
+#[operator(
+    id = "terrain.tool.raise",
+    label = "Raise",
+    description = "Activate the raise sculpt tool, or deactivate if already active.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_tool_raise(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    toggle_to(
+        &mut mode,
+        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Raise),
+    );
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.tool.lower",
+    label = "Lower",
+    description = "Activate the lower sculpt tool, or deactivate if already active.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_tool_lower(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    toggle_to(
+        &mut mode,
+        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Lower),
+    );
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.tool.flatten",
+    label = "Flatten",
+    description = "Activate the flatten sculpt tool, or deactivate if already active.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_tool_flatten(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    toggle_to(
+        &mut mode,
+        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Flatten),
+    );
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.tool.smooth",
+    label = "Smooth",
+    description = "Activate the smooth sculpt tool, or deactivate if already active.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_tool_smooth(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    toggle_to(
+        &mut mode,
+        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Smooth),
+    );
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.tool.noise",
+    label = "Noise",
+    description = "Activate the noise sculpt tool, or deactivate if already active.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_tool_noise(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    toggle_to(
+        &mut mode,
+        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Noise),
+    );
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.tool.generate",
+    label = "Generate",
+    description = "Activate the generate-heightmap mode, or deactivate if already active.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_tool_generate(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    toggle_to(&mut mode, TerrainEditMode::Generate);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.generate",
+    label = "Generate Terrain",
+    description = "Replace the selected terrain's heights with a generated heightmap from \
+                   `TerrainGenerateState.settings`. Pushes a single `SetTerrainHeights` \
+                   history entry.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_generate(
+    _: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut terrains: Query<(&mut jackdaw_jsn::Terrain, &mut TerrainDirtyChunks)>,
+    gen_state: Res<TerrainGenerateState>,
+    mut history: ResMut<CommandHistory>,
+) -> OperatorResult {
+    let Some(entity) = selection.primary() else {
+        return OperatorResult::Cancelled;
+    };
+    let Ok((mut terrain, mut dirty)) = terrains.get_mut(entity) else {
+        return OperatorResult::Cancelled;
+    };
+
+    let old_heights = terrain.heights.clone();
+    let new_heights = jackdaw_terrain::generate_heightmap(terrain.resolution, &gen_state.settings);
+    terrain.heights = new_heights.clone();
+    dirty.rebuild_all = true;
+    history.push_executed(Box::new(SetTerrainHeights {
+        entity,
+        old_heights,
+        new_heights,
+        label: "Generate Terrain".to_string(),
+    }));
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "terrain.erode",
+    label = "Erode Terrain",
+    description = "Run hydraulic erosion in-place on the selected terrain's heights and push \
+                   a `SetTerrainHeights` history entry.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_erode(
+    _: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut terrains: Query<(&mut jackdaw_jsn::Terrain, &mut TerrainDirtyChunks)>,
+    gen_state: Res<TerrainGenerateState>,
+    mut history: ResMut<CommandHistory>,
+) -> OperatorResult {
+    let Some(entity) = selection.primary() else {
+        return OperatorResult::Cancelled;
+    };
+    let Ok((mut terrain, mut dirty)) = terrains.get_mut(entity) else {
+        return OperatorResult::Cancelled;
+    };
+
+    let old_heights = terrain.heights.clone();
+    let mut new_heights = terrain.heights.clone();
+    jackdaw_terrain::hydraulic_erosion(&mut new_heights, terrain.resolution, &gen_state.erosion);
+    terrain.heights = new_heights.clone();
+    dirty.rebuild_all = true;
+    history.push_executed(Box::new(SetTerrainHeights {
+        entity,
+        old_heights,
+        new_heights,
+        label: "Erode Terrain".to_string(),
+    }));
+    OperatorResult::Finished
+}

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -1,9 +1,4 @@
 //! Operators for the terrain contextual toolbar and inspector.
-//!
-//! Six tool-toggle ops flip `TerrainEditMode` between `Sculpt(tool)` /
-//! `Generate` and `None`; `terrain.generate` and `terrain.erode`
-//! apply the corresponding heightmap transform and push a single
-//! [`SetTerrainHeights`] history entry.
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
@@ -42,10 +37,11 @@ fn has_selected_terrain(
     selection.primary().is_some_and(|e| terrains.contains(e))
 }
 
+/// Pick the raise sculpt tool. Pressing again puts the brush away.
 #[operator(
     id = "terrain.tool.raise",
     label = "Raise",
-    description = "Activate the raise sculpt tool, or deactivate if already active.",
+    description = "Pick the raise sculpt tool.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_raise(
@@ -59,10 +55,11 @@ pub(crate) fn terrain_tool_raise(
     OperatorResult::Finished
 }
 
+/// Pick the lower sculpt tool. Pressing again puts the brush away.
 #[operator(
     id = "terrain.tool.lower",
     label = "Lower",
-    description = "Activate the lower sculpt tool, or deactivate if already active.",
+    description = "Pick the lower sculpt tool.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_lower(
@@ -76,10 +73,11 @@ pub(crate) fn terrain_tool_lower(
     OperatorResult::Finished
 }
 
+/// Pick the flatten sculpt tool. Pressing again puts the brush away.
 #[operator(
     id = "terrain.tool.flatten",
     label = "Flatten",
-    description = "Activate the flatten sculpt tool, or deactivate if already active.",
+    description = "Pick the flatten sculpt tool.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_flatten(
@@ -93,10 +91,11 @@ pub(crate) fn terrain_tool_flatten(
     OperatorResult::Finished
 }
 
+/// Pick the smooth sculpt tool. Pressing again puts the brush away.
 #[operator(
     id = "terrain.tool.smooth",
     label = "Smooth",
-    description = "Activate the smooth sculpt tool, or deactivate if already active.",
+    description = "Pick the smooth sculpt tool.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_smooth(
@@ -110,10 +109,11 @@ pub(crate) fn terrain_tool_smooth(
     OperatorResult::Finished
 }
 
+/// Pick the noise sculpt tool. Pressing again puts the brush away.
 #[operator(
     id = "terrain.tool.noise",
     label = "Noise",
-    description = "Activate the noise sculpt tool, or deactivate if already active.",
+    description = "Pick the noise sculpt tool.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_noise(
@@ -127,10 +127,11 @@ pub(crate) fn terrain_tool_noise(
     OperatorResult::Finished
 }
 
+/// Open the heightmap-generation panel. Pressing again closes it.
 #[operator(
     id = "terrain.tool.generate",
     label = "Generate",
-    description = "Activate the generate-heightmap mode, or deactivate if already active.",
+    description = "Open the heightmap-generation panel.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_generate(
@@ -141,12 +142,18 @@ pub(crate) fn terrain_tool_generate(
     OperatorResult::Finished
 }
 
+/// Generate a fresh heightmap for the selected terrain.
+///
+/// Reads the noise/octaves/etc. settings from the inspector's
+/// generation panel ([`TerrainGenerateState`]).
+///
+/// `allows_undo = false` because this op pushes its own
+/// [`SetTerrainHeights`] history entry; letting the framework also
+/// capture a diff would double-record the change.
 #[operator(
     id = "terrain.generate",
     label = "Generate Terrain",
-    description = "Replace the selected terrain's heights with a generated heightmap from \
-                   `TerrainGenerateState.settings`. Pushes a single `SetTerrainHeights` \
-                   history entry.",
+    description = "Generate a fresh heightmap for the selected terrain.",
     is_available = has_selected_terrain,
     allows_undo = false
 )]
@@ -177,11 +184,18 @@ pub(crate) fn terrain_generate(
     OperatorResult::Finished
 }
 
+/// Apply hydraulic erosion to the selected terrain.
+///
+/// Uses the erosion settings from the inspector's generation panel
+/// ([`TerrainGenerateState::erosion`]).
+///
+/// `allows_undo = false` because this op pushes its own
+/// [`SetTerrainHeights`] history entry; letting the framework also
+/// capture a diff would double-record the change.
 #[operator(
     id = "terrain.erode",
     label = "Erode Terrain",
-    description = "Run hydraulic erosion in-place on the selected terrain's heights and push \
-                   a `SetTerrainHeights` history entry.",
+    description = "Apply hydraulic erosion to the selected terrain.",
     is_available = has_selected_terrain,
     allows_undo = false
 )]

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -154,8 +154,7 @@ pub(crate) fn terrain_tool_generate(
     id = "terrain.generate",
     label = "Generate Terrain",
     description = "Generate a fresh heightmap for the selected terrain.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_generate(
     _: In<OperatorParameters>,
@@ -196,8 +195,7 @@ pub(crate) fn terrain_generate(
     id = "terrain.erode",
     label = "Erode Terrain",
     description = "Apply hydraulic erosion to the selected terrain.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_erode(
     _: In<OperatorParameters>,

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -46,8 +46,7 @@ fn has_selected_terrain(
     id = "terrain.tool.raise",
     label = "Raise",
     description = "Activate the raise sculpt tool, or deactivate if already active.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_raise(
     _: In<OperatorParameters>,
@@ -64,8 +63,7 @@ pub(crate) fn terrain_tool_raise(
     id = "terrain.tool.lower",
     label = "Lower",
     description = "Activate the lower sculpt tool, or deactivate if already active.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_lower(
     _: In<OperatorParameters>,
@@ -82,8 +80,7 @@ pub(crate) fn terrain_tool_lower(
     id = "terrain.tool.flatten",
     label = "Flatten",
     description = "Activate the flatten sculpt tool, or deactivate if already active.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_flatten(
     _: In<OperatorParameters>,
@@ -100,8 +97,7 @@ pub(crate) fn terrain_tool_flatten(
     id = "terrain.tool.smooth",
     label = "Smooth",
     description = "Activate the smooth sculpt tool, or deactivate if already active.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_smooth(
     _: In<OperatorParameters>,
@@ -118,8 +114,7 @@ pub(crate) fn terrain_tool_smooth(
     id = "terrain.tool.noise",
     label = "Noise",
     description = "Activate the noise sculpt tool, or deactivate if already active.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_noise(
     _: In<OperatorParameters>,
@@ -136,8 +131,7 @@ pub(crate) fn terrain_tool_noise(
     id = "terrain.tool.generate",
     label = "Generate",
     description = "Activate the generate-heightmap mode, or deactivate if already active.",
-    is_available = has_selected_terrain,
-    allows_undo = false
+    is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_tool_generate(
     _: In<OperatorParameters>,

--- a/src/terrain/toolbar.rs
+++ b/src/terrain/toolbar.rs
@@ -1,10 +1,15 @@
-use bevy::{prelude::*, ui_widgets::observe};
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
 use jackdaw_feathers::{
     button::{self, ButtonProps, ButtonVariant},
     separator, tokens,
 };
 
 use super::TerrainEditMode;
+use super::ops::{
+    TerrainToolFlattenOp, TerrainToolGenerateOp, TerrainToolLowerOp, TerrainToolNoiseOp,
+    TerrainToolRaiseOp, TerrainToolSmoothOp,
+};
 use crate::{EditorEntity, selection::Selection};
 
 pub(super) fn plugin(app: &mut App) {
@@ -72,36 +77,20 @@ pub fn terrain_toolbar() -> impl Bundle {
 }
 
 fn terrain_tool_button(label: &str, tool: TerrainToolButton) -> impl Bundle {
+    let op_id = match tool {
+        TerrainToolButton::Raise => TerrainToolRaiseOp::ID,
+        TerrainToolButton::Lower => TerrainToolLowerOp::ID,
+        TerrainToolButton::Flatten => TerrainToolFlattenOp::ID,
+        TerrainToolButton::Smooth => TerrainToolSmoothOp::ID,
+        TerrainToolButton::Noise => TerrainToolNoiseOp::ID,
+        TerrainToolButton::Generate => TerrainToolGenerateOp::ID,
+    };
     (
         tool,
-        button::button(ButtonProps::new(label).with_variant(ButtonVariant::Default)),
-        observe(
-            move |_: On<Pointer<Click>>, mut edit_mode: ResMut<TerrainEditMode>| {
-                let new_mode = match tool {
-                    TerrainToolButton::Raise => {
-                        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Raise)
-                    }
-                    TerrainToolButton::Lower => {
-                        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Lower)
-                    }
-                    TerrainToolButton::Flatten => {
-                        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Flatten)
-                    }
-                    TerrainToolButton::Smooth => {
-                        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Smooth)
-                    }
-                    TerrainToolButton::Noise => {
-                        TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Noise)
-                    }
-                    TerrainToolButton::Generate => TerrainEditMode::Generate,
-                };
-                // Toggle off if already in this mode
-                if *edit_mode == new_mode {
-                    *edit_mode = TerrainEditMode::None;
-                } else {
-                    *edit_mode = new_mode;
-                }
-            },
+        button::button(
+            ButtonProps::new(label)
+                .with_variant(ButtonVariant::Default)
+                .call_operator(op_id),
         ),
     )
 }

--- a/src/viewport_select.rs
+++ b/src/viewport_select.rs
@@ -12,7 +12,6 @@ use bevy::{
     prelude::*,
 };
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 use jackdaw_jsn::BrushGroup;
 
 /// Marker for the box-select visual overlay node.
@@ -253,8 +252,12 @@ pub(crate) fn handle_viewport_click(
     }
 }
 
-/// Shift+LMB in the viewport dispatches [`BoxSelectOp`]. Modifier+mouse
-/// gestures aren't expressible as BEI key actions, so this stays a system.
+/// Shift+LMB in the viewport dispatches [`BoxSelectOp`], and a release
+/// inside the operator commits it. Both the trigger here and the
+/// release detection on line 327 sit outside the BEI keybind menu
+/// because modifier+mouse gestures aren't expressible as BEI key
+/// actions. Surfacing them in the customisation UI is part of the
+/// keybind menu rebuild (Phase 11).
 fn box_select_invoke_trigger(
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
@@ -280,23 +283,17 @@ fn box_select_invoke_trigger(
         return;
     }
     commands.queue(|world: &mut World| {
-        let _ = world
-            .operator(BoxSelectOp::ID)
-            .settings(CallOperatorSettings {
-                execution_context: ExecutionContext::Invoke,
-                creates_history_entry: false,
-            })
-            .call();
+        if let Err(err) = world.operator(BoxSelectOp::ID).call() {
+            error!("box-select dispatch failed: {err}");
+        }
     });
 }
 
 #[operator(
     id = "selection.box_select",
     label = "Box Select",
-    description = "Drag a rectangle to select entities. \
-                   Modal: commits on mouse release, cancels on Escape.",
+    description = "Drag a rectangle to select entities inside it.",
     modal = true,
-    allows_undo = false,
     cancel = cancel_box_select,
 )]
 pub(crate) fn box_select(
@@ -307,7 +304,7 @@ pub(crate) fn box_select(
     scene_entities: Query<(Entity, &GlobalTransform), (Without<EditorEntity>, With<Name>)>,
     mut selection: ResMut<Selection>,
     mut commands: Commands,
-    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+    active: ActiveModalQuery,
 ) -> OperatorResult {
     let Ok(window) = vp.windows.single() else {
         return OperatorResult::Cancelled;
@@ -316,7 +313,7 @@ pub(crate) fn box_select(
         return OperatorResult::Cancelled;
     };
 
-    if modal.is_none() {
+    if !active.is_modal_running() {
         box_state.active = true;
         box_state.start = cursor_pos;
         box_state.current = cursor_pos;
@@ -335,12 +332,11 @@ pub(crate) fn box_select(
     let Ok((vp_computed, vp_tf)) = vp.viewport.single() else {
         return OperatorResult::Finished;
     };
-    let scale = vp_computed.inverse_scale_factor();
-    let vp_size = vp_computed.size() * scale;
-    let vp_top_left = vp_tf.translation * scale - vp_size / 2.0;
-    let remap = camera.logical_viewport_size().unwrap_or(vp_size) / vp_size;
-    let min = (box_state.start - vp_top_left).min(box_state.current - vp_top_left) * remap;
-    let max = (box_state.start - vp_top_left).max(box_state.current - vp_top_left) * remap;
+    let map = crate::viewport_util::ViewportRemap::new(camera, vp_computed, vp_tf);
+    let start_local = box_state.start - map.top_left;
+    let current_local = box_state.current - map.top_left;
+    let min = start_local.min(current_local) * map.remap;
+    let max = start_local.max(current_local) * map.remap;
 
     let selected: Vec<Entity> = scene_entities
         .iter()

--- a/src/viewport_util.rs
+++ b/src/viewport_util.rs
@@ -2,6 +2,35 @@ use bevy::{prelude::*, ui::UiGlobalTransform};
 
 use crate::viewport::SceneViewport;
 
+/// Window-to-camera-space mapping for the scene viewport node.
+///
+/// `top_left` is where the viewport node starts in window logical pixels,
+/// `vp_size` is its logical size, and `remap` scales window-local pixels
+/// onto the camera's render target (which may differ from the UI node
+/// size on `HiDPI` / fractional scaling).
+pub(crate) struct ViewportRemap {
+    pub top_left: Vec2,
+    pub vp_size: Vec2,
+    pub remap: Vec2,
+}
+
+impl ViewportRemap {
+    /// Compute remap parameters from the camera and the scene viewport's
+    /// `ComputedNode` + `UiGlobalTransform`.
+    pub fn new(camera: &Camera, computed: &ComputedNode, vp_transform: &UiGlobalTransform) -> Self {
+        let scale = computed.inverse_scale_factor();
+        let vp_pos = vp_transform.translation * scale;
+        let vp_size = computed.size() * scale;
+        let top_left = vp_pos - vp_size / 2.0;
+        let target_size = camera.logical_viewport_size().unwrap_or(vp_size);
+        Self {
+            top_left,
+            vp_size,
+            remap: target_size / vp_size,
+        }
+    }
+}
+
 /// Convert window cursor position to viewport-local coordinates in camera space.
 ///
 /// The camera renders to an off-screen image whose logical size may differ from
@@ -17,17 +46,10 @@ pub(crate) fn window_to_viewport_cursor(
     let Ok((computed, vp_transform)) = viewport_query.single() else {
         return Some(cursor_pos);
     };
-    // Convert from physical pixels to logical pixels to match cursor_position()
-    let scale = computed.inverse_scale_factor();
-    let vp_pos = vp_transform.translation * scale;
-    let vp_size = computed.size() * scale;
-    // ComputedNode position is the center, convert to top-left
-    let vp_top_left = vp_pos - vp_size / 2.0;
-    let local = cursor_pos - vp_top_left;
-    if local.x >= 0.0 && local.y >= 0.0 && local.x <= vp_size.x && local.y <= vp_size.y {
-        // Remap from UI-logical space to camera render-target space
-        let target_size = camera.logical_viewport_size().unwrap_or(vp_size);
-        Some(local * target_size / vp_size)
+    let map = ViewportRemap::new(camera, computed, vp_transform);
+    let local = cursor_pos - map.top_left;
+    if local.x >= 0.0 && local.y >= 0.0 && local.x <= map.vp_size.x && local.y <= map.vp_size.y {
+        Some(local * map.remap)
     } else {
         None
     }


### PR DESCRIPTION
First in the stack: #207 builds on this, #208 builds on #207.

Phase 9 ports the long tail of UI buttons to the operator API. Navmesh toolbar, PIE play/pause/stop, terrain tool buttons and generate/erode, asset browser layer cycling and folder picker, material browser create/rescan/folder picker and per-slot texture browse/clear, and inspector component add/remove/revert plus physics enable/disable and the per-field animation keyframe toggle. All UI surfaces now dispatch the operator by ID.