### PR TITLE
impl Residual<()> for OperatorCancelled

### DIFF
--- a/crates/jackdaw_api_internal/src/lib.rs
+++ b/crates/jackdaw_api_internal/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(try_trait_v2)]
+#![feature(try_trait_v2_residual)]
 //! Public API for Jackdaw editor extensions.
 //!
 //! Extensions are entities. An extension entity holds an [`lifecycle::Extension`]

--- a/crates/jackdaw_api_internal/src/operator.rs
+++ b/crates/jackdaw_api_internal/src/operator.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     convert::Infallible,
-    ops::{ControlFlow, FromResidual, Try},
+    ops::{ControlFlow, FromResidual, Residual, Try},
 };
 
 use bevy::ecs::system::{SystemId, SystemState};
@@ -303,6 +303,10 @@ impl<E> FromResidual<Result<Infallible, E>> for OperatorResult {
     fn from_residual(_: Result<Infallible, E>) -> Self {
         OperatorResult::Cancelled
     }
+}
+
+impl Residual<()> for OperatorCancelled {
+    type TryType = OperatorResult;
 }
 
 /// Extension trait on [`World`] for calling operators by id.


### PR DESCRIPTION
To fix change from https://github.com/rust-lang/rust/pull/154451

It doesn't impact the nightly version used by bevy_cli but may be useful when we upgrade.