### PR TITLE
Fix node graph demo startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,6 +4750,7 @@ name = "jackdaw_node_graph"
 version = "0.4.1"
 dependencies = [
  "bevy",
+ "bevy_enhanced_input",
  "bevy_monitors",
  "jackdaw_commands",
  "jackdaw_feathers",

--- a/crates/jackdaw_node_graph/Cargo.toml
+++ b/crates/jackdaw_node_graph/Cargo.toml
@@ -10,6 +10,7 @@ include = ["src/**/*", "Cargo.toml", "LICENSE*"]
 [dependencies]
 bevy.workspace = true
 bevy_monitors.workspace = true
+bevy_enhanced_input.workspace = true
 jackdaw_widgets.workspace = true
 jackdaw_feathers.workspace = true
 jackdaw_commands.workspace = true

--- a/crates/jackdaw_node_graph/examples/demo.rs
+++ b/crates/jackdaw_node_graph/examples/demo.rs
@@ -15,6 +15,7 @@
 
 use bevy::prelude::*;
 
+use bevy_enhanced_input::prelude::EnhancedInputPlugin;
 use jackdaw_feathers::{
     EditorFeathersPlugin,
     text_edit::{self, TextEditProps, TextEditValue},
@@ -27,6 +28,7 @@ use jackdaw_node_graph::{
 fn main() -> AppExit {
     App::new()
         .add_plugins(DefaultPlugins)
+        .add_plugins(EnhancedInputPlugin)
         .add_plugins(EditorFeathersPlugin)
         .add_plugins(NodeGraphPlugin)
         .add_systems(Startup, setup)


### PR DESCRIPTION
## Summary
- add the enhanced input plugin to the standalone node graph demo
- declare bevy_enhanced_input as a direct dependency of jackdaw_node_graph

## Verification
- cargo run --release -p jackdaw_node_graph --example demo