### PR TITLE
Feat/qwer tools

### DIFF
--- a/crates/jackdaw_camera/src/lib.rs
+++ b/crates/jackdaw_camera/src/lib.rs
@@ -126,29 +126,24 @@ fn camera_system(
             }
         }
 
-        // WASD + QE fly movement: only active while right-mouse is held. This frees
-        // E/Q (and W/A/S/D) for tool keybinds (extrude, edge-slide, etc.) when the
-        // user is not actively flying the camera. Mirrors Unreal/Unity convention.
         let mut movement = Vec3::ZERO;
 
-        let fly_active = right_held && !ctrl && !alt;
-
-        if fly_active && keybinds.key_pressed(EditorAction::CameraForward, &keyboard) {
+        if keybinds.key_chord_pressed(EditorAction::CameraForward, &keyboard, &mouse) {
             movement += transform.forward().as_vec3();
         }
-        if fly_active && keybinds.key_pressed(EditorAction::CameraBackward, &keyboard) {
+        if keybinds.key_chord_pressed(EditorAction::CameraBackward, &keyboard, &mouse) {
             movement -= transform.forward().as_vec3();
         }
-        if fly_active && keybinds.key_pressed(EditorAction::CameraLeft, &keyboard) {
+        if keybinds.key_chord_pressed(EditorAction::CameraLeft, &keyboard, &mouse) {
             movement -= transform.right().as_vec3();
         }
-        if fly_active && keybinds.key_pressed(EditorAction::CameraRight, &keyboard) {
+        if keybinds.key_chord_pressed(EditorAction::CameraRight, &keyboard, &mouse) {
             movement += transform.right().as_vec3();
         }
-        if fly_active && keybinds.key_pressed(EditorAction::CameraUp, &keyboard) {
+        if keybinds.key_chord_pressed(EditorAction::CameraUp, &keyboard, &mouse) {
             movement += Vec3::Y;
         }
-        if fly_active && keybinds.key_pressed(EditorAction::CameraDown, &keyboard) {
+        if keybinds.key_chord_pressed(EditorAction::CameraDown, &keyboard, &mouse) {
             movement -= Vec3::Y;
         }
 
@@ -156,5 +151,46 @@ fn camera_system(
             let speed_mult = if shift { settings.run_multiplier } else { 1.0 };
             transform.translation += movement.normalize() * settings.speed * speed_mult * dt;
         }
+    }
+}
+
+#[cfg(test)]
+mod fly_chord_tests {
+    use super::*;
+    use bevy::input::ButtonInput;
+    use jackdaw_commands::keybinds::{EditorAction, KeybindRegistry};
+
+    fn keyboard_with(keys: &[KeyCode]) -> ButtonInput<KeyCode> {
+        let mut k = ButtonInput::<KeyCode>::default();
+        for &c in keys {
+            k.press(c);
+        }
+        k
+    }
+    fn mouse_with(btns: &[MouseButton]) -> ButtonInput<MouseButton> {
+        let mut m = ButtonInput::<MouseButton>::default();
+        for &b in btns {
+            m.press(b);
+        }
+        m
+    }
+
+    #[test]
+    fn forward_chord_requires_rmb() {
+        let kb = KeybindRegistry::default();
+        let keyboard = keyboard_with(&[KeyCode::KeyW]);
+        let no_mouse = mouse_with(&[]);
+        let rmb = mouse_with(&[MouseButton::Right]);
+
+        assert!(!kb.key_chord_pressed(EditorAction::CameraForward, &keyboard, &no_mouse));
+        assert!(kb.key_chord_pressed(EditorAction::CameraForward, &keyboard, &rmb));
+    }
+
+    #[test]
+    fn forward_chord_composes_with_shift_for_run_speed() {
+        let kb = KeybindRegistry::default();
+        let keyboard = keyboard_with(&[KeyCode::KeyW, KeyCode::ShiftLeft]);
+        let rmb = mouse_with(&[MouseButton::Right]);
+        assert!(kb.key_chord_pressed(EditorAction::CameraForward, &keyboard, &rmb));
     }
 }

--- a/crates/jackdaw_camera/src/lib.rs
+++ b/crates/jackdaw_camera/src/lib.rs
@@ -126,25 +126,32 @@ fn camera_system(
             }
         }
 
+        // Fly only while RMB is held. The camera-movement bindings default
+        // to RMB chords, but holding RMB is enforced here at the system level
+        // so a stale or hand-edited keybind file that maps plain WASDQE can
+        // never let the camera fly without RMB, which would clash with the
+        // Q/W/E/R tool shortcuts.
         let mut movement = Vec3::ZERO;
 
-        if keybinds.key_chord_pressed(EditorAction::CameraForward, &keyboard, &mouse) {
-            movement += transform.forward().as_vec3();
-        }
-        if keybinds.key_chord_pressed(EditorAction::CameraBackward, &keyboard, &mouse) {
-            movement -= transform.forward().as_vec3();
-        }
-        if keybinds.key_chord_pressed(EditorAction::CameraLeft, &keyboard, &mouse) {
-            movement -= transform.right().as_vec3();
-        }
-        if keybinds.key_chord_pressed(EditorAction::CameraRight, &keyboard, &mouse) {
-            movement += transform.right().as_vec3();
-        }
-        if keybinds.key_chord_pressed(EditorAction::CameraUp, &keyboard, &mouse) {
-            movement += Vec3::Y;
-        }
-        if keybinds.key_chord_pressed(EditorAction::CameraDown, &keyboard, &mouse) {
-            movement -= Vec3::Y;
+        if right_held {
+            if keybinds.key_chord_pressed(EditorAction::CameraForward, &keyboard, &mouse) {
+                movement += transform.forward().as_vec3();
+            }
+            if keybinds.key_chord_pressed(EditorAction::CameraBackward, &keyboard, &mouse) {
+                movement -= transform.forward().as_vec3();
+            }
+            if keybinds.key_chord_pressed(EditorAction::CameraLeft, &keyboard, &mouse) {
+                movement -= transform.right().as_vec3();
+            }
+            if keybinds.key_chord_pressed(EditorAction::CameraRight, &keyboard, &mouse) {
+                movement += transform.right().as_vec3();
+            }
+            if keybinds.key_chord_pressed(EditorAction::CameraUp, &keyboard, &mouse) {
+                movement += Vec3::Y;
+            }
+            if keybinds.key_chord_pressed(EditorAction::CameraDown, &keyboard, &mouse) {
+                movement -= Vec3::Y;
+            }
         }
 
         if movement != Vec3::ZERO {

--- a/crates/jackdaw_commands/src/keybinds.rs
+++ b/crates/jackdaw_commands/src/keybinds.rs
@@ -1089,25 +1089,11 @@ impl Default for KeybindRegistry {
         bindings.insert(A::CameraDown, rmb(K::KeyQ));
         bindings.insert(A::CameraUp, rmb(K::KeyE));
 
-        // -- Camera bookmarks (Ctrl+N to save, N to load) -------------
-        bindings.insert(A::SaveBookmark1, b(K::Digit1, true, false, false));
-        bindings.insert(A::SaveBookmark2, b(K::Digit2, true, false, false));
-        bindings.insert(A::SaveBookmark3, b(K::Digit3, true, false, false));
-        bindings.insert(A::SaveBookmark4, b(K::Digit4, true, false, false));
-        bindings.insert(A::SaveBookmark5, b(K::Digit5, true, false, false));
-        bindings.insert(A::SaveBookmark6, b(K::Digit6, true, false, false));
-        bindings.insert(A::SaveBookmark7, b(K::Digit7, true, false, false));
-        bindings.insert(A::SaveBookmark8, b(K::Digit8, true, false, false));
-        bindings.insert(A::SaveBookmark9, b(K::Digit9, true, false, false));
-        bindings.insert(A::LoadBookmark1, k(K::Digit1));
-        bindings.insert(A::LoadBookmark2, k(K::Digit2));
-        bindings.insert(A::LoadBookmark3, k(K::Digit3));
-        bindings.insert(A::LoadBookmark4, k(K::Digit4));
-        bindings.insert(A::LoadBookmark5, k(K::Digit5));
-        bindings.insert(A::LoadBookmark6, k(K::Digit6));
-        bindings.insert(A::LoadBookmark7, k(K::Digit7));
-        bindings.insert(A::LoadBookmark8, k(K::Digit8));
-        bindings.insert(A::LoadBookmark9, k(K::Digit9));
+        // Camera bookmarks (save/load slots 1..=9) are intentionally left
+        // unbound by default. They remain remappable in the keybind settings
+        // and are reachable from the camera bookmark menu. Leaving them
+        // unbound keeps the bare number keys free for the edit-mode shortcuts
+        // (Vertex/Edge/Face/Clip on 1..=4).
 
         // -- Modal transform (disabled, keybinds ready) ----------------
         bindings.insert(A::ModalGrab, k(K::KeyG));

--- a/crates/jackdaw_commands/src/keybinds.rs
+++ b/crates/jackdaw_commands/src/keybinds.rs
@@ -77,10 +77,11 @@ pub enum EditorAction {
     CsgIntersect,
     ExtendFaceToBrush,
 
-    // Gizmo
-    GizmoRotate,
-    GizmoScale,
-    GizmoTranslate,
+    // Tools
+    ToolSelect,
+    ToolTranslate,
+    ToolRotate,
+    ToolScale,
     ToggleGizmoSpace,
 
     // Viewport
@@ -185,9 +186,10 @@ impl fmt::Display for EditorAction {
             Self::CsgSubtract => "CSG Subtract",
             Self::CsgIntersect => "CSG Intersect",
             Self::ExtendFaceToBrush => "Extend Face to Brush",
-            Self::GizmoRotate => "Gizmo Rotate",
-            Self::GizmoScale => "Gizmo Scale",
-            Self::GizmoTranslate => "Gizmo Translate",
+            Self::ToolSelect => "Tool Select",
+            Self::ToolTranslate => "Tool Translate",
+            Self::ToolRotate => "Tool Rotate",
+            Self::ToolScale => "Tool Scale",
             Self::ToggleGizmoSpace => "Toggle Gizmo Space",
             Self::FocusSelected => "Focus Selected",
             Self::DecreaseGrid => "Decrease Grid",
@@ -284,9 +286,10 @@ impl EditorAction {
             "CSG Subtract" => Some(Self::CsgSubtract),
             "CSG Intersect" => Some(Self::CsgIntersect),
             "Extend Face to Brush" => Some(Self::ExtendFaceToBrush),
-            "Gizmo Rotate" => Some(Self::GizmoRotate),
-            "Gizmo Scale" => Some(Self::GizmoScale),
-            "Gizmo Translate" => Some(Self::GizmoTranslate),
+            "Tool Select" => Some(Self::ToolSelect),
+            "Tool Translate" => Some(Self::ToolTranslate),
+            "Tool Rotate" => Some(Self::ToolRotate),
+            "Tool Scale" => Some(Self::ToolScale),
             "Toggle Gizmo Space" => Some(Self::ToggleGizmoSpace),
             "Focus Selected" => Some(Self::FocusSelected),
             "Decrease Grid" => Some(Self::DecreaseGrid),
@@ -378,10 +381,11 @@ impl EditorAction {
             | Self::CsgSubtract
             | Self::CsgIntersect
             | Self::ExtendFaceToBrush => "CSG",
-            Self::GizmoRotate
-            | Self::GizmoScale
-            | Self::GizmoTranslate
-            | Self::ToggleGizmoSpace => "Gizmo",
+            Self::ToolSelect
+            | Self::ToolTranslate
+            | Self::ToolRotate
+            | Self::ToolScale
+            | Self::ToggleGizmoSpace => "Tools",
             Self::FocusSelected
             | Self::CameraForward
             | Self::CameraBackward
@@ -479,10 +483,11 @@ impl EditorAction {
             A::CsgSubtract,
             A::CsgIntersect,
             A::ExtendFaceToBrush,
-            // Gizmo
-            A::GizmoRotate,
-            A::GizmoScale,
-            A::GizmoTranslate,
+            // Tools
+            A::ToolSelect,
+            A::ToolTranslate,
+            A::ToolRotate,
+            A::ToolScale,
             A::ToggleGizmoSpace,
             // Navigation
             A::FocusSelected,
@@ -518,25 +523,30 @@ impl EditorAction {
     }
 }
 
-/// A single key binding: a key plus modifier flags.
+/// A single key binding: a key plus modifier flags and an optional mouse-button chord.
 ///
-/// Modifier matching is **exact**: a keybind with `ctrl: true, shift: false`
+/// Modifier matching is exact: a keybind with `ctrl: true, shift: false`
 /// matches only when Ctrl is held AND Shift is NOT held. Left/Right variants
-/// of each modifier are unified internally.
+/// of each modifier are unified internally. When `mouse` is `Some(btn)`, the
+/// named button must be held. When `mouse` is `None`, any held mouse button
+/// causes a non-match, preventing plain tool keys from firing mid-drag.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Keybind {
     pub key: KeyCode,
     pub ctrl: bool,
     pub shift: bool,
     pub alt: bool,
+    #[serde(default)]
+    pub mouse: Option<MouseButton>,
 }
 
 impl Keybind {
-    /// Parse a human-readable keybind string like `"Ctrl+Shift+Z"`.
+    /// Parse a human-readable keybind string like `"Ctrl+Shift+Z"` or `"RMB+W"`.
     pub fn parse(s: &str) -> Option<Self> {
         let mut ctrl = false;
         let mut shift = false;
         let mut alt = false;
+        let mut mouse: Option<MouseButton> = None;
 
         let parts: Vec<&str> = s.split('+').collect();
         if parts.is_empty() {
@@ -549,6 +559,9 @@ impl Keybind {
                 "Ctrl" => ctrl = true,
                 "Shift" => shift = true,
                 "Alt" => alt = true,
+                "RMB" => mouse = Some(MouseButton::Right),
+                "MMB" => mouse = Some(MouseButton::Middle),
+                "LMB" => mouse = Some(MouseButton::Left),
                 _ => return None,
             }
         }
@@ -559,7 +572,32 @@ impl Keybind {
             ctrl,
             shift,
             alt,
+            mouse,
         })
+    }
+
+    /// Human-readable string for this keybind, e.g. `"Ctrl+Z"` or `"RMB+W"`.
+    pub fn display_name(&self) -> String {
+        let mut out = String::new();
+        if let Some(btn) = self.mouse {
+            out.push_str(match btn {
+                MouseButton::Right => "RMB+",
+                MouseButton::Middle => "MMB+",
+                MouseButton::Left => "LMB+",
+                MouseButton::Back | MouseButton::Forward | MouseButton::Other(_) => "Mouse?+",
+            });
+        }
+        if self.ctrl {
+            out.push_str("Ctrl+");
+        }
+        if self.shift {
+            out.push_str("Shift+");
+        }
+        if self.alt {
+            out.push_str("Alt+");
+        }
+        out.push_str(key_display_name(self.key));
+        out
     }
 
     /// Keybind with no modifiers.
@@ -569,6 +607,7 @@ impl Keybind {
             ctrl: false,
             shift: false,
             alt: false,
+            mouse: None,
         }
     }
 
@@ -579,6 +618,7 @@ impl Keybind {
             ctrl: true,
             shift: false,
             alt: false,
+            mouse: None,
         }
     }
 
@@ -589,6 +629,7 @@ impl Keybind {
             ctrl: true,
             shift: true,
             alt: false,
+            mouse: None,
         }
     }
 
@@ -599,30 +640,45 @@ impl Keybind {
             ctrl: false,
             shift: false,
             alt: true,
+            mouse: None,
         }
     }
 
-    /// Check if the modifier keys match exactly (Left/Right unified).
-    pub fn modifiers_match(&self, keyboard: &ButtonInput<KeyCode>) -> bool {
+    /// Keybind that requires RMB held alongside the key, with no keyboard modifiers.
+    pub const fn rmb_key(key: KeyCode) -> Self {
+        Self {
+            key,
+            ctrl: false,
+            shift: false,
+            alt: false,
+            mouse: Some(MouseButton::Right),
+        }
+    }
+
+    /// Check if the modifier keys and mouse button state match exactly (Left/Right unified).
+    pub fn modifiers_match(
+        &self,
+        keyboard: &ButtonInput<KeyCode>,
+        mouse: &ButtonInput<MouseButton>,
+    ) -> bool {
         let ctrl = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
         let shift = keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);
         let alt = keyboard.any_pressed([KeyCode::AltLeft, KeyCode::AltRight]);
-        self.ctrl == ctrl && self.shift == shift && self.alt == alt
+        let mouse_ok = match self.mouse {
+            Some(btn) => mouse.pressed(btn),
+            None => {
+                !mouse.pressed(MouseButton::Right)
+                    && !mouse.pressed(MouseButton::Middle)
+                    && !mouse.pressed(MouseButton::Left)
+            }
+        };
+        self.ctrl == ctrl && self.shift == shift && self.alt == alt && mouse_ok
     }
 }
 
 impl fmt::Display for Keybind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.ctrl {
-            f.write_str("Ctrl+")?;
-        }
-        if self.shift {
-            f.write_str("Shift+")?;
-        }
-        if self.alt {
-            f.write_str("Alt+")?;
-        }
-        f.write_str(key_display_name(self.key))
+        f.write_str(&self.display_name())
     }
 }
 
@@ -804,38 +860,53 @@ pub struct KeybindRegistry {
 
 impl KeybindRegistry {
     /// Check if the action's full keybind (key + exact modifiers) was just pressed.
-    pub fn just_pressed(&self, action: EditorAction, keyboard: &ButtonInput<KeyCode>) -> bool {
+    pub fn just_pressed(
+        &self,
+        action: EditorAction,
+        keyboard: &ButtonInput<KeyCode>,
+        mouse: &ButtonInput<MouseButton>,
+    ) -> bool {
         if self.recording {
             return false;
         }
         self.bindings.get(&action).is_some_and(|binds| {
             binds
                 .iter()
-                .any(|b| keyboard.just_pressed(b.key) && b.modifiers_match(keyboard))
+                .any(|b| keyboard.just_pressed(b.key) && b.modifiers_match(keyboard, mouse))
         })
     }
 
     /// Check if the action's full keybind (key + exact modifiers) is held.
-    pub fn pressed(&self, action: EditorAction, keyboard: &ButtonInput<KeyCode>) -> bool {
+    pub fn pressed(
+        &self,
+        action: EditorAction,
+        keyboard: &ButtonInput<KeyCode>,
+        mouse: &ButtonInput<MouseButton>,
+    ) -> bool {
         if self.recording {
             return false;
         }
         self.bindings.get(&action).is_some_and(|binds| {
             binds
                 .iter()
-                .any(|b| keyboard.pressed(b.key) && b.modifiers_match(keyboard))
+                .any(|b| keyboard.pressed(b.key) && b.modifiers_match(keyboard, mouse))
         })
     }
 
     /// Check if the action's full keybind (key + exact modifiers) was just released.
-    pub fn just_released(&self, action: EditorAction, keyboard: &ButtonInput<KeyCode>) -> bool {
+    pub fn just_released(
+        &self,
+        action: EditorAction,
+        keyboard: &ButtonInput<KeyCode>,
+        mouse: &ButtonInput<MouseButton>,
+    ) -> bool {
         if self.recording {
             return false;
         }
         self.bindings.get(&action).is_some_and(|binds| {
             binds
                 .iter()
-                .any(|b| keyboard.just_released(b.key) && b.modifiers_match(keyboard))
+                .any(|b| keyboard.just_released(b.key) && b.modifiers_match(keyboard, mouse))
         })
     }
 
@@ -854,8 +925,9 @@ impl KeybindRegistry {
 
     /// Check only if the action's key is held (ignoring modifiers).
     ///
-    /// Use for continuous input (e.g. camera WASD) where modifiers are checked
-    /// separately by the system.
+    /// Use for continuous input where modifier logic is handled by the system
+    /// itself. For chorded continuous input (key + mouse button), use
+    /// [`Self::key_chord_pressed`].
     pub fn key_pressed(&self, action: EditorAction, keyboard: &ButtonInput<KeyCode>) -> bool {
         if self.recording {
             return false;
@@ -865,14 +937,38 @@ impl KeybindRegistry {
             .is_some_and(|binds| binds.iter().any(|b| keyboard.pressed(b.key)))
     }
 
+    /// Check that the action's key is held and its mouse modifier is held (if any),
+    /// while ignoring ctrl/shift/alt state. Use for continuous-input chords where
+    /// keyboard modifiers must compose freely (e.g. camera fly + Shift run).
+    pub fn key_chord_pressed(
+        &self,
+        action: EditorAction,
+        keyboard: &ButtonInput<KeyCode>,
+        mouse: &ButtonInput<MouseButton>,
+    ) -> bool {
+        if self.recording {
+            return false;
+        }
+        self.bindings.get(&action).is_some_and(|binds| {
+            binds
+                .iter()
+                .any(|b| keyboard.pressed(b.key) && b.mouse.is_none_or(|btn| mouse.pressed(btn)))
+        })
+    }
+
     /// Check only if the action's modifiers are currently held (not the key).
-    pub fn modifiers_held(&self, action: EditorAction, keyboard: &ButtonInput<KeyCode>) -> bool {
+    pub fn modifiers_held(
+        &self,
+        action: EditorAction,
+        keyboard: &ButtonInput<KeyCode>,
+        mouse: &ButtonInput<MouseButton>,
+    ) -> bool {
         if self.recording {
             return false;
         }
         self.bindings
             .get(&action)
-            .is_some_and(|binds| binds.iter().any(|b| b.modifiers_match(keyboard)))
+            .is_some_and(|binds| binds.iter().any(|b| b.modifiers_match(keyboard, mouse)))
     }
 }
 
@@ -889,9 +985,11 @@ impl Default for KeybindRegistry {
                 ctrl,
                 shift,
                 alt,
+                mouse: None,
             }]
         };
         let k = |key: KeyCode| -> Vec<Keybind> { vec![Keybind::key(key)] };
+        let rmb = |key: KeyCode| -> Vec<Keybind> { vec![Keybind::rmb_key(key)] };
 
         // -- File ------------------------------------------------------
         bindings.insert(A::Undo, b(K::KeyZ, true, false, false));
@@ -966,10 +1064,11 @@ impl Default for KeybindRegistry {
         bindings.insert(A::CsgIntersect, b(K::KeyK, true, true, false));
         bindings.insert(A::ExtendFaceToBrush, b(K::KeyE, true, false, false));
 
-        // -- Gizmo -----------------------------------------------------
-        bindings.insert(A::GizmoRotate, k(K::KeyR));
-        bindings.insert(A::GizmoScale, k(K::KeyT));
-        bindings.insert(A::GizmoTranslate, k(K::Escape));
+        // -- Tools -----------------------------------------------------
+        bindings.insert(A::ToolSelect, k(K::KeyQ));
+        bindings.insert(A::ToolTranslate, k(K::KeyW));
+        bindings.insert(A::ToolRotate, k(K::KeyE));
+        bindings.insert(A::ToolScale, k(K::KeyR));
         bindings.insert(A::ToggleGizmoSpace, k(K::KeyX));
 
         // -- Viewport --------------------------------------------------
@@ -983,12 +1082,12 @@ impl Default for KeybindRegistry {
         bindings.insert(A::ToggleWireframe, b(K::KeyW, true, true, false));
 
         // -- Camera movement -------------------------------------------
-        bindings.insert(A::CameraForward, k(K::KeyW));
-        bindings.insert(A::CameraBackward, k(K::KeyS));
-        bindings.insert(A::CameraLeft, k(K::KeyA));
-        bindings.insert(A::CameraRight, k(K::KeyD));
-        bindings.insert(A::CameraDown, k(K::KeyQ));
-        bindings.insert(A::CameraUp, k(K::KeyE));
+        bindings.insert(A::CameraForward, rmb(K::KeyW));
+        bindings.insert(A::CameraBackward, rmb(K::KeyS));
+        bindings.insert(A::CameraLeft, rmb(K::KeyA));
+        bindings.insert(A::CameraRight, rmb(K::KeyD));
+        bindings.insert(A::CameraDown, rmb(K::KeyQ));
+        bindings.insert(A::CameraUp, rmb(K::KeyE));
 
         // -- Camera bookmarks (Ctrl+N to save, N to load) -------------
         bindings.insert(A::SaveBookmark1, b(K::Digit1, true, false, false));
@@ -1024,5 +1123,58 @@ impl Default for KeybindRegistry {
             bindings,
             recording: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod mouse_modifier_tests {
+    use super::*;
+    use bevy::input::ButtonInput;
+    use bevy::prelude::{KeyCode, MouseButton};
+
+    fn empty_keyboard() -> ButtonInput<KeyCode> {
+        ButtonInput::default()
+    }
+    fn mouse_with(btns: &[MouseButton]) -> ButtonInput<MouseButton> {
+        let mut input = ButtonInput::<MouseButton>::default();
+        for &b in btns {
+            input.press(b);
+        }
+        input
+    }
+
+    #[test]
+    fn plain_keybind_has_no_mouse_modifier() {
+        let kb = Keybind::key(KeyCode::KeyW);
+        assert_eq!(kb.mouse, None);
+    }
+
+    #[test]
+    fn rmb_key_sets_right_mouse_modifier() {
+        let kb = Keybind::rmb_key(KeyCode::KeyW);
+        assert_eq!(kb.mouse, Some(MouseButton::Right));
+        assert_eq!(kb.key, KeyCode::KeyW);
+        assert!(!kb.ctrl && !kb.shift && !kb.alt);
+    }
+
+    #[test]
+    fn modifiers_match_requires_mouse_state_to_match() {
+        let plain = Keybind::key(KeyCode::KeyW);
+        let chord = Keybind::rmb_key(KeyCode::KeyW);
+        let kb = empty_keyboard();
+        let no_mouse = mouse_with(&[]);
+        let rmb = mouse_with(&[MouseButton::Right]);
+
+        assert!(plain.modifiers_match(&kb, &no_mouse));
+        assert!(!plain.modifiers_match(&kb, &rmb));
+        assert!(!chord.modifiers_match(&kb, &no_mouse));
+        assert!(chord.modifiers_match(&kb, &rmb));
+    }
+
+    #[test]
+    fn parse_round_trips_rmb_prefix() {
+        let kb = Keybind::parse("RMB+W").expect("parse RMB+W");
+        assert_eq!(kb, Keybind::rmb_key(KeyCode::KeyW));
+        assert_eq!(kb.display_name(), "RMB+W");
     }
 }

--- a/src/active_tool.rs
+++ b/src/active_tool.rs
@@ -1,0 +1,26 @@
+//! `ActiveTool` resource: which top-level tool the user has active.
+//!
+//! Drives gizmo rendering and the toolbar active-state highlight.
+//! `Select` hides any manipulator; the other variants render their
+//! respective gizmo when something is selected.
+
+use bevy::prelude::*;
+
+#[derive(Resource, Default, PartialEq, Eq, Clone, Copy, Debug)]
+pub enum ActiveTool {
+    #[default]
+    Select,
+    Translate,
+    Rotate,
+    Scale,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_select() {
+        assert_eq!(ActiveTool::default(), ActiveTool::Select);
+    }
+}

--- a/src/alignment_guides.rs
+++ b/src/alignment_guides.rs
@@ -1,8 +1,9 @@
 use bevy::prelude::*;
 
+use crate::active_tool::ActiveTool;
 use crate::brush::BrushMeshCache;
 use crate::default_style;
-use crate::gizmos::{GizmoDragState, GizmoMode};
+use crate::gizmos::GizmoDragState;
 use crate::modal_transform::{ModalOp, ModalTransformState, ViewportDragState};
 use crate::selection::Selected;
 use crate::viewport_overlays::{self, OverlaySettings};
@@ -54,11 +55,11 @@ pub struct AlignmentGuideState {
 /// Returns true if a translation drag is currently active.
 fn is_translate_drag_active(
     gizmo_drag: &GizmoDragState,
-    gizmo_mode: &GizmoMode,
+    active_tool: &ActiveTool,
     modal_state: &ModalTransformState,
     viewport_drag: &ViewportDragState,
 ) -> bool {
-    if gizmo_drag.active && *gizmo_mode == GizmoMode::Translate {
+    if gizmo_drag.active && *active_tool == ActiveTool::Translate {
         return true;
     }
     if let Some(ref active) = modal_state.active
@@ -72,14 +73,14 @@ fn is_translate_drag_active(
 /// Returns the entity being dragged and its current world position.
 fn dragged_entity_position(
     gizmo_drag: &GizmoDragState,
-    gizmo_mode: &GizmoMode,
+    active_tool: &ActiveTool,
     modal_state: &ModalTransformState,
     viewport_drag: &ViewportDragState,
     transforms: &Query<&GlobalTransform>,
 ) -> Option<(Entity, Vec3)> {
     // Gizmo translate
     if gizmo_drag.active
-        && *gizmo_mode == GizmoMode::Translate
+        && *active_tool == ActiveTool::Translate
         && let Some(e) = gizmo_drag.entity
         && let Ok(gt) = transforms.get(e)
     {
@@ -106,7 +107,7 @@ fn cache_reference_coords(
     mut state: ResMut<AlignmentGuideState>,
     settings: Res<OverlaySettings>,
     gizmo_drag: Res<GizmoDragState>,
-    gizmo_mode: Res<GizmoMode>,
+    active_tool: Res<ActiveTool>,
     modal_state: Res<ModalTransformState>,
     viewport_drag: Res<ViewportDragState>,
     non_selected: Query<(Entity, &GlobalTransform, Option<&BrushMeshCache>), Without<Selected>>,
@@ -122,7 +123,8 @@ fn cache_reference_coords(
         return;
     }
 
-    let dragging = is_translate_drag_active(&gizmo_drag, &gizmo_mode, &modal_state, &viewport_drag);
+    let dragging =
+        is_translate_drag_active(&gizmo_drag, &active_tool, &modal_state, &viewport_drag);
 
     if !dragging {
         state.cache_valid = false;
@@ -221,7 +223,7 @@ fn draw_alignment_guides(
     state: Res<AlignmentGuideState>,
     settings: Res<OverlaySettings>,
     gizmo_drag: Res<GizmoDragState>,
-    gizmo_mode: Res<GizmoMode>,
+    active_tool: Res<ActiveTool>,
     modal_state: Res<ModalTransformState>,
     viewport_drag: Res<ViewportDragState>,
     transforms: Query<&GlobalTransform>,
@@ -239,7 +241,7 @@ fn draw_alignment_guides(
 
     let Some((dragged_entity, drag_pos)) = dragged_entity_position(
         &gizmo_drag,
-        &gizmo_mode,
+        &active_tool,
         &modal_state,
         &viewport_drag,
         &transforms,

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -188,6 +188,7 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::view_ops::add_to_extension(ctx);
         crate::grid_ops::add_to_extension(ctx);
         crate::gizmo_ops::add_to_extension(ctx);
+        crate::tool_ops::add_to_extension(ctx);
         crate::edit_mode_ops::add_to_extension(ctx);
         crate::entity_ops::add_to_extension(ctx);
         crate::transform_ops::add_to_extension(ctx);

--- a/src/edit_mode_ops.rs
+++ b/src/edit_mode_ops.rs
@@ -1,12 +1,9 @@
-//! Edit-mode switch operators: Object / Vertex / Edge / Face / Clip /
-//! Physics. Each one either enters the named mode or, if already in
-//! it, toggles back out to Object.
+//! Edit-mode switch operators: Vertex / Edge / Face / Clip / Knife.
+//! Each one either enters the named mode or, if already in it, toggles
+//! back to Object. All `allows_undo = false` because edit-mode is UI
+//! state, not a scene mutation.
 //!
-//! These replace what `handle_edit_mode_keys` and the toolbar's
-//! per-variant `.observe(...)` closures did before. All `allows_undo =
-//! false` because edit-mode is a UI state, not a scene mutation.
-//!
-//! Default keybinds: `1` vertex, `2` edge, `3` face, `4` clip.
+//! Default keybinds: `1` vertex, `2` edge, `3` face, `4` clip, `K` knife.
 
 use bevy::{input_focus::InputFocus, prelude::*};
 use bevy_enhanced_input::prelude::{Press, *};
@@ -20,9 +17,23 @@ use crate::core_extension::CoreExtensionInputContext;
 use crate::draw_brush::DrawBrushState;
 use crate::selection::Selection;
 
+/// Resets edit mode to Object, clears any brush sub-element selection,
+/// and cancels an in-progress draw brush session. Called by `tool.select`
+/// so that switching to the Select tool always lands in Object mode.
+pub(crate) fn set_edit_mode_object(world: &mut World) {
+    if let Some(mut edit_mode) = world.get_resource_mut::<EditMode>() {
+        *edit_mode = EditMode::Object;
+    }
+    if let Some(mut brush_selection) = world.get_resource_mut::<BrushSelection>() {
+        brush_selection.clear();
+    }
+    if let Some(mut draw_state) = world.get_resource_mut::<DrawBrushState>() {
+        draw_state.active = None;
+    }
+}
+
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
-    ctx.register_operator::<EditModeObjectOp>()
-        .register_operator::<EditModeVertexOp>()
+    ctx.register_operator::<EditModeVertexOp>()
         .register_operator::<EditModeEdgeOp>()
         .register_operator::<EditModeFaceOp>()
         .register_operator::<EditModeClipOp>()
@@ -133,24 +144,6 @@ fn can_change_edit_mode(
         return false;
     }
     true
-}
-
-#[operator(
-    id = "edit_mode.object",
-    label = "Object Mode",
-    is_available = can_change_edit_mode,
-    allows_undo = false,
-)]
-pub fn edit_mode_object(
-    _: In<OperatorParameters>,
-    mut edit_mode: ResMut<EditMode>,
-    mut brush_selection: ResMut<BrushSelection>,
-    mut draw_state: ResMut<DrawBrushState>,
-) -> OperatorResult {
-    *edit_mode = EditMode::Object;
-    brush_selection.clear();
-    draw_state.active = None;
-    OperatorResult::Finished
 }
 
 #[operator(

--- a/src/gizmo_ops.rs
+++ b/src/gizmo_ops.rs
@@ -1,44 +1,21 @@
-//! Gizmo mode + space operators.
+//! Gizmo space operator.
 //!
-//! Mode ops (`gizmo.mode.translate/rotate/scale`) flip the active
-//! transform gizmo. Space op (`gizmo.space.toggle`) flips world/local.
-//! All gated to Object mode so they don't fire while the user is
-//! editing brush sub-elements or mid-modal.
-//!
-//! Default keybinds: R=rotate, T=scale, Escape=translate, X=space
-//! toggle.
+//! `gizmo.space.toggle` flips world/local transform space.
+//! Default keybind: X.
 
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{Press, *};
 use jackdaw_api::prelude::*;
 
 use crate::core_extension::CoreExtensionInputContext;
-use crate::gizmos::{GizmoMode, GizmoSpace};
+use crate::gizmos::GizmoSpace;
 use crate::keybind_focus::KeybindFocus;
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
-    ctx.register_operator::<GizmoModeTranslateOp>()
-        .register_operator::<GizmoModeRotateOp>()
-        .register_operator::<GizmoModeScaleOp>()
-        .register_operator::<GizmoSpaceToggleOp>();
+    ctx.register_operator::<GizmoSpaceToggleOp>();
 
     let ext = ctx.id();
     ctx.entity_mut().world_scope(|world| {
-        world.spawn((
-            Action::<GizmoModeRotateOp>::new(),
-            ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::KeyR, Press::default())],
-        ));
-        world.spawn((
-            Action::<GizmoModeScaleOp>::new(),
-            ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::KeyT, Press::default())],
-        ));
-        world.spawn((
-            Action::<GizmoModeTranslateOp>::new(),
-            ActionOf::<CoreExtensionInputContext>::new(ext),
-            bindings![(KeyCode::Escape, Press::default())],
-        ));
         world.spawn((
             Action::<GizmoSpaceToggleOp>::new(),
             ActionOf::<CoreExtensionInputContext>::new(ext),
@@ -47,59 +24,16 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     });
 }
 
-/// Gizmo mode changes are ignored while any overlay is typing into a
-/// text field or a modal operator is in flight; matches the guards
-/// the legacy handler used to apply.
-fn can_change_gizmo(
-    keybind_focus: KeybindFocus,
-    edit_mode: Res<crate::brush::EditMode>,
-    active: ActiveModalQuery,
-) -> bool {
-    !keybind_focus.is_typing()
-        && !active.is_modal_running()
-        && *edit_mode == crate::brush::EditMode::Object
-}
-
-#[operator(
-    id = "gizmo.mode.translate",
-    label = "Gizmo Translate",
-    is_available = can_change_gizmo
-)]
-pub(crate) fn gizmo_mode_translate(
-    _: In<OperatorParameters>,
-    mut mode: ResMut<GizmoMode>,
-) -> OperatorResult {
-    *mode = GizmoMode::Translate;
-    OperatorResult::Finished
-}
-
-#[operator(
-    id = "gizmo.mode.rotate",
-    label = "Gizmo Rotate",
-    is_available = can_change_gizmo
-)]
-pub fn gizmo_mode_rotate(_: In<OperatorParameters>, mut mode: ResMut<GizmoMode>) -> OperatorResult {
-    *mode = GizmoMode::Rotate;
-    OperatorResult::Finished
-}
-
-#[operator(
-    id = "gizmo.mode.scale",
-    label = "Gizmo Scale",
-    is_available = can_change_gizmo
-)]
-pub(crate) fn gizmo_mode_scale(
-    _: In<OperatorParameters>,
-    mut mode: ResMut<GizmoMode>,
-) -> OperatorResult {
-    *mode = GizmoMode::Scale;
-    OperatorResult::Finished
+/// Space toggle is allowed in any edit mode. Modal drags block it via
+/// `is_modal_running`; the toggle is a no-op when no gizmo is visible.
+fn can_toggle_space(keybind_focus: KeybindFocus, active: ActiveModalQuery) -> bool {
+    !keybind_focus.is_typing() && !active.is_modal_running()
 }
 
 #[operator(
     id = "gizmo.space.toggle",
     label = "Toggle Gizmo Space",
-    is_available = can_change_gizmo
+    is_available = can_toggle_space
 )]
 pub(crate) fn gizmo_space_toggle(
     _: In<OperatorParameters>,

--- a/src/gizmos.rs
+++ b/src/gizmos.rs
@@ -7,6 +7,7 @@ use bevy::{
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 
+use crate::active_tool::ActiveTool;
 use crate::default_style;
 use crate::{
     modal_transform::ModalTransformState,
@@ -48,14 +49,6 @@ const AXIS_HIT_DISTANCE: f32 = 35.0;
 const EPSILON: f32 = 1e-6;
 
 #[derive(Resource, Default, PartialEq, Eq, Clone, Copy, Debug)]
-pub enum GizmoMode {
-    #[default]
-    Translate,
-    Rotate,
-    Scale,
-}
-
-#[derive(Resource, Default, PartialEq, Eq, Clone, Copy, Debug)]
 pub enum GizmoSpace {
     #[default]
     World,
@@ -95,7 +88,7 @@ pub struct TransformGizmosPlugin;
 
 impl Plugin for TransformGizmosPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<GizmoMode>()
+        app.init_resource::<ActiveTool>()
             .init_resource::<GizmoSpace>()
             .init_resource::<GizmoDragState>()
             .init_resource::<GizmoHoverState>()
@@ -149,7 +142,7 @@ pub(crate) fn handle_gizmo_hover(
     transforms: Query<&GlobalTransform, With<Selected>>,
     camera_query: Query<(&Camera, &GlobalTransform, &Projection), With<MainViewportCamera>>,
     cursor: crate::viewport::UiCursorPos,
-    mode: Res<GizmoMode>,
+    mode: Res<ActiveTool>,
     space: Res<GizmoSpace>,
     mut hover: ResMut<GizmoHoverState>,
     drag_state: Res<GizmoDragState>,
@@ -199,8 +192,12 @@ pub(crate) fn handle_gizmo_hover(
     };
 
     let gizmo_pos = global_tf.translation();
+    if matches!(*mode, ActiveTool::Select) {
+        return;
+    }
+
     // Scale is inherently local, so force local orientation so handles match transform.scale axes
-    let effective_space = if *mode == GizmoMode::Scale {
+    let effective_space = if *mode == ActiveTool::Scale {
         &GizmoSpace::Local
     } else {
         &space
@@ -221,7 +218,7 @@ pub(crate) fn handle_gizmo_hover(
 
     for (axis, dir) in &axes {
         let dist = match *mode {
-            GizmoMode::Translate | GizmoMode::Scale => {
+            ActiveTool::Translate | ActiveTool::Scale => {
                 let start = gizmo_pos + *dir * (AXIS_START_OFFSET * scale);
                 let endpoint = gizmo_pos + *dir * (AXIS_LENGTH * scale);
                 let Some(start_screen) = camera.world_to_viewport(cam_tf, start).ok() else {
@@ -232,7 +229,7 @@ pub(crate) fn handle_gizmo_hover(
                 };
                 point_to_segment_dist(viewport_cursor, start_screen, end_screen)
             }
-            GizmoMode::Rotate => point_to_ring_screen_dist(
+            ActiveTool::Rotate => point_to_ring_screen_dist(
                 viewport_cursor,
                 camera,
                 cam_tf,
@@ -240,6 +237,7 @@ pub(crate) fn handle_gizmo_hover(
                 *dir,
                 ROTATE_RING_RADIUS * scale,
             ),
+            ActiveTool::Select => continue,
         };
         if dist < threshold && dist < best_dist {
             best_dist = dist;
@@ -289,7 +287,7 @@ fn gizmo_drag_invoke_trigger(
     description = "Drag the active transform gizmo to translate / rotate / scale the \
                    primary selection. Modal: commits on LMB release, cancels on \
                    Escape (restoring the start transform). Mode and axis come from \
-                   the toolbar's `GizmoMode` resource and the click-time \
+                   the toolbar's `ActiveTool` resource and the click-time \
                    `GizmoHoverState`.",
     modal = true,
     allows_undo = true,
@@ -304,7 +302,7 @@ pub fn gizmo_drag(
     mut cursor_query: Query<&mut CursorOptions, With<Window>>,
     mouse: Res<ButtonInput<MouseButton>>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    mode: Res<GizmoMode>,
+    mode: Res<ActiveTool>,
     space: Res<GizmoSpace>,
     hover: Res<GizmoHoverState>,
     mut drag_state: ResMut<GizmoDragState>,
@@ -388,7 +386,7 @@ pub fn gizmo_drag(
         return OperatorResult::Finished;
     };
 
-    let effective_space = if *mode == GizmoMode::Scale {
+    let effective_space = if *mode == ActiveTool::Scale {
         &GizmoSpace::Local
     } else {
         &space
@@ -403,8 +401,12 @@ pub fn gizmo_drag(
     let ctrl = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
     let mouse_delta = viewport_cursor - drag_state.drag_start_screen;
 
+    if matches!(*mode, ActiveTool::Select) {
+        return OperatorResult::Finished;
+    }
+
     match *mode {
-        GizmoMode::Translate => {
+        ActiveTool::Translate => {
             let drag_start_pos = drag_state.start_transform.translation;
             let Ok(origin_screen) = camera.world_to_viewport(cam_tf, drag_start_pos) else {
                 return OperatorResult::Running;
@@ -422,7 +424,7 @@ pub fn gizmo_drag(
             let snapped = snap_settings.snap_translate_vec3_if(axis_dir * projected, ctrl);
             transform.translation = drag_state.start_transform.translation + snapped;
         }
-        GizmoMode::Rotate => {
+        ActiveTool::Rotate => {
             let screen_axis = match axis {
                 GizmoAxis::X => Vec2::Y,
                 GizmoAxis::Y => Vec2::X,
@@ -433,7 +435,7 @@ pub fn gizmo_drag(
             transform.rotation =
                 Quat::from_axis_angle(axis_dir, angle) * drag_state.start_transform.rotation;
         }
-        GizmoMode::Scale => {
+        ActiveTool::Scale => {
             let Ok(origin_screen) = camera.world_to_viewport(cam_tf, gizmo_pos) else {
                 return OperatorResult::Running;
             };
@@ -450,6 +452,7 @@ pub fn gizmo_drag(
             }
             transform.scale = snap_settings.snap_scale_vec3_if(new_scale, ctrl);
         }
+        ActiveTool::Select => {}
     }
     OperatorResult::Running
 }
@@ -487,13 +490,17 @@ fn draw_gizmos(
     transforms: Query<&GlobalTransform, With<Selected>>,
     camera_query: Query<(Entity, &GlobalTransform, &Projection), With<MainViewportCamera>>,
     active: Res<crate::viewport::ActiveViewport>,
-    mode: Res<GizmoMode>,
+    mode: Res<ActiveTool>,
     space: Res<GizmoSpace>,
     hover: Res<GizmoHoverState>,
     drag_state: Res<GizmoDragState>,
     modal: Res<ModalTransformState>,
     edit_mode: Res<crate::brush::EditMode>,
 ) {
+    if matches!(*mode, ActiveTool::Select) {
+        return;
+    }
+
     // Hide gizmo during modal operations or brush edit mode
     if modal.active.is_some() || *edit_mode != crate::brush::EditMode::Object {
         return;
@@ -519,7 +526,7 @@ fn draw_gizmos(
     };
 
     let pos = global_tf.translation();
-    let effective_space = if *mode == GizmoMode::Scale {
+    let effective_space = if *mode == ActiveTool::Scale {
         &GizmoSpace::Local
     } else {
         &space
@@ -544,7 +551,7 @@ fn draw_gizmos(
     let z_color = axis_color(GizmoAxis::Z, active_axis, dragging);
 
     match *mode {
-        GizmoMode::Translate => {
+        ActiveTool::Translate => {
             gizmos
                 .arrow(
                     pos + right * (AXIS_START_OFFSET * scale),
@@ -567,7 +574,7 @@ fn draw_gizmos(
                 )
                 .with_tip_length(AXIS_TIP_LENGTH * scale);
         }
-        GizmoMode::Rotate => {
+        ActiveTool::Rotate => {
             // Draw rotation rings
             gizmos.circle(
                 Isometry3d::new(pos, Quat::from_rotation_arc(Vec3::Z, right)),
@@ -585,7 +592,7 @@ fn draw_gizmos(
                 z_color,
             );
         }
-        GizmoMode::Scale => {
+        ActiveTool::Scale => {
             // Draw scale handles: lines with cubes at the end
             let cube_half = SCALE_CUBE_SIZE * scale;
             for (dir, color) in [(right, x_color), (up, y_color), (forward, z_color)] {
@@ -622,6 +629,7 @@ fn draw_gizmos(
                 gizmos.line(corners[3], corners[7], color);
             }
         }
+        ActiveTool::Select => {}
     }
 }
 

--- a/src/keybind_settings.rs
+++ b/src/keybind_settings.rs
@@ -697,6 +697,7 @@ fn capture_keybind_recording(
             ctrl,
             shift,
             alt,
+            mouse: None,
         };
 
         // If we're in conflict confirmation mode, check if user pressed the same key

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -12,19 +12,20 @@ use jackdaw_localization::LocalizedText;
 
 use crate::{
     EditorEntity,
+    active_tool::ActiveTool,
     brush::{BrushEditMode, EditMode},
     draw_brush::ActivateDrawBrushModalOp,
     edit_mode_ops::{
-        EditModeClipOp, EditModeEdgeOp, EditModeFaceOp, EditModeKnifeOp, EditModeObjectOp,
-        EditModeVertexOp,
+        EditModeClipOp, EditModeEdgeOp, EditModeFaceOp, EditModeKnifeOp, EditModeVertexOp,
     },
-    gizmo_ops::{GizmoModeRotateOp, GizmoModeScaleOp, GizmoModeTranslateOp, GizmoSpaceToggleOp},
-    gizmos::{GizmoMode, GizmoSpace},
+    gizmo_ops::GizmoSpaceToggleOp,
+    gizmos::GizmoSpace,
     hierarchy::{HierarchyPanel, HierarchyShowAllButton, HierarchyTreeContainer},
     inspector::Inspector,
     measure_tool::MeasureDistanceOp,
     physics_tool::PhysicsActivateOp,
     remote::ConnectionManager,
+    tool_ops::{ToolRotateOp, ToolScaleOp, ToolSelectOp, ToolTranslateOp},
     viewport::SceneViewport,
 };
 
@@ -482,15 +483,15 @@ fn toolbar() -> impl Bundle {
         BackgroundColor(tokens::PANEL_HEADER_BG),
         BorderColor::all(tokens::TOOLBAR_BORDER),
         children![
-            toolbar_op_button::<GizmoModeTranslateOp>(Icon::Move3d),
-            toolbar_op_button::<GizmoModeRotateOp>(Icon::Rotate3d),
-            toolbar_op_button::<GizmoModeScaleOp>(Icon::Scale3d),
+            toolbar_op_button::<ToolSelectOp>(Icon::MousePointer),
+            toolbar_op_button::<ToolTranslateOp>(Icon::Move3d),
+            toolbar_op_button::<ToolRotateOp>(Icon::Rotate3d),
+            toolbar_op_button::<ToolScaleOp>(Icon::Scale3d),
             separator::separator(separator::SeparatorProps::vertical()),
             // Gizmo space toggle. Active highlight = `Local`; default
             // = `World`. Tooltip is the discoverability path.
             toolbar_op_button::<GizmoSpaceToggleOp>(Icon::Globe),
             separator::separator(separator::SeparatorProps::vertical()),
-            toolbar_op_button::<EditModeObjectOp>(Icon::MousePointer2),
             toolbar_op_button::<ActivateDrawBrushModalOp>(Icon::Box),
             toolbar_op_button::<MeasureDistanceOp>(Icon::RulerDimensionLine),
             toolbar_op_button::<EditModeVertexOp>(Icon::CircleDot),
@@ -708,7 +709,7 @@ fn scene_view() -> impl Bundle {
 /// loop is O(toolbar buttons), trivially cheap.
 pub fn update_toolbar_button_variants(
     edit_mode: Res<EditMode>,
-    gizmo_mode: Res<GizmoMode>,
+    active_tool: Res<ActiveTool>,
     gizmo_space: Res<GizmoSpace>,
     active_modal: ActiveModalQuery,
     mut buttons: Query<(&ButtonOperatorCall, &mut ButtonVariant)>,
@@ -722,16 +723,16 @@ pub fn update_toolbar_button_variants(
         // pick this up automatically through the fall-through arm.
         let active = if modal_running {
             active_modal.is_operator(&call.id)
-        } else if call.id == GizmoModeTranslateOp::ID {
-            *gizmo_mode == GizmoMode::Translate
-        } else if call.id == GizmoModeRotateOp::ID {
-            *gizmo_mode == GizmoMode::Rotate
-        } else if call.id == GizmoModeScaleOp::ID {
-            *gizmo_mode == GizmoMode::Scale
+        } else if call.id == ToolTranslateOp::ID {
+            *active_tool == ActiveTool::Translate
+        } else if call.id == ToolRotateOp::ID {
+            *active_tool == ActiveTool::Rotate
+        } else if call.id == ToolScaleOp::ID {
+            *active_tool == ActiveTool::Scale
         } else if call.id == GizmoSpaceToggleOp::ID {
             *gizmo_space == GizmoSpace::Local
-        } else if call.id == EditModeObjectOp::ID {
-            *edit_mode == EditMode::Object
+        } else if call.id == ToolSelectOp::ID {
+            *active_tool == ActiveTool::Select
         } else if call.id == EditModeVertexOp::ID {
             *edit_mode == EditMode::BrushEdit(BrushEditMode::Vertex)
         } else if call.id == EditModeEdgeOp::ID {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Main crate for the Jackdaw editor.
 //! Usage of this crate is meant for headless operation. If you want to interact with the jackdaw API for extensions, use the `jackdaw_api` crate instead.
+pub mod active_tool;
 pub mod add_entity_picker;
 pub mod alignment_guides;
 pub mod app_ops;
@@ -69,6 +70,7 @@ pub mod selection;
 pub mod snapping;
 pub mod status_bar;
 pub mod terrain;
+pub mod tool_ops;
 pub mod transform_ops;
 pub mod undo_snapshot;
 pub mod view_modes;

--- a/src/modal_transform.rs
+++ b/src/modal_transform.rs
@@ -6,8 +6,9 @@ use bevy::{
 };
 
 use crate::{
+    active_tool::ActiveTool,
     commands::SetTransform,
-    gizmos::{GizmoAxis, GizmoDragState, GizmoHoverState, GizmoMode},
+    gizmos::{GizmoAxis, GizmoDragState, GizmoHoverState},
     selection::Selection,
     snapping::SnapSettings,
     viewport::{MainViewportCamera, SceneViewport},
@@ -98,7 +99,7 @@ impl Plugin for ModalTransformPlugin {
 
 fn snap_toggle(
     mouse: Res<ButtonInput<MouseButton>>,
-    mode: Res<GizmoMode>,
+    mode: Res<ActiveTool>,
     modal: Res<ModalTransformState>,
     mut snap_settings: ResMut<SnapSettings>,
 ) {
@@ -108,9 +109,10 @@ fn snap_toggle(
 
     if mouse.just_pressed(MouseButton::Middle) {
         match *mode {
-            GizmoMode::Translate => snap_settings.translate_snap = !snap_settings.translate_snap,
-            GizmoMode::Rotate => snap_settings.rotate_snap = !snap_settings.rotate_snap,
-            GizmoMode::Scale => snap_settings.scale_snap = !snap_settings.scale_snap,
+            ActiveTool::Select => {}
+            ActiveTool::Translate => snap_settings.translate_snap = !snap_settings.translate_snap,
+            ActiveTool::Rotate => snap_settings.rotate_snap = !snap_settings.rotate_snap,
+            ActiveTool::Scale => snap_settings.scale_snap = !snap_settings.scale_snap,
         }
     }
 }

--- a/src/status_bar.rs
+++ b/src/status_bar.rs
@@ -3,10 +3,11 @@ use jackdaw_feathers::status_bar::{StatusBarCenter, StatusBarLeft, StatusBarRigh
 
 use crate::{
     EditorEntity,
+    active_tool::ActiveTool,
     brush::{BrushEditMode, EditMode},
     build_status::{BuildState, BuildStatus},
     draw_brush::DrawBrushState,
-    gizmos::{GizmoMode, GizmoSpace},
+    gizmos::GizmoSpace,
     modal_transform::{ModalOp, ModalTransformState},
     scene_io::{SceneDirtyState, SceneFilePath},
 };
@@ -119,7 +120,7 @@ fn update_status_center(
 pub struct SceneStatsText;
 
 fn update_status_right(
-    mode: Res<GizmoMode>,
+    mode: Res<ActiveTool>,
     space: Res<GizmoSpace>,
     modal: Res<ModalTransformState>,
     edit_mode: Res<EditMode>,
@@ -227,9 +228,10 @@ fn update_status_right(
     }
 
     let mode_str = match *mode {
-        GizmoMode::Translate => "Translate",
-        GizmoMode::Rotate => "Rotate",
-        GizmoMode::Scale => "Scale",
+        ActiveTool::Select => "Select",
+        ActiveTool::Translate => "Translate",
+        ActiveTool::Rotate => "Rotate",
+        ActiveTool::Scale => "Scale",
     };
     let space_str = match *space {
         GizmoSpace::World => "World",

--- a/src/tool_ops.rs
+++ b/src/tool_ops.rs
@@ -1,0 +1,157 @@
+//! Tool switch operators: Select, Translate, Rotate, Scale.
+//!
+//! Bound to Q/W/E/R via `bevy_enhanced_input`. Each action is guarded
+//! by a `BlockBy` referencing an RMB-held sentinel so the keys do not
+//! fire while the user is flying the camera.
+
+use bevy::prelude::*;
+use bevy_enhanced_input::prelude::{Press, *};
+use jackdaw_api::prelude::*;
+
+use crate::active_tool::ActiveTool;
+use crate::core_extension::CoreExtensionInputContext;
+use crate::keybind_focus::KeybindFocus;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<ToolSelectOp>()
+        .register_operator::<ToolTranslateOp>()
+        .register_operator::<ToolRotateOp>()
+        .register_operator::<ToolScaleOp>();
+
+    let ext = ctx.id();
+    ctx.entity_mut().world_scope(|world| {
+        let rmb_guard = world
+            .spawn((
+                Action::<RmbHeldGuard>::new(),
+                ActionOf::<CoreExtensionInputContext>::new(ext),
+                bindings![MouseButton::Right],
+            ))
+            .id();
+
+        world.spawn((
+            Action::<ToolSelectOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            BlockBy::single(rmb_guard),
+            bindings![(KeyCode::KeyQ, Press::default())],
+        ));
+        world.spawn((
+            Action::<ToolTranslateOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            BlockBy::single(rmb_guard),
+            bindings![(KeyCode::KeyW, Press::default())],
+        ));
+        world.spawn((
+            Action::<ToolRotateOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            BlockBy::single(rmb_guard),
+            bindings![(KeyCode::KeyE, Press::default())],
+        ));
+        world.spawn((
+            Action::<ToolScaleOp>::new(),
+            ActionOf::<CoreExtensionInputContext>::new(ext),
+            BlockBy::single(rmb_guard),
+            bindings![(KeyCode::KeyR, Press::default())],
+        ));
+    });
+}
+
+/// Tool switching is allowed in any edit mode (Object / Vertex / Edge / Face).
+/// In-flight brush drags are blocked by `is_modal_running` since drag systems
+/// install an `ActiveModalOperator` for their duration.
+fn can_change_tool(keybind_focus: KeybindFocus, active: ActiveModalQuery) -> bool {
+    !keybind_focus.is_typing() && !active.is_modal_running()
+}
+
+pub(crate) fn tool_select_impl(world: &mut World) {
+    world.insert_resource(ActiveTool::Select);
+    crate::edit_mode_ops::set_edit_mode_object(world);
+}
+
+pub(crate) fn tool_translate_impl(world: &mut World) {
+    world.insert_resource(ActiveTool::Translate);
+}
+
+pub(crate) fn tool_rotate_impl(world: &mut World) {
+    world.insert_resource(ActiveTool::Rotate);
+}
+
+pub(crate) fn tool_scale_impl(world: &mut World) {
+    world.insert_resource(ActiveTool::Scale);
+}
+
+#[operator(id = "tool.select", label = "Select Tool", is_available = can_change_tool)]
+pub fn tool_select(_: In<OperatorParameters>, world: &mut World) -> OperatorResult {
+    tool_select_impl(world);
+    OperatorResult::Finished
+}
+
+#[operator(
+    id = "tool.translate",
+    label = "Translate Tool",
+    is_available = can_change_tool
+)]
+pub fn tool_translate(_: In<OperatorParameters>, world: &mut World) -> OperatorResult {
+    tool_translate_impl(world);
+    OperatorResult::Finished
+}
+
+#[operator(id = "tool.rotate", label = "Rotate Tool", is_available = can_change_tool)]
+pub fn tool_rotate(_: In<OperatorParameters>, world: &mut World) -> OperatorResult {
+    tool_rotate_impl(world);
+    OperatorResult::Finished
+}
+
+#[operator(id = "tool.scale", label = "Scale Tool", is_available = can_change_tool)]
+pub fn tool_scale(_: In<OperatorParameters>, world: &mut World) -> OperatorResult {
+    tool_scale_impl(world);
+    OperatorResult::Finished
+}
+
+/// Sentinel action: fires while RMB is held. Used as a `BlockBy`
+/// guard so Q/W/E/R do not fire during camera fly.
+#[derive(InputAction)]
+#[action_output(bool)]
+struct RmbHeldGuard;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::brush::{BrushEditMode, EditMode};
+    use bevy::app::App;
+    use bevy::prelude::World;
+
+    fn world_with_resources() -> World {
+        let mut app = App::new();
+        app.init_resource::<ActiveTool>()
+            .init_resource::<EditMode>();
+        app.init_resource::<crate::brush::BrushSelection>();
+        app.init_resource::<crate::draw_brush::DrawBrushState>();
+        std::mem::take(app.world_mut())
+    }
+
+    #[test]
+    fn tool_select_sets_select_and_resets_edit_mode() {
+        let mut world = world_with_resources();
+        world.insert_resource(ActiveTool::Translate);
+        world.insert_resource(EditMode::BrushEdit(BrushEditMode::Vertex));
+
+        super::tool_select_impl(&mut world);
+
+        assert_eq!(*world.resource::<ActiveTool>(), ActiveTool::Select);
+        assert_eq!(*world.resource::<EditMode>(), EditMode::Object);
+    }
+
+    #[test]
+    fn tool_translate_only_sets_tool() {
+        let mut world = world_with_resources();
+        world.insert_resource(EditMode::BrushEdit(BrushEditMode::Vertex));
+
+        super::tool_translate_impl(&mut world);
+
+        assert_eq!(*world.resource::<ActiveTool>(), ActiveTool::Translate);
+        assert_eq!(
+            *world.resource::<EditMode>(),
+            EditMode::BrushEdit(BrushEditMode::Vertex)
+        );
+    }
+}

--- a/src/undo_snapshot.rs
+++ b/src/undo_snapshot.rs
@@ -17,8 +17,9 @@ use jackdaw_api_internal::snapshot::{ActiveSnapshotter, SceneSnapshot, SceneSnap
 use jackdaw_avian_integration::PhysicsOverlayConfig;
 use jackdaw_jsn::SceneJsnAst;
 
+use crate::active_tool::ActiveTool;
 use crate::brush::EditMode;
-use crate::gizmos::{GizmoMode, GizmoSpace};
+use crate::gizmos::GizmoSpace;
 use crate::snapping::SnapSettings;
 use crate::view_modes::ViewModeSettings;
 use crate::viewport_overlays::OverlaySettings;
@@ -83,7 +84,7 @@ impl SceneSnapshot for JsnAstSnapshot {
 #[derive(Clone, PartialEq)]
 struct EditorStateSnapshot {
     edit_mode: EditMode,
-    gizmo_mode: GizmoMode,
+    active_tool: ActiveTool,
     gizmo_space: GizmoSpace,
     snap_settings: SnapSettings,
     view_mode: ViewModeSettings,
@@ -100,7 +101,7 @@ impl EditorStateSnapshot {
     fn capture(world: &World) -> Self {
         Self {
             edit_mode: *world.resource::<EditMode>(),
-            gizmo_mode: *world.resource::<GizmoMode>(),
+            active_tool: *world.resource::<ActiveTool>(),
             gizmo_space: *world.resource::<GizmoSpace>(),
             snap_settings: world.resource::<SnapSettings>().clone(),
             view_mode: world.resource::<ViewModeSettings>().clone(),
@@ -112,7 +113,7 @@ impl EditorStateSnapshot {
 
     fn apply(&self, world: &mut World) {
         *world.resource_mut::<EditMode>() = self.edit_mode;
-        *world.resource_mut::<GizmoMode>() = self.gizmo_mode;
+        *world.resource_mut::<ActiveTool>() = self.active_tool;
         *world.resource_mut::<GizmoSpace>() = self.gizmo_space;
         *world.resource_mut::<SnapSettings>() = self.snap_settings.clone();
         *world.resource_mut::<ViewModeSettings>() = self.view_mode.clone();

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -65,7 +65,7 @@ fn can_pass_params_to_operator() {
 }
 
 /// Verifies that the snapshot mechanism notices changes to editor-state
-/// resources (`EditMode`, `GizmoMode`, `ViewModeSettings`, ...). Two
+/// resources (`EditMode`, `ActiveTool`, `ViewModeSettings`, ...). Two
 /// snapshots taken either side of a resource mutation must compare
 /// unequal - if they compared equal, the operator dispatcher would
 /// silently drop the undo entry and Ctrl+Z wouldn't restore the old
@@ -75,8 +75,9 @@ fn can_pass_params_to_operator() {
 /// editor.
 #[test]
 fn snapshot_notices_editor_state_changes() {
+    use jackdaw::active_tool::ActiveTool;
     use jackdaw::brush::{BrushEditMode, EditMode};
-    use jackdaw::gizmos::{GizmoMode, GizmoSpace};
+    use jackdaw::gizmos::GizmoSpace;
     use jackdaw::snapping::SnapSettings;
     use jackdaw::view_modes::ViewModeSettings;
     use jackdaw::viewport_overlays::OverlaySettings;
@@ -94,7 +95,7 @@ fn snapshot_notices_editor_state_changes() {
     // Flip each editor-state resource the snapshot should cover.
     *world.resource_mut::<ViewModeSettings>() = ViewModeSettings { wireframe: true };
     *world.resource_mut::<EditMode>() = EditMode::BrushEdit(BrushEditMode::Face);
-    *world.resource_mut::<GizmoMode>() = GizmoMode::Rotate;
+    *world.resource_mut::<ActiveTool>() = ActiveTool::Rotate;
     *world.resource_mut::<GizmoSpace>() = GizmoSpace::Local;
     world.resource_mut::<SnapSettings>().grid_power = 3;
     world.resource_mut::<OverlaySettings>().show_bounding_boxes = true;

--- a/tests/operator_availability.rs
+++ b/tests/operator_availability.rs
@@ -36,12 +36,13 @@ const HAS_PRIMARY_SELECTION_OPS: &[&str] = &[
     "animation.toggle_keyframe",
 ];
 
-/// Operators gated on `can_change_gizmo` (no modal running, no rename
-/// in progress). With a clean app these should already be available.
-const CAN_CHANGE_GIZMO_OPS: &[&str] = &[
-    "gizmo.mode.translate",
-    "gizmo.mode.rotate",
-    "gizmo.mode.scale",
+/// Tool and gizmo operators that should be available in a clean app
+/// (no modal running, no text field focused).
+const TOOL_AND_GIZMO_OPS: &[&str] = &[
+    "tool.select",
+    "tool.translate",
+    "tool.rotate",
+    "tool.scale",
     "gizmo.space.toggle",
 ];
 
@@ -86,9 +87,9 @@ fn has_primary_selection_gate_clears_with_selection() {
 }
 
 #[test]
-fn can_change_gizmo_gate_open_in_clean_app() {
+fn tool_and_gizmo_ops_available_in_clean_app() {
     let mut app = util::editor_test_app();
-    for id in CAN_CHANGE_GIZMO_OPS {
+    for id in TOOL_AND_GIZMO_OPS {
         let ready = app
             .world_mut()
             .operator(*id)

--- a/tests/operator_modals.rs
+++ b/tests/operator_modals.rs
@@ -19,9 +19,8 @@
 
 use bevy::prelude::*;
 use jackdaw::draw_brush::ActivateDrawBrushModalOp;
-use jackdaw::edit_mode_ops::EditModeObjectOp;
-use jackdaw::gizmo_ops::GizmoModeRotateOp;
 use jackdaw::layout::update_toolbar_button_variants;
+use jackdaw::tool_ops::{ToolRotateOp, ToolSelectOp};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::{ActiveModalOperator, OperatorEntity};
 use jackdaw_feathers::button::{ButtonOperatorCall, ButtonVariant};
@@ -134,14 +133,14 @@ fn modal_dispatch_steals_toolbar_highlight() {
     let object_button = app
         .world_mut()
         .spawn((
-            ButtonOperatorCall::new(EditModeObjectOp::ID),
+            ButtonOperatorCall::new(ToolSelectOp::ID),
             ButtonVariant::Active,
         ))
         .id();
     let rotate_button = app
         .world_mut()
         .spawn((
-            ButtonOperatorCall::new(GizmoModeRotateOp::ID),
+            ButtonOperatorCall::new(ToolRotateOp::ID),
             ButtonVariant::Active,
         ))
         .id();

--- a/tests/operator_undo.rs
+++ b/tests/operator_undo.rs
@@ -13,7 +13,7 @@
 //! ```
 //!
 //! The snapshot capture covers `ViewModeSettings`, `OverlaySettings`,
-//! `EditMode`, `GizmoMode`, `GizmoSpace`, `SnapSettings`,
+//! `EditMode`, `ActiveTool`, `GizmoSpace`, `SnapSettings`,
 //! `PhysicsOverlayConfig`, `GroupEditState.active_group`, and the
 //! scene AST (see `src/undo_snapshot.rs`).
 //!
@@ -129,17 +129,30 @@ fn grid_decrease_round_trip() {
 }
 
 #[test]
-fn gizmo_mode_rotate_round_trip() {
-    // Default `GizmoMode` is `Translate`; rotate diverges, so the
+fn tool_rotate_round_trip() {
+    // Default `ActiveTool` is `Select`; rotate diverges, so the
     // snapshot diff is non-empty.
     let mut app = util::editor_test_app();
-    assert_undo_redo_round_trip(&mut app, "gizmo.mode.rotate");
+    assert_undo_redo_round_trip(&mut app, "tool.rotate");
 }
 
 #[test]
-fn gizmo_mode_scale_round_trip() {
+fn tool_select_round_trip_from_translate() {
+    // `tool.select` flips both `ActiveTool` and `EditMode`; starting
+    // from a non-default state proves the snapshot captures both.
     let mut app = util::editor_test_app();
-    assert_undo_redo_round_trip(&mut app, "gizmo.mode.scale");
+    *app.world_mut()
+        .resource_mut::<jackdaw::active_tool::ActiveTool>() =
+        jackdaw::active_tool::ActiveTool::Translate;
+    *app.world_mut().resource_mut::<jackdaw::brush::EditMode>() =
+        jackdaw::brush::EditMode::BrushEdit(jackdaw::brush::BrushEditMode::Vertex);
+    assert_undo_redo_round_trip(&mut app, "tool.select");
+}
+
+#[test]
+fn tool_scale_round_trip() {
+    let mut app = util::editor_test_app();
+    assert_undo_redo_round_trip(&mut app, "tool.scale");
 }
 
 #[test]

--- a/tests/prefab_lifecycle.rs
+++ b/tests/prefab_lifecycle.rs
@@ -3388,7 +3388,7 @@ fn spawn_instance_undo_via_framework_snapshot_round_trip_removes_instance() {
     // The JsnAstSnapshotter captures editor state alongside the AST;
     // initialize the resources it reads so its capture/apply don't panic.
     app.init_resource::<jackdaw::brush::EditMode>();
-    app.init_resource::<jackdaw::gizmos::GizmoMode>();
+    app.init_resource::<jackdaw::active_tool::ActiveTool>();
     app.init_resource::<jackdaw::gizmos::GizmoSpace>();
     app.init_resource::<jackdaw::snapping::SnapSettings>();
     app.init_resource::<jackdaw::view_modes::ViewModeSettings>();
@@ -3863,7 +3863,7 @@ fn typed_command_and_snapshot_diff_interleave_cleanly_on_undo() {
 
     // Initialize editor-state resources the snapshotter expects.
     app.init_resource::<jackdaw::brush::EditMode>();
-    app.init_resource::<jackdaw::gizmos::GizmoMode>();
+    app.init_resource::<jackdaw::active_tool::ActiveTool>();
     app.init_resource::<jackdaw::gizmos::GizmoSpace>();
     app.init_resource::<jackdaw::snapping::SnapSettings>();
     app.init_resource::<jackdaw::view_modes::ViewModeSettings>();


### PR DESCRIPTION
This adds Q/W/E/R support for a Select Tool, Transform Tool, Rotate Tool, and Scale Tool, respectively. This is an initial pass at separating out the "edit/object mode" and giving selection a dedicated tool:

<img width="410" height="129" alt="image" src="https://github.com/user-attachments/assets/4abc4e3b-8c6c-4411-b8ec-8c9ea6f1e9c6" />

Closes #285
