### PR TITLE
Update manifold-csg and remove manifold-csg-sys pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,7 +4950,6 @@ dependencies = [
  "jackdaw_geometry",
  "jackdaw_scene_types",
  "manifold-csg",
- "manifold-csg-sys",
 ]
 
 [[package]]
@@ -6291,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "manifold-csg"
-version = "0.1.8"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7d61a2fed9e32a65e9f987505c01e7e1b1b34d32b3f75df3ecff77c246b78a"
+checksum = "7ba5f54cbee94b26c917504c18754dcf263896a98af7a28c7987f3187a21ca8f"
 dependencies = [
  "log",
  "manifold-csg-sys",
@@ -6302,9 +6301,9 @@ dependencies = [
 
 [[package]]
 name = "manifold-csg-sys"
-version = "3.4.107"
+version = "3.5.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ba98ad842ca99ec2752d2e556f43ce69aa3f8000bd55b188053b383f9cb095"
+checksum = "9e64dddec38e7f930b9a311adc289519aa2ad864c823082f9de3428d6fac6cb5"
 dependencies = [
  "cmake",
 ]

--- a/crates/jackdaw_csg/Cargo.toml
+++ b/crates/jackdaw_csg/Cargo.toml
@@ -11,12 +11,7 @@ glam.workspace = true
 jackdaw_geometry = { path = "../jackdaw_geometry", default-features = false }
 # manifold-csg pulls in manifold3d (C++ via cmake). Build prereqs:
 # cmake, a C++ compiler, git. See the crate README for details.
-manifold-csg = { version = "0.1", default-features = false }
-# Pin the FFI crate: `manifold-csg 0.1.8` has a too-loose constraint on
-# `manifold-csg-sys` and resolves against 3.5.x, which renamed several
-# FFI symbols and breaks the build. Constrain transitively to the last
-# compatible sys version. Drop once `manifold-csg` upgrades.
-manifold-csg-sys = { version = "=3.4.107", default-features = false }
+manifold-csg = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 jackdaw_scene_types.workspace = true


### PR DESCRIPTION
Update `manifold-csg` so that users can benefit from:
- https://github.com/zmerlynn/manifold-csg/issues/49

The `manifold-csg-sys` pin shouldn't be needed anymore, but I'm not sure so let me know if we still need a pin for some reason.