### PR TITLE
Fix UI-scale coord-space bugs across editor

### DIFF
--- a/crates/jackdaw_animation/src/timeline.rs
+++ b/crates/jackdaw_animation/src/timeline.rs
@@ -12,6 +12,7 @@
 
 use bevy::prelude::*;
 use bevy::ui::ComputedNode;
+use bevy::ui::UiScale;
 use bevy::ui::ui_transform::UiGlobalTransform;
 use jackdaw_feathers::button::{
     ButtonClickEvent, ButtonProps, ButtonSize, ButtonVariant, IconButtonProps, button, icon_button,
@@ -1050,13 +1051,14 @@ pub fn handle_scrubber_click(
     mut hint: ResMut<TimelineSnapHint>,
     keys: Res<ButtonInput<KeyCode>>,
     mut seek: MessageWriter<crate::player::AnimationSeek>,
+    ui_scale: Res<UiScale>,
 ) {
     let Ok((scrubber, computed, global_tf)) = scrubbers.get(event.event_target()) else {
         return;
     };
     let duration = clip_display_duration(scrubber.clip, &clips);
     let raw_time = scrubber_time_for_cursor(
-        event.pointer_location.position.x,
+        event.pointer_location.position.x / ui_scale.0,
         computed,
         global_tf,
         duration,
@@ -1092,13 +1094,14 @@ pub fn handle_scrubber_drag(
     mut hint: ResMut<TimelineSnapHint>,
     keys: Res<ButtonInput<KeyCode>>,
     mut seek: MessageWriter<crate::player::AnimationSeek>,
+    ui_scale: Res<UiScale>,
 ) {
     let Ok((scrubber, computed, global_tf)) = scrubbers.get(event.event_target()) else {
         return;
     };
     let duration = clip_display_duration(scrubber.clip, &clips);
     let raw_time = scrubber_time_for_cursor(
-        event.pointer_location.position.x,
+        event.pointer_location.position.x / ui_scale.0,
         computed,
         global_tf,
         duration,

--- a/crates/jackdaw_feathers/src/popover.rs
+++ b/crates/jackdaw_feathers/src/popover.rs
@@ -1,6 +1,6 @@
 use bevy::picking::hover::Hovered;
 use bevy::prelude::*;
-use bevy::ui::UiGlobalTransform;
+use bevy::ui::{UiGlobalTransform, UiScale};
 use bevy::window::PrimaryWindow;
 use lucide_icons::Icon;
 
@@ -252,9 +252,12 @@ fn handle_popover_position(
     >,
     anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
     window: Single<&Window, With<PrimaryWindow>>,
+    ui_scale: Res<UiScale>,
 ) {
     let window = window.into_inner();
-    let window_size = Vec2::new(window.width(), window.height());
+
+    // Convert to UI coordinates
+    let window_size = Vec2::new(window.width(), window.height()) / ui_scale.0;
 
     for (
         anchor_ref,
@@ -276,7 +279,7 @@ fn handle_popover_position(
         }
 
         let (anchor_top_left, anchor_size) = if let Some(pos) = anchor_ref.position {
-            (pos, Vec2::ZERO)
+            (pos / ui_scale.0, Vec2::ZERO)
         } else {
             let scale = anchor_computed.inverse_scale_factor();
             let anchor_center = anchor_transform.translation * scale;

--- a/crates/jackdaw_node_graph/src/add_node_popover.rs
+++ b/crates/jackdaw_node_graph/src/add_node_popover.rs
@@ -57,7 +57,7 @@ const HEADER_TEXT: Color = Color::srgb(0.6, 0.62, 0.68);
 const ENTRY_TEXT: Color = Color::srgb(0.88, 0.89, 0.92);
 const ENTRY_HOVER_BG: Color = Color::srgba(1.0, 1.0, 1.0, 0.06);
 
-/// Open the popover at `position` (screen pixels) for `graph`.
+/// Open the popover at `position` (UI-logical pixels) for `graph`.
 ///
 /// `spawn_position` is the cursor's canvas-space position where the picked
 /// node should be inserted. Previously-open popovers (and their backdrops)
@@ -75,7 +75,7 @@ pub fn spawn_popover(
     existing: &Query<Entity, With<AddNodePopover>>,
     existing_backdrops: &Query<Entity, With<AddNodeBackdrop>>,
     graph: Entity,
-    screen_position: Vec2,
+    position: Vec2,
     spawn_position: Vec2,
 ) {
     // Close any existing popover + backdrop first.
@@ -122,8 +122,8 @@ pub fn spawn_popover(
         },
         Node {
             position_type: PositionType::Absolute,
-            left: Val::Px(screen_position.x),
-            top: Val::Px(screen_position.y),
+            left: Val::Px(position.x),
+            top: Val::Px(position.y),
             width: Val::Px(POPOVER_WIDTH),
             max_height: Val::Px(POPOVER_MAX_HEIGHT),
             flex_direction: FlexDirection::Column,
@@ -355,6 +355,7 @@ pub fn on_canvas_right_click(
     existing: Query<Entity, With<AddNodePopover>>,
     existing_backdrops: Query<Entity, With<AddNodeBackdrop>>,
     mut commands: Commands,
+    ui_scale: Res<bevy::ui::UiScale>,
 ) {
     if event.button != PointerButton::Secondary {
         return;
@@ -373,7 +374,7 @@ pub fn on_canvas_right_click(
         &existing,
         &existing_backdrops,
         viewport.graph,
-        cursor,
+        cursor / ui_scale.0,
         spawn_pos,
     );
 }
@@ -390,6 +391,7 @@ pub fn handle_tab_quick_add(
     existing: Query<Entity, With<AddNodePopover>>,
     existing_backdrops: Query<Entity, With<AddNodeBackdrop>>,
     mut commands: Commands,
+    ui_scale: Res<bevy::ui::UiScale>,
 ) {
     if !keys.just_pressed(KeyCode::Tab) {
         return;
@@ -426,7 +428,7 @@ pub fn handle_tab_quick_add(
         &existing,
         &existing_backdrops,
         graph,
-        cursor,
+        cursor / ui_scale.0,
         spawn_pos,
     );
 }

--- a/crates/jackdaw_panels/src/drag.rs
+++ b/crates/jackdaw_panels/src/drag.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy::ui::UiGlobalTransform;
+use bevy::ui::{UiGlobalTransform, UiScale};
 use jackdaw_feathers::tokens;
 
 use crate::area::{DockArea, DockTab};
@@ -82,6 +82,7 @@ fn on_tab_drag_start(
     tabs: Query<&DockTab>,
     mut drag_state: ResMut<DockDragState>,
     registry: Res<crate::WindowRegistry>,
+    ui_scale: Res<UiScale>,
 ) {
     let entity = trigger.event_target();
     let Ok(tab) = tabs.get(entity) else { return };
@@ -99,7 +100,7 @@ fn on_tab_drag_start(
         start_pos: Vec2::new(
             trigger.event().pointer_location.position.x,
             trigger.event().pointer_location.position.y,
-        ),
+        ) / ui_scale.0,
     };
 }
 
@@ -108,6 +109,7 @@ fn on_sidebar_icon_drag_start(
     icons: Query<&DockSidebarIcon>,
     mut drag_state: ResMut<DockDragState>,
     registry: Res<crate::WindowRegistry>,
+    ui_scale: Res<UiScale>,
 ) {
     let entity = trigger.event_target();
     let Ok(icon) = icons.get(entity) else { return };
@@ -125,7 +127,7 @@ fn on_sidebar_icon_drag_start(
         start_pos: Vec2::new(
             trigger.event().pointer_location.position.x,
             trigger.event().pointer_location.position.y,
-        ),
+        ) / ui_scale.0,
     };
 }
 
@@ -138,6 +140,7 @@ fn on_grip_drag_start(
     bindings: Query<&crate::reconcile::LeafBinding>,
     mut drag_state: ResMut<DockDragState>,
     registry: Res<crate::WindowRegistry>,
+    ui_scale: Res<UiScale>,
 ) {
     let entity = trigger.event_target();
     if grips.get(entity).is_err() {
@@ -189,7 +192,7 @@ fn on_grip_drag_start(
         start_pos: Vec2::new(
             trigger.event().pointer_location.position.x,
             trigger.event().pointer_location.position.y,
-        ),
+        ) / ui_scale.0,
     };
 }
 
@@ -211,12 +214,13 @@ fn on_drag_move(
     >,
     node_query: Query<(&ComputedNode, &UiGlobalTransform)>,
     parent_query: Query<&ChildOf>,
+    ui_scale: Res<UiScale>,
 ) {
     let drag_event = trigger.event();
-    let cursor = Vec2::new(
+    let cursor_pos_ui = Vec2::new(
         drag_event.pointer_location.position.x,
         drag_event.pointer_location.position.y,
-    );
+    ) / ui_scale.0;
 
     match &*drag_state {
         DockDragState::PendingDrag {
@@ -226,7 +230,7 @@ fn on_drag_move(
             window_name,
             start_pos,
         } => {
-            if cursor.distance(*start_pos) < DRAG_THRESHOLD {
+            if cursor_pos_ui.distance(*start_pos) < DRAG_THRESHOLD {
                 return;
             }
 
@@ -242,8 +246,8 @@ fn on_drag_move(
                     DragGhost,
                     Node {
                         position_type: PositionType::Absolute,
-                        left: Val::Px(cursor.x - 40.0),
-                        top: Val::Px(cursor.y - 12.0),
+                        left: Val::Px(cursor_pos_ui.x - 40.0),
+                        top: Val::Px(cursor_pos_ui.y - 12.0),
                         padding: UiRect::axes(Val::Px(10.0), Val::Px(4.0)),
                         border: UiRect::all(Val::Px(1.0)),
                         border_radius: BorderRadius::all(Val::Px(4.0)),
@@ -270,7 +274,7 @@ fn on_drag_move(
                 window_name,
                 source_area: source_area.unwrap_or(Entity::PLACEHOLDER),
                 ghost_entity: ghost,
-                cursor_pos: cursor,
+                cursor_pos: cursor_pos_ui,
                 drop_target: None,
                 overlay_entity: None,
             };
@@ -287,8 +291,8 @@ fn on_drag_move(
 
             commands.entity(ghost).insert(Node {
                 position_type: PositionType::Absolute,
-                left: Val::Px(cursor.x - 40.0),
-                top: Val::Px(cursor.y - 12.0),
+                left: Val::Px(cursor_pos_ui.x - 40.0),
+                top: Val::Px(cursor_pos_ui.y - 12.0),
                 padding: UiRect::axes(Val::Px(10.0), Val::Px(4.0)),
                 border: UiRect::all(Val::Px(1.0)),
                 border_radius: BorderRadius::all(Val::Px(4.0)),
@@ -308,9 +312,9 @@ fn on_drag_move(
                     node_query
                         .get(parent.0)
                         .is_ok_and(|(parent_computed, parent_transform)| {
-                            logical_rect(parent_computed, parent_transform).contains(cursor)
+                            logical_rect(parent_computed, parent_transform).contains(cursor_pos_ui)
                         });
-                if !row_rect.contains(cursor) && !parent_contains {
+                if !row_rect.contains(cursor_pos_ui) && !parent_contains {
                     continue;
                 }
                 let mut closest_child: Option<(Vec2, Vec2, usize, f32)> = None;
@@ -321,7 +325,7 @@ fn on_drag_move(
                     let (_scale, _angle, center) = ui_transform.to_scale_angle_translation();
                     let child_center = center.trunc() * computed.inverse_scale_factor();
                     let child_size = child_computed.size() * child_computed.inverse_scale_factor();
-                    let distance = child_center.distance_squared(cursor);
+                    let distance = child_center.distance_squared(cursor_pos_ui);
                     if closest_child.is_none_or(|(_, _, _, closest_dist)| distance < closest_dist) {
                         closest_child = Some((child_center, child_size, index, distance));
                     }
@@ -329,7 +333,7 @@ fn on_drag_move(
                 let Some((child_center, child_size, mut index, _)) = closest_child else {
                     continue;
                 };
-                let (is_far_side, is_vertical) = is_far_side(cursor, child_center, node);
+                let (is_far_side, is_vertical) = is_far_side(cursor_pos_ui, child_center, node);
                 if is_far_side {
                     index += 1;
                 }
@@ -390,11 +394,11 @@ fn on_drag_move(
             if new_target.is_none() {
                 for (area_entity, computed, ui_transform) in &areas {
                     let area_rect = logical_rect(computed, ui_transform);
-                    if !area_rect.contains(cursor) {
+                    if !area_rect.contains(cursor_pos_ui) {
                         continue;
                     }
 
-                    if let Some(edge) = cursor_edge(area_rect, cursor) {
+                    if let Some(edge) = cursor_edge(area_rect, cursor_pos_ui) {
                         new_target = Some(DropTarget::AreaEdge {
                             area: area_entity,
                             edge,
@@ -457,7 +461,7 @@ fn on_drag_move(
             {
                 *drop_target = new_target;
                 *overlay_entity = new_overlay;
-                *cursor_pos = cursor;
+                *cursor_pos = cursor_pos_ui;
             }
 
             trigger.propagate(false);

--- a/src/brush/interaction.rs
+++ b/src/brush/interaction.rs
@@ -411,12 +411,7 @@ pub(super) fn brush_face_hover(
         super::HoverIntent::PushPull
     };
 
-    let Ok(window) = vp.windows.single() else {
-        hover.entity = None;
-        hover.face_index = None;
-        return;
-    };
-    let Some(cursor_pos) = window.cursor_position() else {
+    let Some(cursor_pos) = vp.cursor() else {
         hover.entity = None;
         hover.face_index = None;
         return;

--- a/src/brush/knife_mode.rs
+++ b/src/brush/knife_mode.rs
@@ -64,7 +64,6 @@
 
 use bevy::prelude::*;
 use bevy::ui::ui_transform::UiGlobalTransform;
-use bevy::window::PrimaryWindow;
 use jackdaw_geometry::halfedge::ops::edge_split::split_edge;
 use jackdaw_geometry::halfedge::ops::face_poke::face_poke;
 use jackdaw_geometry::halfedge::ops::face_split::split_face;
@@ -243,7 +242,7 @@ pub(super) fn handle_knife_mode(
     edit_mode: Res<EditMode>,
     active: Res<ActiveViewport>,
     selection: Res<BrushSelection>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    cursor: crate::viewport::UiCursorPos,
     camera_query: Query<(&Camera, &GlobalTransform), With<MainViewportCamera>>,
     viewport_query: Query<(&ComputedNode, &UiGlobalTransform), With<SceneViewport>>,
     brush_caches: Query<&BrushMeshCache>,
@@ -287,11 +286,7 @@ pub(super) fn handle_knife_mode(
     // Cursor / camera / viewport plumbing. We use the hovered viewport
     // (via `ActiveViewport`) so knife mode works in multi-viewport
     // layouts the same way clip mode does.
-    let Ok(window) = primary_window.single() else {
-        knife.hover_snap = None;
-        return;
-    };
-    let Some(cursor_pos) = window.cursor_position() else {
+    let Some(cursor_pos) = cursor.get() else {
         knife.hover_snap = None;
         return;
     };

--- a/src/brush/topology_ops/edge_bevel.rs
+++ b/src/brush/topology_ops/edge_bevel.rs
@@ -7,7 +7,6 @@
 //! RMB cancels and restores the pre-modal mesh.
 
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
@@ -87,12 +86,11 @@ pub(crate) fn brush_edge_bevel(
     mut modal_state: ResMut<EdgeBevelModalState>,
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    cursor: crate::viewport::UiCursorPos,
     snap_settings: Res<SnapSettings>,
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
-    let window = primary_window.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = cursor.get()?;
 
     // --- First invoke: snapshot and enter modal ---
     if modal_entity.is_none() {

--- a/src/brush/topology_ops/edge_slide_modal.rs
+++ b/src/brush/topology_ops/edge_slide_modal.rs
@@ -12,7 +12,6 @@
 
 use bevy::prelude::*;
 use bevy::ui::ui_transform::UiGlobalTransform;
-use bevy::window::PrimaryWindow;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
@@ -108,16 +107,15 @@ pub(crate) fn brush_edge_slide_modal(
     mut modal_state: ResMut<EdgeSlideModalState>,
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    cursor: crate::viewport::UiCursorPos,
     camera_query: Query<(&Camera, &GlobalTransform), With<MainViewportCamera>>,
     viewport_query: Query<(&ComputedNode, &UiGlobalTransform), With<SceneViewport>>,
     snap_settings: Res<SnapSettings>,
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
-    // Raw window-space cursor; dragging outside the viewport panel should not
+    // Ui-logical cursor; dragging outside the viewport panel should not
     // cancel the modal (matches inset / extrude / loop_cut behavior).
-    let window = primary_window.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = cursor.get()?;
 
     // --- First invoke: snapshot and enter modal ---
     if modal_entity.is_none() {

--- a/src/brush/topology_ops/inset.rs
+++ b/src/brush/topology_ops/inset.rs
@@ -7,7 +7,6 @@
 //! cancels and restores the pre-modal mesh.
 
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
@@ -123,14 +122,11 @@ pub(crate) fn brush_inset(
     mut modal_state: ResMut<InsetModalState>,
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    cursor: crate::viewport::UiCursorPos,
     snap_settings: Res<SnapSettings>,
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
-    // Cursor position in window space (raw, so dragging outside the panel does
-    // not abort the modal the way a bounds-clipped viewport cursor would).
-    let window = primary_window.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = cursor.get()?;
 
     // --- First invoke: snapshot and enter modal ---
     if modal_entity.is_none() {

--- a/src/brush/topology_ops/loop_cut.rs
+++ b/src/brush/topology_ops/loop_cut.rs
@@ -87,6 +87,7 @@ pub(crate) fn brush_loop_cut(
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
     // --- Cursor position ---
+    let (camera, cam_tf) = camera_query.single()?;
     let cursor_pos = cursor.get()?;
 
     // --- First invoke: snapshot and enter modal ---

--- a/src/brush/topology_ops/loop_cut.rs
+++ b/src/brush/topology_ops/loop_cut.rs
@@ -87,6 +87,10 @@ pub(crate) fn brush_loop_cut(
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
     // --- Cursor position ---
+    // Use raw UI-space cursor so dragging outside the viewport panel
+    // doesn't cancel the modal (the bounds check in window_to_viewport_cursor
+    // returns None when the cursor leaves the UI node, which previously caused
+    // the modal to cancel mid-drag).
     let (camera, cam_tf) = camera_query.single()?;
     let cursor_pos = cursor.get()?;
 

--- a/src/brush/topology_ops/loop_cut.rs
+++ b/src/brush/topology_ops/loop_cut.rs
@@ -2,7 +2,6 @@
 
 use bevy::prelude::*;
 use bevy::ui::ui_transform::UiGlobalTransform;
-use bevy::window::PrimaryWindow;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
@@ -81,20 +80,14 @@ pub(crate) fn brush_loop_cut(
     mut preview_lines: ResMut<LoopCutPreviewLines>,
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    cursor: crate::viewport::UiCursorPos,
     camera_query: Query<(&Camera, &GlobalTransform), With<MainViewportCamera>>,
     viewport_query: Query<(&ComputedNode, &UiGlobalTransform), With<SceneViewport>>,
     snap_settings: Res<SnapSettings>,
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
     // --- Cursor position ---
-    // Use raw window-space cursor so dragging outside the viewport panel
-    // doesn't cancel the modal (the bounds check in window_to_viewport_cursor
-    // returns None when the cursor leaves the UI node, which previously caused
-    // the modal to cancel mid-drag).
-    let window = primary_window.single()?;
-    let cursor_pos = window.cursor_position()?;
-    let (camera, cam_tf) = camera_query.single()?;
+    let cursor_pos = cursor.get()?;
 
     // --- First invoke: snapshot and enter modal ---
     if modal_entity.is_none() {

--- a/src/brush/topology_ops/vertex_bevel.rs
+++ b/src/brush/topology_ops/vertex_bevel.rs
@@ -7,7 +7,6 @@
 //! commits; Esc / RMB cancels and restores the pre-modal mesh.
 
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
@@ -87,12 +86,11 @@ pub(crate) fn brush_vertex_bevel(
     mut modal_state: ResMut<VertexBevelModalState>,
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    cursor: crate::viewport::UiCursorPos,
     snap_settings: Res<SnapSettings>,
     modal_entity: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
-    let window = primary_window.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = cursor.get()?;
 
     // --- First invoke: snapshot and enter modal ---
     if modal_entity.is_none() {

--- a/src/brush_drag_ops.rs
+++ b/src/brush_drag_ops.rs
@@ -733,6 +733,7 @@ pub fn brush_vertex_drag(
     mut halfedge_q: Query<&mut crate::brush::BrushHalfedge>,
     snap_settings: Res<SnapSettings>,
 ) -> OperatorResult {
+    let brush_entity = brush_selection.entity?;
     let cursor_pos = vp.cursor()?;
     let (camera_entity, viewport_entity) = if modal.is_none() {
         let camera_entity = vp.camera_entity()?;
@@ -1114,6 +1115,7 @@ pub fn brush_edge_drag(
     mut halfedge_q: Query<&mut crate::brush::BrushHalfedge>,
     snap_settings: Res<SnapSettings>,
 ) -> OperatorResult {
+    let brush_entity = brush_selection.entity?;
     let cursor_pos = vp.cursor()?;
     let (camera_entity, viewport_entity) = if modal.is_none() {
         let camera_entity = vp.camera_entity()?;

--- a/src/brush_drag_ops.rs
+++ b/src/brush_drag_ops.rs
@@ -166,8 +166,7 @@ pub fn brush_face_drag(
     modal: Option<Single<Entity, With<ActiveModalOperator>>>,
     mut halfedge_q: Query<&mut crate::brush::BrushHalfedge>,
 ) -> OperatorResult {
-    let window = vp.windows.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = vp.cursor()?;
     // First invoke uses the hovered viewport; subsequent invokes use
     // the captured one so the drag stays bound to its origin panel.
     let (camera_entity, viewport_entity) = if modal.is_none() {
@@ -734,9 +733,7 @@ pub fn brush_vertex_drag(
     mut halfedge_q: Query<&mut crate::brush::BrushHalfedge>,
     snap_settings: Res<SnapSettings>,
 ) -> OperatorResult {
-    let brush_entity = brush_selection.entity?;
-    let window = vp.windows.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = vp.cursor()?;
     let (camera_entity, viewport_entity) = if modal.is_none() {
         let camera_entity = vp.camera_entity()?;
         let viewport_entity = vp.viewport_entity()?;
@@ -1117,9 +1114,7 @@ pub fn brush_edge_drag(
     mut halfedge_q: Query<&mut crate::brush::BrushHalfedge>,
     snap_settings: Res<SnapSettings>,
 ) -> OperatorResult {
-    let brush_entity = brush_selection.entity?;
-    let window = vp.windows.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = vp.cursor()?;
     let (camera_entity, viewport_entity) = if modal.is_none() {
         let camera_entity = vp.camera_entity()?;
         let viewport_entity = vp.viewport_entity()?;

--- a/src/draw_brush.rs
+++ b/src/draw_brush.rs
@@ -302,7 +302,7 @@ pub(crate) fn draw_brush_commit_polygon(
     }
     active.polygon_vertices = hull;
     let viewport_cursor = (|| {
-        let cursor_pos = vp.windows.single().ok()?.cursor_position()?;
+        let cursor_pos = vp.cursor()?;
         let camera_entity = active.camera.or_else(|| vp.camera_entity())?;
         let viewport_entity = active.viewport.or_else(|| vp.viewport_entity())?;
         let (camera, _) = vp.camera_for(camera_entity)?;
@@ -368,8 +368,7 @@ fn confirm_draw_brush(
     let active = draw_state.active.as_mut()?;
 
     // Verify cursor is in viewport
-    let window = vp.windows.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = vp.cursor()?;
     let camera_entity = active.camera.or_else(|| vp.camera_entity());
     let viewport_entity = active.viewport.or_else(|| vp.viewport_entity());
     let (Some(camera_entity), Some(viewport_entity)) = (camera_entity, viewport_entity) else {
@@ -3624,8 +3623,7 @@ fn find_hovered_face_on_brush(
     ray_cast: &mut MeshRayCast,
     brush_faces: &Query<&BrushFaceEntity>,
 ) -> Option<usize> {
-    let window = vp.windows.single().ok()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = vp.cursor()?;
     let camera_entity = vp.camera_entity()?;
     let viewport_entity = vp.viewport_entity()?;
     let (camera, cam_tf) = vp.camera_for(camera_entity)?;

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -870,15 +870,14 @@ pub(crate) fn hierarchy_open_context_menu(
     _: In<OperatorParameters>,
     mut commands: Commands,
     mut state: ResMut<ContextMenuState>,
-    windows: Query<&Window>,
+    cursor: crate::viewport::UiCursorPos,
     selection: Res<Selection>,
     tree_row_contents: Query<(Entity, &ChildOf), With<TreeRowContent>>,
     tree_nodes: Query<&TreeNode>,
     computed_nodes: Query<(&ComputedNode, &UiGlobalTransform), With<TreeRowContent>>,
     extension_add_entries: Query<&jackdaw_api_internal::lifecycle::RegisteredMenuEntry>,
 ) -> OperatorResult {
-    let window = windows.single()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = cursor.get()?;
 
     // Close any existing context menu
     if let Some(menu) = state.menu_entity.take()
@@ -893,9 +892,10 @@ pub(crate) fn hierarchy_open_context_menu(
         let Ok((computed, global_transform)) = computed_nodes.get(content_entity) else {
             continue;
         };
-        let size = computed.size();
+        let inv_scale = computed.inverse_scale_factor();
+        let size = computed.size() * inv_scale;
         let (_, _, translation) = global_transform.to_scale_angle_translation();
-        let pos = translation;
+        let pos = translation * inv_scale;
         let half = size / 2.0;
         let rect = Rect::from_center_half_size(pos, half);
         if rect.contains(cursor_pos)

--- a/src/measure_tool.rs
+++ b/src/measure_tool.rs
@@ -100,9 +100,6 @@ pub(crate) fn measure_distance(
     vp: crate::viewport::ViewportCursor,
     mut ray_cast: MeshRayCast,
 ) -> OperatorResult {
-    // Outside `AppState::Editor` (e.g. headless tests, project-select
-    // screen) the window or main viewport camera don't exist yet.
-    let window = vp.windows.single()?;
     // Capture the viewport the modal was started on; subsequent
     // frames stick to it even if the cursor strays elsewhere.
     let camera_entity = state.camera.or_else(|| vp.camera_entity());
@@ -119,7 +116,7 @@ pub(crate) fn measure_distance(
     let (camera, cam_tf) = vp.camera_for(camera_entity)?;
 
     // Try to get a world-space point under the cursor.
-    let current_point = window.cursor_position().and_then(|cursor_pos| {
+    let current_point = vp.cursor().and_then(|cursor_pos| {
         let vp_cursor = vp.viewport_cursor_for(camera, viewport_entity, cursor_pos)?;
         let ray = camera.viewport_to_world(cam_tf, vp_cursor).ok()?;
         Some(

--- a/src/scenes/ui.rs
+++ b/src/scenes/ui.rs
@@ -209,7 +209,8 @@ fn spawn_scene_tab(
             move |click: On<Pointer<Click>>,
                   mut commands: Commands,
                   mut state: ResMut<ContextMenuState>,
-                  windows: Query<&Window>| {
+                  windows: Query<&Window>,
+                  ui_scale: Res<bevy::ui::UiScale>| {
                 match click.event().button {
                     PointerButton::Primary => {
                         commands.queue(move |world: &mut World| {
@@ -226,7 +227,8 @@ fn spawn_scene_tab(
                             .single()
                             .ok()
                             .and_then(bevy::prelude::Window::cursor_position)
-                            .unwrap_or_default();
+                            .unwrap_or_default()
+                            / ui_scale.0;
                         if let Some(menu) = state.menu_entity.take()
                             && let Ok(mut ec) = commands.get_entity(menu)
                         {

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -86,8 +86,7 @@ fn terrain_brush_hit(
     let selected = selection.primary()?;
     let (terrain_entity, terrain, terrain_tf) = terrain_query.get(selected).ok()?;
 
-    let window = vp.windows.single().ok()?;
-    let cursor_pos = window.cursor_position()?;
+    let cursor_pos = vp.cursor()?;
 
     let camera_entity = vp.camera_entity()?;
     let viewport_entity = vp.viewport_entity()?;


### PR DESCRIPTION
When adding UI scaling I tried fixing the places in the editor that confused window coordinates and UI coordinates. After testing at bit I realized I had missed quite a few places, so I did a more systematic search.

I tested a bunch of these, but I couldn't figure out how to test every tool, and there might still be more bugs lurking I didn't find.