### PR TITLE
Only show recent projects that exist on disk

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -1,4 +1,7 @@
-use std::{path::{Path, PathBuf}, fs};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use bevy::prelude::*;
 use jackdaw_api_internal::paths::recent_file_path;
@@ -44,8 +47,8 @@ pub fn read_recent_projects() -> RecentProjects {
     let Ok(data) = std::fs::read_to_string(&path) else {
         return RecentProjects::default();
     };
-    
-    let mut projects = serde_json::from_str(&data).unwrap_or_default();
+
+    let mut projects: Vec<RecentEntry> = serde_json::from_str(&data).unwrap_or_default();
 
     projects.projects.retain(|entry| fs::exists(entry.path));
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -50,7 +50,7 @@ pub fn read_recent_projects() -> RecentProjects {
 
     let mut projects: RecentProjects = serde_json::from_str(&data).unwrap_or_default();
 
-    projects.projects.retain(|entry| fs::exists(entry.path));
+    projects.projects.retain(|entry| fs::exists(entry.path).unwrap_or_default());
 
     projects
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -50,7 +50,9 @@ pub fn read_recent_projects() -> RecentProjects {
 
     let mut projects: RecentProjects = serde_json::from_str(&data).unwrap_or_default();
 
-    projects.projects.retain(|entry| fs::exists(entry.path).unwrap_or_default());
+    projects
+        .projects
+        .retain(|entry| fs::exists(entry.path.clone()).unwrap_or_default());
 
     projects
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::{path::{Path, PathBuf}, fs};
 
 use bevy::prelude::*;
 use jackdaw_api_internal::paths::recent_file_path;
@@ -44,7 +44,12 @@ pub fn read_recent_projects() -> RecentProjects {
     let Ok(data) = std::fs::read_to_string(&path) else {
         return RecentProjects::default();
     };
-    serde_json::from_str(&data).unwrap_or_default()
+    
+    let mut projects = serde_json::from_str(&data).unwrap_or_default();
+
+    projects.projects.retain(|entry| fs::exists(entry.path));
+
+    projects
 }
 
 pub fn save_recent_projects(projects: &RecentProjects) {

--- a/src/project.rs
+++ b/src/project.rs
@@ -48,7 +48,7 @@ pub fn read_recent_projects() -> RecentProjects {
         return RecentProjects::default();
     };
 
-    let mut projects: Vec<RecentEntry> = serde_json::from_str(&data).unwrap_or_default();
+    let mut projects: RecentProjects = serde_json::from_str(&data).unwrap_or_default();
 
     projects.projects.retain(|entry| fs::exists(entry.path));
 


### PR DESCRIPTION
This won't actually clear them from the `projects.json` file, just ensure they don't appear on the select screen.