### PR TITLE
Fix the dynamic game template to not shadow the `GamePlugin` trait

### DIFF
--- a/templates/game/src/lib.rs.template
+++ b/templates/game/src/lib.rs.template
@@ -6,7 +6,7 @@
 //!
 //! # How this template is wired
 //!
-//! `GamePlugin::build` adds one system that rotates any entity
+//! `MyGamePlugin::build` adds one system that rotates any entity
 //! carrying the [`SpinningCube`] component while `PlayState::Playing`.
 //! **No entities are spawned from code.** Jackdaw's scene (the
 //! `.jsn` file) is the source of truth for level content, so a cube
@@ -50,9 +50,9 @@ pub struct SpinningCube {
 }
 
 #[derive(Default)]
-pub struct GamePlugin;
+pub struct MyGamePlugin;
 
-impl GamePlugin for GamePlugin {
+impl GamePlugin for MyGamePlugin {
     fn build(&self, ctx: &mut GameApp<'_>) {
         ctx.add_systems(Update, spin_cube.run_if(in_state(PlayState::Playing)));
     }
@@ -65,4 +65,4 @@ fn spin_cube(time: Res<Time>, mut cubes: Query<(&SpinningCube, &mut Transform)>)
     }
 }
 
-jackdaw_api::export_game!("{{project-name}}", GamePlugin);
+jackdaw_api::export_game!("{{project-name}}", MyGamePlugin);


### PR DESCRIPTION
This also makes the name of the game plugin structure consistent with the name used in `game-static`.

There was some conversation about changing the name of `GamePlugin` to `DynamicPlugin`, `EditorPlugin`, `JackdawPlugin`, `JackdawDynamicPlugin`, or something along those lines. Until a consensus is reached, I didn't want to push for that change, though that's totally something that can be done later.