### PR TITLE
Avoid jumping command palette

### DIFF
--- a/crates/jackdaw_feathers/src/picker.rs
+++ b/crates/jackdaw_feathers/src/picker.rs
@@ -328,7 +328,10 @@ impl<T: Pickable> PickerProps<T> {
                 Node {
                     max_height: percent(100),
                     width: percent(100),
-                    padding: px(tokens::SPACING_LG).all(),
+                    padding: px(tokens::SPACING_LG)
+                        .all()
+                        // Avoid overlapping menu bar
+                        .with_top(px(tokens::SPACING_LG * 4.0)),
                     justify_content: JustifyContent::Center,
                     ..default()
                 },

--- a/crates/jackdaw_feathers/src/picker.rs
+++ b/crates/jackdaw_feathers/src/picker.rs
@@ -290,6 +290,7 @@ impl<T: Pickable> PickerProps<T> {
                     border_radius: BorderRadius::all(px(tokens::BORDER_RADIUS_MD)),
                     row_gap: px(tokens::SPACING_MD),
                     width: px(600),
+                    max_height: percent(100),
                     ..default()
                 },
                 BorderColor::all(tokens::BORDER_COLOR),
@@ -325,9 +326,9 @@ impl<T: Pickable> PickerProps<T> {
             .entity(ctx.entity)
             .insert((
                 Node {
-                    height: percent(100),
+                    max_height: percent(100),
                     width: percent(100),
-                    align_items: AlignItems::Center,
+                    padding: px(tokens::SPACING_LG).all(),
                     justify_content: JustifyContent::Center,
                     ..default()
                 },

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -57,7 +57,7 @@ pub(crate) fn toggle_command_palette(
     let operators = match world.run_system_cached(get_operators) {
         Ok(ops) => ops,
         Err(e) => {
-            error!("Couldn't get the avilable operators: {e}");
+            error!("Couldn't get the available operators: {e}");
             return OperatorResult::Finished;
         }
     };


### PR DESCRIPTION
Previously, when you typed in the command palette to filter the items, it jumped around the screen as the number of matches changed and the palette was centered to the screen.

With this PR, it's fixed to the top to avoid this jumping, which is easier on the eyes IMO:
<img width="2256" height="1440" alt="image" src="https://github.com/user-attachments/assets/3b55a0fa-a94e-4f5b-ac61-3980db3432fa" />
<img width="2256" height="1440" alt="image" src="https://github.com/user-attachments/assets/0ba3ecc1-cb01-41a0-87d2-8513461a1363" />

That's also how e.g. the VS Code command palette works.