### PR TITLE
Add terrain authoring and export tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,9 +168,7 @@ fn delete_entity(
     params: In<OperatorParameters>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let Some(entity) = params.as_entity("entity") else {
-        return OperatorResult::Cancelled;
-    };
+    let entity = params.as_entity("entity")?;
     commands.entity(entity).despawn();
     OperatorResult::Finished
 }
@@ -178,7 +176,7 @@ fn delete_entity(
 
 Each entry in `params(...)` is `name(Type, default = ..., doc = "...")`. `default` and `doc` are optional. Supported types: `bool`, `i64`, `f64`, `String`, `Vec2`, `Vec3`, `Color`, `Entity`. Defaults are supported on `bool` / `i64` / `f64` / `String` for now.
 
-The schema is informational; it does not change how parameters are extracted at call time. Continue reading values via `params.as_int("...")` / `as_str("...")` / `as_entity("...")` etc. inside the function body. The `let Some(...) = ... else { return Cancelled }` pattern is the current shape; the long-term goal is `let entity = params.as_entity("entity")?;`, which needs `OperatorResult` to implement `Try` (and `FromResidual<Option<Infallible>>`). It's not wired up yet, so use the `let-else` form for now.
+The schema is informational; it does not change how parameters are extracted at call time. Continue reading values via `params.as_int("...")` / `as_str("...")` / `as_entity("...")` etc. inside the function body. `OperatorResult` implements `Try` (`FromResidual<Option<Infallible>>` and `FromResidual<Result<Infallible, E>>`), so `?` on an `Option`- or `Result`-returning call short-circuits to `OperatorResult::Cancelled` directly -- prefer it over the older `let Some(...) = ... else { return Cancelled }` form.
 
 A `# Parameters` heading in the function's `///` doc comment is still welcome for longer prose, but the macro `params(...)` block is the primary record. Keep both in sync.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5242,6 +5242,7 @@ version = "0.19.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/book/src/user-guide/terrain.md
+++ b/book/src/user-guide/terrain.md
@@ -44,13 +44,65 @@ runs on the CPU and rebuilds every chunk mesh when it
 finishes. Save before you click. We do not have a cancel
 button yet.
 
-## Texture painting
+## Paint channels
 
-Texture painting on terrain is on the roadmap but not built.
-Today the terrain takes a single material applied to the
-whole surface. If you need varied surface textures, blend in
-your fragment shader or split the heightmap into multiple
-terrains, each with its own material.
+Choose the paintbrush in the terrain toolbar to edit integer
+channels such as biome, ground type, or buildability. Add a
+channel and one or more palette values in the **Paint
+Channels** section, select the value to write, and drag over
+the terrain. Hold `Ctrl` while painting to restore value `0`.
+
+**Show Painted Values** tints the terrain with the active
+palette so the stored data is visible even before a game
+material consumes it. New channel and palette entries receive
+generated names and colours; project-specific descriptor
+names, integer widths, labels, values, and colours can also be
+authored directly in the scene document.
+
+## Quantization
+
+Enable quantization when the game needs a fixed metric grid or
+terraced elevations. **Cell Size** controls the world-space
+distance between samples and **Height Step** controls the
+elevation interval. Sculpt, generation, and erosion snap new
+changes while quantization is enabled. Click **Apply** once to
+snap heights that existed before it was enabled.
+
+Turning quantization off stops future snapping but does not
+alter heights that are already stored.
+
+## Scatter
+
+The **Scatter** section places model instances across the
+selected terrain. Add one or more model assets, then configure
+density, spacing, scale, yaw, normal alignment, and an optional
+paint-channel mask. A seed produces the same placement for the
+same terrain and channel data.
+
+Re-running the same scatter group replaces untouched generated
+instances. Instances moved, rotated, or scaled by hand are
+preserved. The whole run is a single undoable edit.
+
+## Sidecars and export
+
+Scene files keep the small terrain descriptor, while heights
+and per-cell channel values are stored beside the scene in
+versioned `.jdterrain` files. Save and move those sidecars with
+the `.bsn` scene that references them.
+
+For a headless runtime or another engine, export the authored
+terrain with:
+
+```text
+jd export-terrain path/to/scene.bsn --out path/to/export
+```
+
+The export contains height and channel images, a manifest, and
+placed-scene data. Quantized projects normally keep cell size
+and elevation step on the terrain; unquantized scenes can pass
+`--cell-size` and `--elevation-step` together for an export-only
+grid. Add `--raw-heights` when the consumer also needs the raw
+height buffer.
 
 ## Chunking
 

--- a/book/src/user-guide/terrain.md
+++ b/book/src/user-guide/terrain.md
@@ -104,6 +104,41 @@ and elevation step on the terrain; unquantized scenes can pass
 grid. Add `--raw-heights` when the consumer also needs the raw
 height buffer.
 
+### Export format contract
+
+This is a cross-repo contract: an importer in another repo is
+built against it, so treat the shapes below as stable.
+
+- `manifest.json`, `format_version: 2`. Bumped whenever a field
+  is added, removed, or reinterpreted; an importer should check
+  it and refuse (or degrade explicitly) on a version it does
+  not understand, rather than assume the shape it expects.
+- `heightmap.png` is a 16-bit grayscale PNG. Every pixel decodes
+  to a world-space height via
+  `height = manifest.heightmap.base_m + pixel * manifest.heightmap.step_m`
+  (`encoding: "unsigned-steps-from-base"`). Quantized exports
+  set `step_m` to the terrain's elevation step; unquantized
+  exports derive `step_m` from the actual authored height span
+  (not from `max_height_m`, which is a configured ceiling and
+  can differ from the real data range).
+- Each paint channel is its own PNG (`channels/<name>.png`, 8-
+  or 16-bit depending on the channel's element width) plus a
+  manifest entry: `name`, `file`, `bit_depth`, `element`
+  (`"u8"` / `"u16"`), and `palette` -- a list of
+  `{ value, label, color }` entries, `color` as `#rrggbb`.
+  Channel names are guaranteed unique in one export: the writer
+  refuses the whole export if the scene's channel names collide,
+  either exactly or after filename sanitization.
+- `placements.json`, its own `format_version: 1`, lists every
+  scattered / placed instance: `name`, `asset` (nullable),
+  `translation_m` / `rotation_quat` / `scale`, and `components`
+  (a free-form JSON map of any extra authored component data on
+  that instance).
+- `heights.f32`, present only with `--raw-heights`: the raw
+  height buffer as little-endian `f32`, row-major, unquantized
+  and unscaled -- for a consumer that wants the source values
+  rather than the quantized PNG encoding.
+
 ## Chunking
 
 Chunks are 32 cells per edge (`src/terrain/mod.rs::CHUNK_SIZE`).
@@ -123,9 +158,16 @@ renders at full resolution.
   knob to tune first. Defaults aim for a generic mountain;
   rolling hills want fewer iterations and a higher
   evaporation rate.
-- **Standalone game shows no terrain.** `jackdaw_runtime`
-  doesn't pull in `jackdaw_terrain`. If your game needs
-  terrain at runtime, add `jackdaw_terrain` to your
-  standalone `Cargo.toml` and bring whatever plugin /
-  systems you want into your game's plugin alongside
-  `JackdawPlugin`.
+- **Standalone game shows no terrain.** Two separate causes
+  land on the same symptom. First, `jackdaw_runtime` doesn't
+  pull in `jackdaw_terrain`: if your game needs terrain at
+  runtime, add `jackdaw_terrain` to your standalone
+  `Cargo.toml` and bring whatever plugin / systems you want
+  into your game's plugin alongside `JackdawPlugin`. Second,
+  even with the crate present, a terrain's heights and paint
+  channels live in a `.jdterrain` sidecar next to the `.bsn`
+  scene, not in the scene file itself (see "Sidecars and
+  export" above) -- if you load a `.bsn` scene directly at
+  runtime rather than through the `jd export-terrain` pipeline,
+  every referenced `.jdterrain` sidecar has to ship and load
+  alongside it, or the terrain reads as flat.

--- a/crates/jackdaw_api_internal/src/inspector.rs
+++ b/crates/jackdaw_api_internal/src/inspector.rs
@@ -124,7 +124,7 @@ pub fn seed_default_categories(r: &mut InspectorRegistry) {
         // Core transform/visibility components live in the Object tab.
         ("bevy_transform::components::transform::Transform", "object"),
         ("bevy_ecs::name::Name", "object"),
-        ("bevy_render::view::visibility::Visibility", "object"),
+        ("bevy_camera::visibility::Visibility", "object"),
         // Brush geometry lives in the Mesh tab. The real reflect path is
         // jackdaw_scene_types::types::Brush; the short alias is seeded as well so
         // any lookup using the unqualified form also resolves correctly.

--- a/crates/jackdaw_scene_types/src/lib.rs
+++ b/crates/jackdaw_scene_types/src/lib.rs
@@ -30,6 +30,7 @@ pub use node_id::{SCENE_NODE_ID_TYPE_PATH, SPARSE_MIN, SceneNodeId};
 pub use types::{
     Brush, BrushFaceData, BrushGroup, BrushPlane, BrushTopology, CustomProperties, DerivedFaceMesh,
     GltfSource, NavmeshRegion, PrefabBaseline, PropertyValue, SceneRootTag, Terrain,
+    TerrainChannel, TerrainChannelElement, TerrainPaletteEntry, TerrainQuantization,
 };
 
 use bevy::prelude::*;
@@ -77,6 +78,10 @@ impl Plugin for SceneTypesPlugin {
             .register_type::<GltfSource>()
             .register_type::<NavmeshRegion>()
             .register_type::<Terrain>()
+            .register_type::<TerrainChannel>()
+            .register_type::<TerrainChannelElement>()
+            .register_type::<TerrainPaletteEntry>()
+            .register_type::<TerrainQuantization>()
             .register_type::<MeshMirror>()
             .register_type::<ModifierStack>()
             .register_type::<ModifierEntry>()

--- a/crates/jackdaw_scene_types/src/types.rs
+++ b/crates/jackdaw_scene_types/src/types.rs
@@ -868,9 +868,10 @@ pub struct NavmeshRegion {
 ///
 /// Only the small, human-editable fields live here. The bulk per-cell
 /// arrays -- heights and every paint channel -- live in a binary sidecar
-/// beside the scene ([`jackdaw_terrain::sidecar`]), keyed by
-/// [`Terrain::data_path`]. A 512-resolution heightmap is 262,144 floats,
-/// which scene text cannot carry and stay readable in a `git diff`.
+/// beside the scene (`jackdaw_terrain::sidecar`), keyed by
+/// [`Terrain::data_path`]. A 512-resolution heightmap is 262,144 floats;
+/// serializing that as scene text defeats the point of a format you can
+/// read in a `git diff`.
 #[derive(Component, Reflect, Clone, Debug)]
 #[reflect(Component, Default, @crate::EditorCategory::new("Terrain"), @crate::EditorHidden)]
 pub struct Terrain {

--- a/crates/jackdaw_scene_types/src/types.rs
+++ b/crates/jackdaw_scene_types/src/types.rs
@@ -864,7 +864,13 @@ pub struct NavmeshRegion {
     pub connection_url: String,
 }
 
-/// Terrain heightmap component. Stores all data needed for serialization.
+/// Terrain shape and the descriptive parts of its data.
+///
+/// Only the small, human-editable fields live here. The bulk per-cell
+/// arrays -- heights and every paint channel -- live in a binary sidecar
+/// beside the scene ([`jackdaw_terrain::sidecar`]), keyed by
+/// [`Terrain::data_path`]. A 512-resolution heightmap is 262,144 floats,
+/// which scene text cannot carry and stay readable in a `git diff`.
 #[derive(Component, Reflect, Clone, Debug)]
 #[reflect(Component, Default, @crate::EditorCategory::new("Terrain"), @crate::EditorHidden)]
 pub struct Terrain {
@@ -874,19 +880,198 @@ pub struct Terrain {
     pub size: Vec2,
     /// Maximum height value for normalization.
     pub max_height: f32,
-    /// Row-major height data, length = resolution^2.
+    /// The paint channels this terrain declares, in project order.
+    ///
+    /// Descriptors only -- name, width, palette. They are small and a
+    /// person edits them, so they stay inline and diffable. The per-cell
+    /// values they describe live in the sidecar with the heights.
+    pub channels: Vec<TerrainChannel>,
+    /// Scene-relative path of this terrain's binary data sidecar.
+    ///
+    /// The editor keeps the decoded data in a resource keyed by this
+    /// string, which is why it has to travel on the component: a tab
+    /// swap round-trips the scene through BSN *text* and respawns every
+    /// entity, so a plain reflected `String` is the only thing that
+    /// survives the trip.
+    pub data_path: String,
+    /// Legacy inline heights, read from scenes written before the
+    /// sidecar existed.
+    ///
+    /// This is a migration inlet, not storage. The editor drains it into
+    /// the sidecar store on load and leaves it empty, so a scene saved by
+    /// this build writes `heights: []` and the real data goes to
+    /// [`Terrain::data_path`]. Read heights through the store, never
+    /// from here.
     pub heights: Vec<f32>,
+    /// Optional snapping of this terrain onto the game's own metric grid.
+    ///
+    /// Off by default, and a terrain that never touches it behaves
+    /// exactly as one authored before the setting existed.
+    pub quantization: TerrainQuantization,
 }
 
 impl Default for Terrain {
     fn default() -> Self {
-        let resolution = 256;
         Self {
-            resolution,
+            resolution: 256,
             size: Vec2::new(100.0, 100.0),
             max_height: 50.0,
-            heights: vec![0.0; (resolution * resolution) as usize],
+            channels: Vec::new(),
+            data_path: String::new(),
+            heights: Vec::new(),
+            quantization: TerrainQuantization::default(),
         }
+    }
+}
+
+impl Terrain {
+    /// Cell count this terrain's per-cell arrays must have.
+    pub fn cell_count(&self) -> usize {
+        (self.resolution as usize) * (self.resolution as usize)
+    }
+}
+
+/// Optional snapping of a terrain onto a game's own metric grid.
+///
+/// A game whose world is built out of 1 m cells and 0.25 m elevation
+/// steps wants a terrain that is exactly that, not one that happens to
+/// pass near it. With this on, sculpting snaps heights to multiples of
+/// [`TerrainQuantization::height_step`] as the user drags, the mesh is
+/// built flat-shaded so the terraces are visible, and
+/// [`TerrainQuantization::cell_size`] pins the terrain's XZ vertex
+/// spacing -- which is what makes an integer export lossless.
+///
+/// Both steps are opt-in independently: a project can want a metric cell
+/// size with continuous elevation, or terraced elevation at whatever
+/// size the terrain already is.
+/// The derived `Default` -- off, both steps zero -- is the contract: a
+/// terrain that never touches this field is byte-identical to one from
+/// before it existed.
+#[derive(Reflect, Clone, Debug, Default, PartialEq)]
+#[reflect(Default)]
+pub struct TerrainQuantization {
+    pub enabled: bool,
+    /// World units per cell edge in XZ. 0 leaves [`Terrain::size`] alone.
+    pub cell_size: f32,
+    /// World units per elevation step. 0 disables height snapping.
+    pub height_step: f32,
+}
+
+impl TerrainQuantization {
+    /// World-space XZ extent a terrain of `resolution` vertices needs for
+    /// its vertex spacing to equal [`Self::cell_size`] exactly.
+    ///
+    /// Vertex spacing is `size / (resolution - 1)` -- `resolution` counts
+    /// vertices, so a 256-vertex edge has 255 cells. Returns `None` when
+    /// there is no cell size to honour or the grid is too degenerate to
+    /// have a spacing.
+    pub fn world_size_for(&self, resolution: u32) -> Option<Vec2> {
+        if !self.enabled || !self.cell_size.is_finite() || self.cell_size <= 0.0 || resolution < 2 {
+            return None;
+        }
+        Some(Vec2::splat(self.cell_size * (resolution - 1) as f32))
+    }
+
+    /// The elevation step to snap to, or `None` when height snapping is
+    /// off for this terrain.
+    pub fn active_height_step(&self) -> Option<f32> {
+        if !self.enabled || !self.height_step.is_finite() || self.height_step <= 0.0 {
+            return None;
+        }
+        Some(self.height_step)
+    }
+}
+
+/// Storage width of a paint channel's values on disk.
+///
+/// Mirrors `jackdaw_terrain::ChannelElement`. It exists separately because
+/// `jackdaw_terrain` is deliberately dependency-light (`bevy_math` only)
+/// and this one has to be reflected to reach the scene document.
+#[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[reflect(Default)]
+pub enum TerrainChannelElement {
+    /// One byte per cell, values `0..=255`.
+    #[default]
+    U8,
+    /// Two bytes per cell, values `0..=65535`.
+    U16,
+}
+
+impl TerrainChannelElement {
+    /// Largest value this width can hold. Painting clamps to it.
+    pub fn max_value(self) -> u16 {
+        match self {
+            Self::U8 => u8::MAX as u16,
+            Self::U16 => u16::MAX,
+        }
+    }
+
+    /// Human-readable name, for a width picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::U8 => "u8 (0-255)",
+            Self::U16 => "u16 (0-65535)",
+        }
+    }
+
+    /// Every width, in picker order.
+    pub const ALL: [Self; 2] = [Self::U8, Self::U16];
+}
+
+/// One entry in a paint channel's palette: a value, what the project
+/// calls it, and how the editor draws it.
+///
+/// Jackdaw never interprets `label`. It is the project's word for what
+/// this value means -- "grass", "walkable", "spawn: heavy" -- and the
+/// editor only ever displays it.
+#[derive(Reflect, Clone, Debug, PartialEq)]
+#[reflect(Default)]
+pub struct TerrainPaletteEntry {
+    /// The value written into the channel when this entry is painted.
+    pub value: u16,
+    /// Project-defined name. Display only.
+    pub label: String,
+    /// Swatch colour, and the tint the viewport draws for this value.
+    pub color: Color,
+}
+
+impl Default for TerrainPaletteEntry {
+    fn default() -> Self {
+        Self {
+            value: 0,
+            label: "unset".to_string(),
+            color: Color::srgb(0.5, 0.5, 0.5),
+        }
+    }
+}
+
+/// A named per-cell integer layer over a terrain.
+///
+/// Only the descriptor lives here. The values are `resolution^2` entries
+/// in the terrain's sidecar. Jackdaw stores the name and palette as
+/// opaque data: it never validates them, ships defaults for them, or
+/// branches on them.
+#[derive(Reflect, Clone, Debug, Default, PartialEq)]
+#[reflect(Default)]
+pub struct TerrainChannel {
+    /// Project-defined name. Also the export filename for this layer.
+    pub name: String,
+    /// Storage width, and therefore the value ceiling.
+    pub element: TerrainChannelElement,
+    /// Named values with display colours, in project order.
+    pub palette: Vec<TerrainPaletteEntry>,
+}
+
+impl TerrainChannel {
+    /// The palette entry for a stored value, if the palette names it.
+    pub fn entry(&self, value: u16) -> Option<&TerrainPaletteEntry> {
+        self.palette.iter().find(|entry| entry.value == value)
+    }
+
+    /// Colour to draw a stored value with. Values the palette does not
+    /// name draw as unpainted ground rather than as an error.
+    pub fn color_of(&self, value: u16) -> Option<Color> {
+        self.entry(value).map(|entry| entry.color)
     }
 }
 
@@ -947,5 +1132,68 @@ mod tests {
     fn pyramid_has_four_sides_plus_base() {
         let p = Brush::pyramid(0.5, 0.5, 0.5);
         assert_eq!(p.faces.len(), 5); // 4 side faces + 1 base cap
+    }
+
+    #[test]
+    fn quantization_ships_off_and_inert() {
+        let q = TerrainQuantization::default();
+        assert!(!q.enabled);
+        assert_eq!(q.cell_size, 0.0);
+        assert_eq!(q.height_step, 0.0);
+        assert_eq!(q.world_size_for(256), None);
+        assert_eq!(q.active_height_step(), None);
+        assert_eq!(Terrain::default().quantization, q);
+    }
+
+    #[test]
+    fn cell_size_sets_a_world_size_whose_spacing_is_that_cell() {
+        let q = TerrainQuantization {
+            enabled: true,
+            cell_size: 1.0,
+            height_step: 0.0,
+        };
+        // 256 vertices is 255 cells, so a 1-unit cell wants 255 units.
+        let size = q.world_size_for(256).expect("a size for a live cell size");
+        assert_eq!(size, Vec2::splat(255.0));
+        assert_eq!(size.x / (256 - 1) as f32, 1.0);
+
+        let q = TerrainQuantization {
+            cell_size: 2.5,
+            ..q
+        };
+        assert_eq!(q.world_size_for(65), Some(Vec2::splat(160.0)));
+    }
+
+    #[test]
+    fn a_disabled_or_degenerate_quantization_asks_for_no_resize() {
+        let live = TerrainQuantization {
+            enabled: true,
+            cell_size: 1.5,
+            height_step: 0.25,
+        };
+        assert!(live.world_size_for(256).is_some());
+        assert_eq!(live.active_height_step(), Some(0.25));
+
+        // Off wins over any value.
+        let off = TerrainQuantization {
+            enabled: false,
+            ..live.clone()
+        };
+        assert_eq!(off.world_size_for(256), None);
+        assert_eq!(off.active_height_step(), None);
+
+        // Zero, negative and non-finite steps each opt out on their own.
+        for bad in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+            let q = TerrainQuantization {
+                cell_size: bad,
+                height_step: bad,
+                ..live.clone()
+            };
+            assert_eq!(q.world_size_for(256), None, "cell_size {bad}");
+            assert_eq!(q.active_height_step(), None, "height_step {bad}");
+        }
+
+        // A grid with no cells has no spacing to pin.
+        assert_eq!(live.world_size_for(1), None);
     }
 }

--- a/crates/jackdaw_snap/Cargo.toml
+++ b/crates/jackdaw_snap/Cargo.toml
@@ -10,5 +10,8 @@ repository = "https://github.com/jbuehler23/jackdaw"
 glam.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [lints]
 workspace = true

--- a/crates/jackdaw_snap/src/lib.rs
+++ b/crates/jackdaw_snap/src/lib.rs
@@ -1,6 +1,6 @@
 //! Engine-agnostic snapping math.
 //!
-//! [`SnapSettings`] holds the grid power and the per-tool snap toggles and
+//! [`SnapSettings`] holds the grid size and the per-tool snap toggles and
 //! increments, and computes snapped translation, rotation, and scale values.
 //! The math here is pure arithmetic over [`glam`] vectors with no engine
 //! dependency, so it can drive snapping in any host. The editor wraps this in
@@ -16,8 +16,10 @@ pub const GRID_POWER_MIN: i32 = -5;
 /// `2^GRID_POWER_MAX`.
 pub const GRID_POWER_MAX: i32 = 8;
 
-/// Snap toggles, increments, and the grid power. The grid size is derived from
-/// the power; the per-tool increments and flags drive the snap methods.
+/// Snap toggles, increments, and the grid size. The grid size is the
+/// explicit [`SnapSettings::grid_increment`] when one is set and the
+/// power-of-two ladder otherwise; the per-tool increments and flags drive
+/// the snap methods.
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct SnapSettings {
     pub translate_snap: bool,
@@ -26,8 +28,23 @@ pub struct SnapSettings {
     pub rotate_increment: f32,
     pub scale_snap: bool,
     pub scale_increment: f32,
-    /// Exponential grid power. Actual grid size = `2^grid_power`.
+    /// Exponential grid power. The grid size is `2^grid_power` unless
+    /// [`SnapSettings::grid_increment`] overrides it.
     pub grid_power: i32,
+    /// Explicit grid size in world units, or `0.0` for "derived from
+    /// `grid_power`".
+    ///
+    /// The power ladder is the right control for a world with no metric
+    /// of its own -- halving and doubling is how you find a working grid
+    /// by feel. A game built on 1.5 m or 2.5 m cells has already
+    /// decided, and no power of two will ever be its cell. This is the
+    /// way to say the number outright.
+    ///
+    /// `#[serde(default)]` because settings written before this field
+    /// existed have to keep loading, and its default is exactly the old
+    /// behaviour.
+    #[serde(default)]
+    pub grid_increment: f32,
 }
 
 impl Default for SnapSettings {
@@ -43,13 +60,23 @@ impl Default for SnapSettings {
             scale_snap: false,
             scale_increment: 0.1,
             grid_power,
+            grid_increment: 0.0,
         }
     }
 }
 
 impl SnapSettings {
-    /// Actual grid size derived from `grid_power`: `2^grid_power`.
+    /// The grid size in world units.
+    ///
+    /// An explicit [`SnapSettings::grid_increment`] wins: the two
+    /// controls are two ways of saying the same thing, so the one the
+    /// user touched last is the one that holds. Zero, negative and
+    /// non-finite increments fall back to the `2^grid_power` ladder
+    /// rather than yielding a grid nothing can snap to.
     pub fn grid_size(&self) -> f32 {
+        if self.grid_increment.is_finite() && self.grid_increment > 0.0 {
+            return self.grid_increment;
+        }
         2.0_f32.powi(self.grid_power)
     }
 
@@ -180,6 +207,81 @@ mod tests {
         assert!((s.grid_size() - 8.0).abs() < 1e-6);
         s.grid_power = -2;
         assert!((s.grid_size() - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn an_explicit_increment_beats_the_power() {
+        let s = SnapSettings {
+            grid_power: 3, // would be 8.0
+            grid_increment: 1.5,
+            ..SnapSettings::default()
+        };
+        assert!((s.grid_size() - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn an_increment_of_zero_falls_back_to_the_power() {
+        let mut s = SnapSettings {
+            grid_power: 3,
+            grid_increment: 0.0,
+            ..SnapSettings::default()
+        };
+        assert!((s.grid_size() - 8.0).abs() < 1e-6);
+
+        // So does anything that is not a usable interval.
+        for bad in [-1.5, f32::NAN, f32::INFINITY] {
+            s.grid_increment = bad;
+            assert!((s.grid_size() - 8.0).abs() < 1e-6, "increment {bad}");
+        }
+    }
+
+    #[test]
+    fn a_one_and_a_half_metre_grid_snaps_to_its_own_lattice() {
+        let s = SnapSettings {
+            grid_increment: 1.5,
+            ..SnapSettings::default()
+        };
+        // 2.2 is nearer 1.5 than 3.0; 2.3 is nearer 3.0.
+        assert!((s.snap_position_to_grid(Vec3::splat(2.2)) - Vec3::splat(1.5)).length() < 1e-5);
+        assert!((s.snap_position_to_grid(Vec3::splat(2.3)) - Vec3::splat(3.0)).length() < 1e-5);
+    }
+
+    #[test]
+    fn the_increment_ships_off_so_the_power_still_rules() {
+        let s = SnapSettings::default();
+        assert_eq!(s.grid_increment, 0.0);
+        assert!((s.grid_size() - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn settings_round_trip_through_serde() {
+        let s = SnapSettings {
+            grid_power: 1,
+            grid_increment: 2.5,
+            translate_snap: true,
+            ..SnapSettings::default()
+        };
+        let json = serde_json::to_string(&s).expect("serialize");
+        let back: SnapSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(back == s);
+        assert!((back.grid_size() - 2.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn settings_written_before_the_increment_existed_still_load() {
+        // Exactly the field set an earlier build wrote.
+        let legacy = r#"{
+            "translate_snap": false,
+            "translate_increment": 0.25,
+            "rotate_snap": false,
+            "rotate_increment": 0.2617994,
+            "scale_snap": false,
+            "scale_increment": 0.1,
+            "grid_power": -2
+        }"#;
+        let loaded: SnapSettings = serde_json::from_str(legacy).expect("deserialize legacy");
+        assert_eq!(loaded.grid_increment, 0.0);
+        assert!((loaded.grid_size() - 0.25).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/jackdaw_terrain/src/brush.rs
+++ b/crates/jackdaw_terrain/src/brush.rs
@@ -152,16 +152,32 @@ pub fn affected_chunks(
     radius: f32,
     chunk_size: u32,
 ) -> Vec<(u32, u32)> {
-    let (cx_count, cz_count) = heightmap.chunk_count(chunk_size);
+    affected_chunks_at(heightmap.resolution, center, radius, chunk_size)
+}
+
+/// Determine which chunks a brush stroke touches, given only the grid
+/// resolution.
+///
+/// Same result as [`affected_chunks`] without needing the heights, so a
+/// paint stroke over a channel can mark exactly the chunks a sculpt stroke
+/// of the same shape would.
+pub fn affected_chunks_at(
+    resolution: u32,
+    center: Vec2,
+    radius: f32,
+    chunk_size: u32,
+) -> Vec<(u32, u32)> {
+    if resolution < 2 || chunk_size == 0 {
+        return Vec::new();
+    }
+    let cells = resolution - 1;
+    let cx_count = cells.div_ceil(chunk_size);
+    let cz_count = cells.div_ceil(chunk_size);
 
     let min_gx = (center.x - radius).floor().max(0.0) as u32;
-    let max_gx = (center.x + radius)
-        .ceil()
-        .min(heightmap.resolution as f32 - 1.0) as u32;
+    let max_gx = (center.x + radius).ceil().min(resolution as f32 - 1.0) as u32;
     let min_gz = (center.y - radius).floor().max(0.0) as u32;
-    let max_gz = (center.y + radius)
-        .ceil()
-        .min(heightmap.resolution as f32 - 1.0) as u32;
+    let max_gz = (center.y + radius).ceil().min(resolution as f32 - 1.0) as u32;
 
     let min_cx = min_gx / chunk_size;
     let max_cx = (max_gx / chunk_size).min(cx_count - 1);
@@ -175,4 +191,32 @@ pub fn affected_chunks(
         }
     }
     chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_lookup_agrees_with_the_heightmap_form() {
+        let hm = Heightmap::new(65, Vec2::splat(64.0), 10.0);
+        let center = Vec2::new(40.0, 20.0);
+        assert_eq!(
+            affected_chunks(&hm, center, 5.0, 32),
+            affected_chunks_at(65, center, 5.0, 32),
+        );
+    }
+
+    #[test]
+    fn a_degenerate_grid_touches_no_chunks_instead_of_panicking() {
+        assert!(affected_chunks_at(0, Vec2::ZERO, 4.0, 32).is_empty());
+        assert!(affected_chunks_at(1, Vec2::ZERO, 4.0, 32).is_empty());
+        assert!(affected_chunks_at(65, Vec2::ZERO, 4.0, 0).is_empty());
+    }
+
+    #[test]
+    fn a_stroke_spanning_a_chunk_seam_marks_both_chunks() {
+        let touched = affected_chunks_at(65, Vec2::new(32.0, 32.0), 3.0, 32);
+        assert_eq!(touched.len(), 4, "got {touched:?}");
+    }
 }

--- a/crates/jackdaw_terrain/src/brush.rs
+++ b/crates/jackdaw_terrain/src/brush.rs
@@ -64,6 +64,14 @@ pub fn apply_brush(
     dt: f32,
     noise_fn: Option<&dyn Fn(f32, f32) -> f32>,
 ) {
+    // `compute_falloff` already swallows a non-finite falloff or distance
+    // via `f32::max`'s NaN-ignoring semantics, but `amount = strength * f
+    // * dt` below has no such protection: a non-finite radius, strength,
+    // or dt would otherwise write NaN straight into the heightmap.
+    if !radius.is_finite() || radius <= 0.0 || !strength.is_finite() || !dt.is_finite() {
+        return;
+    }
+
     let res = heightmap.resolution;
     let center_height = heightmap.sample_bilinear(center.x, center.y);
 
@@ -218,5 +226,51 @@ mod tests {
     fn a_stroke_spanning_a_chunk_seam_marks_both_chunks() {
         let touched = affected_chunks_at(65, Vec2::new(32.0, 32.0), 3.0, 32);
         assert_eq!(touched.len(), 4, "got {touched:?}");
+    }
+
+    /// I2 pinning test: a non-finite strength (parsed from a hand-typed
+    /// "nan" or "inf" in the strength field) must not poison the
+    /// heightmap. Before the guard, `amount = strength * f * dt` wrote
+    /// NaN directly into every cell the falloff touched.
+    #[test]
+    fn a_non_finite_strength_does_not_poison_the_heightmap() {
+        let mut hm = Heightmap::new(5, Vec2::splat(4.0), 10.0);
+        hm.heights = vec![1.0; 25];
+
+        apply_brush(
+            &mut hm,
+            SculptTool::Raise,
+            Vec2::new(2.0, 2.0),
+            2.0,
+            f32::NAN,
+            1.0,
+            1.0 / 60.0,
+            None,
+        );
+
+        assert!(
+            hm.heights.iter().all(|h| *h == 1.0),
+            "a non-finite strength must leave the heightmap untouched: {:?}",
+            hm.heights
+        );
+    }
+
+    #[test]
+    fn a_non_finite_radius_does_not_poison_the_heightmap() {
+        let mut hm = Heightmap::new(5, Vec2::splat(4.0), 10.0);
+        hm.heights = vec![1.0; 25];
+
+        apply_brush(
+            &mut hm,
+            SculptTool::Raise,
+            Vec2::new(2.0, 2.0),
+            f32::INFINITY,
+            1.0,
+            1.0,
+            1.0 / 60.0,
+            None,
+        );
+
+        assert!(hm.heights.iter().all(|h| *h == 1.0));
     }
 }

--- a/crates/jackdaw_terrain/src/channel.rs
+++ b/crates/jackdaw_terrain/src/channel.rs
@@ -1,0 +1,295 @@
+//! Named per-cell integer layers painted over a heightmap.
+//!
+//! A channel is whatever the project says it is. Jackdaw stores the name,
+//! the values, and the width; it never interprets them. Games use channels
+//! for material indices, biome ids, walkability, spawn weights, zoning --
+//! anything that is one small number per terrain cell.
+
+use bevy_math::Vec2;
+
+use crate::brush::compute_falloff;
+
+/// Storage width a channel's values are written with on disk.
+///
+/// Values always live in memory as `u16` so there is one paint path and one
+/// undo shape; the width only decides how many bytes a channel costs in the
+/// sidecar and what the largest paintable value is.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ChannelElement {
+    /// One byte per cell, values `0..=255`.
+    #[default]
+    U8,
+    /// Two bytes per cell, values `0..=65535`.
+    U16,
+}
+
+impl ChannelElement {
+    /// Largest value this width can hold. Painting clamps to it.
+    pub fn max_value(self) -> u16 {
+        match self {
+            Self::U8 => u16::from(u8::MAX),
+            Self::U16 => u16::MAX,
+        }
+    }
+
+    /// Bytes one cell occupies on disk.
+    pub fn byte_width(self) -> usize {
+        match self {
+            Self::U8 => 1,
+            Self::U16 => 2,
+        }
+    }
+
+    /// Wire tag used by the sidecar format.
+    pub fn tag(self) -> u8 {
+        match self {
+            Self::U8 => 0,
+            Self::U16 => 1,
+        }
+    }
+
+    /// Inverse of [`ChannelElement::tag`]. Returns `None` for unknown tags.
+    pub fn from_tag(tag: u8) -> Option<Self> {
+        match tag {
+            0 => Some(Self::U8),
+            1 => Some(Self::U16),
+            _ => None,
+        }
+    }
+}
+
+/// One named layer of per-cell values, row-major, `resolution^2` long.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelData {
+    /// Project-defined name. Opaque to jackdaw; used as the export filename.
+    pub name: String,
+    /// Storage width, and therefore the value ceiling.
+    pub element: ChannelElement,
+    /// Row-major values, length `resolution^2`.
+    pub values: Vec<u16>,
+}
+
+impl ChannelData {
+    /// A channel of `resolution^2` zeroes.
+    pub fn new(name: impl Into<String>, element: ChannelElement, resolution: u32) -> Self {
+        Self {
+            name: name.into(),
+            element,
+            values: vec![0; (resolution as usize) * (resolution as usize)],
+        }
+    }
+
+    /// Value at integer grid coordinates, or 0 out of bounds.
+    pub fn get(&self, resolution: u32, x: u32, z: u32) -> u16 {
+        if x >= resolution || z >= resolution {
+            return 0;
+        }
+        self.values[(z * resolution + x) as usize]
+    }
+
+    /// Grow or shrink to `resolution^2`, zero-filling any new cells.
+    ///
+    /// Used when a channel is added to a terrain that already has height
+    /// data, and when a terrain's resolution changes underneath it.
+    pub fn resize_to(&mut self, resolution: u32) {
+        let want = (resolution as usize) * (resolution as usize);
+        self.values.resize(want, 0);
+    }
+}
+
+/// Stamp `value` into a channel under a circular brush.
+///
+/// Integer channels cannot blend, so the brush is a threshold stamp rather
+/// than an accumulation: a cell is written when its falloff is at least
+/// `threshold`, and left alone otherwise. `threshold` of 0 writes the whole
+/// disc; raising it shrinks the written area inside the same visible ring,
+/// which is how a soft-edged brush behaves on discrete data.
+///
+/// `center` and `radius` are in grid cells. `value` is clamped to `element`.
+/// Returns the number of cells changed, so a caller can skip an undo entry
+/// for a stroke that did nothing.
+pub fn apply_channel_brush(
+    values: &mut [u16],
+    resolution: u32,
+    element: ChannelElement,
+    center: Vec2,
+    radius: f32,
+    falloff: f32,
+    threshold: f32,
+    value: u16,
+) -> usize {
+    if resolution == 0 || radius <= 0.0 {
+        return 0;
+    }
+    let value = value.min(element.max_value());
+    let res = resolution as i32;
+
+    let min_x = ((center.x - radius).floor() as i32).clamp(0, res - 1);
+    let max_x = ((center.x + radius).ceil() as i32).clamp(0, res - 1);
+    let min_z = ((center.y - radius).floor() as i32).clamp(0, res - 1);
+    let max_z = ((center.y + radius).ceil() as i32).clamp(0, res - 1);
+
+    let mut changed = 0;
+    for gz in min_z..=max_z {
+        for gx in min_x..=max_x {
+            let dist = ((gx as f32 - center.x).powi(2) + (gz as f32 - center.y).powi(2)).sqrt();
+            if compute_falloff(dist, radius, falloff) < threshold.max(f32::EPSILON) {
+                continue;
+            }
+            let idx = (gz * res + gx) as usize;
+            if values[idx] != value {
+                values[idx] = value;
+                changed += 1;
+            }
+        }
+    }
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn element_widths_and_ceilings() {
+        assert_eq!(ChannelElement::U8.byte_width(), 1);
+        assert_eq!(ChannelElement::U8.max_value(), 255);
+        assert_eq!(ChannelElement::U16.byte_width(), 2);
+        assert_eq!(ChannelElement::U16.max_value(), 65535);
+    }
+
+    #[test]
+    fn element_tags_round_trip() {
+        for e in [ChannelElement::U8, ChannelElement::U16] {
+            assert_eq!(ChannelElement::from_tag(e.tag()), Some(e));
+        }
+        assert_eq!(ChannelElement::from_tag(7), None);
+    }
+
+    #[test]
+    fn new_channel_is_zeroed_at_the_right_length() {
+        let c = ChannelData::new("biome", ChannelElement::U8, 8);
+        assert_eq!(c.values.len(), 64);
+        assert!(c.values.iter().all(|v| *v == 0));
+    }
+
+    #[test]
+    fn resize_zero_fills_new_cells_and_keeps_old_ones() {
+        let mut c = ChannelData::new("m", ChannelElement::U16, 2);
+        c.values = vec![1, 2, 3, 4];
+        c.resize_to(3);
+        assert_eq!(c.values.len(), 9);
+        assert_eq!(&c.values[..4], &[1, 2, 3, 4]);
+        assert!(c.values[4..].iter().all(|v| *v == 0));
+    }
+
+    #[test]
+    fn brush_stamps_a_disc_and_reports_changed_cells() {
+        let mut values = vec![0u16; 100];
+        let changed = apply_channel_brush(
+            &mut values,
+            10,
+            ChannelElement::U8,
+            Vec2::new(5.0, 5.0),
+            2.0,
+            1.0,
+            0.0,
+            3,
+        );
+        assert!(changed > 0);
+        assert_eq!(values[5 * 10 + 5], 3);
+        // A cell well outside the radius is untouched.
+        assert_eq!(values[0], 0);
+        // Painting the same value again changes nothing.
+        let again = apply_channel_brush(
+            &mut values,
+            10,
+            ChannelElement::U8,
+            Vec2::new(5.0, 5.0),
+            2.0,
+            1.0,
+            0.0,
+            3,
+        );
+        assert_eq!(again, 0);
+    }
+
+    #[test]
+    fn brush_clamps_value_to_the_element_ceiling() {
+        let mut values = vec![0u16; 25];
+        apply_channel_brush(
+            &mut values,
+            5,
+            ChannelElement::U8,
+            Vec2::new(2.0, 2.0),
+            1.5,
+            1.0,
+            0.0,
+            9000,
+        );
+        assert_eq!(values[2 * 5 + 2], 255);
+    }
+
+    #[test]
+    fn brush_at_the_edge_does_not_wrap_or_panic() {
+        let mut values = vec![0u16; 25];
+        apply_channel_brush(
+            &mut values,
+            5,
+            ChannelElement::U16,
+            Vec2::new(0.0, 0.0),
+            3.0,
+            1.0,
+            0.0,
+            42,
+        );
+        assert_eq!(values[0], 42);
+        // Nothing wrapped onto the opposite edge of row 0.
+        assert_eq!(values[4], 0);
+    }
+
+    #[test]
+    fn brush_outside_the_terrain_is_a_no_op() {
+        let mut values = vec![0u16; 25];
+        let changed = apply_channel_brush(
+            &mut values,
+            5,
+            ChannelElement::U8,
+            Vec2::new(50.0, 50.0),
+            2.0,
+            1.0,
+            0.0,
+            1,
+        );
+        assert_eq!(changed, 0);
+        assert!(values.iter().all(|v| *v == 0));
+    }
+
+    #[test]
+    fn a_high_threshold_writes_fewer_cells_than_a_low_one() {
+        let mut soft = vec![0u16; 400];
+        let wide = apply_channel_brush(
+            &mut soft,
+            20,
+            ChannelElement::U8,
+            Vec2::new(10.0, 10.0),
+            6.0,
+            1.0,
+            0.0,
+            1,
+        );
+        let mut hard = vec![0u16; 400];
+        let narrow = apply_channel_brush(
+            &mut hard,
+            20,
+            ChannelElement::U8,
+            Vec2::new(10.0, 10.0),
+            6.0,
+            1.0,
+            0.7,
+            1,
+        );
+        assert!(narrow < wide, "narrow {narrow} should be under wide {wide}");
+        assert!(narrow > 0);
+    }
+}

--- a/crates/jackdaw_terrain/src/erosion.rs
+++ b/crates/jackdaw_terrain/src/erosion.rs
@@ -29,6 +29,22 @@ pub struct ErosionParams {
     pub min_slope: f32,
 }
 
+/// Iterations above this are clamped down to it rather than run.
+///
+/// Each iteration costs up to `max_lifetime` steps, so an unbounded
+/// count -- typed into the UI, or passed by a script or a headless
+/// caller -- can hang the editor for an unbounded amount of time. This
+/// is well above the default (70,000) and any legitimate heavy use, and
+/// is enforced here regardless of which widget or caller set
+/// `iterations`, not just whatever limit an inspector field happens to
+/// impose.
+pub const MAX_ITERATIONS: u32 = 1_000_000;
+
+/// Clamp a requested iteration count to [`MAX_ITERATIONS`].
+fn clamp_iterations(requested: u32) -> u32 {
+    requested.min(MAX_ITERATIONS)
+}
+
 impl Default for ErosionParams {
     fn default() -> Self {
         Self {
@@ -56,11 +72,12 @@ impl Default for ErosionParams {
 pub fn hydraulic_erosion(heights: &mut [f32], resolution: u32, params: &ErosionParams) {
     let res = resolution as i32;
     let mut rng = rand::rng();
+    let iterations = clamp_iterations(params.iterations);
 
     // Precompute erosion brush weights
     let brush = compute_erosion_brush(params.erosion_radius as i32);
 
-    for _ in 0..params.iterations {
+    for _ in 0..iterations {
         // Random start position (avoid edges)
         let mut pos_x = rng.random_range(1.0..(res - 2) as f32);
         let mut pos_z = rng.random_range(1.0..(res - 2) as f32);
@@ -251,5 +268,26 @@ fn erode_at(
         if x >= 0 && x < res && z >= 0 && z < res {
             heights[(z * res + x) as usize] -= amount * brush.weights[i];
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// I11 pinning test: an iteration count typed into the UI (or set by
+    /// any other caller) is capped regardless of what requested it, since
+    /// each iteration costs real, unbounded wall-clock time.
+    #[test]
+    fn a_pathological_iteration_count_is_clamped() {
+        assert_eq!(clamp_iterations(u32::MAX), MAX_ITERATIONS);
+        assert_eq!(clamp_iterations(MAX_ITERATIONS + 1), MAX_ITERATIONS);
+    }
+
+    #[test]
+    fn ordinary_iteration_counts_are_left_alone() {
+        assert_eq!(clamp_iterations(70_000), 70_000);
+        assert_eq!(clamp_iterations(0), 0);
+        assert_eq!(clamp_iterations(MAX_ITERATIONS), MAX_ITERATIONS);
     }
 }

--- a/crates/jackdaw_terrain/src/lib.rs
+++ b/crates/jackdaw_terrain/src/lib.rs
@@ -1,11 +1,19 @@
 pub mod brush;
+pub mod channel;
 pub mod erosion;
 pub mod generate;
 pub mod heightmap;
 pub mod mesh;
+pub mod quantize;
+pub mod scatter;
+pub mod sidecar;
 
-pub use brush::{SculptTool, affected_chunks, apply_brush};
+pub use brush::{SculptTool, affected_chunks, affected_chunks_at, apply_brush};
+pub use channel::{ChannelData, ChannelElement, apply_channel_brush};
 pub use erosion::{ErosionParams, hydraulic_erosion};
 pub use generate::{GenerateSettings, NoiseType, generate_heightmap};
 pub use heightmap::Heightmap;
-pub use mesh::{ChunkMeshData, build_chunk_mesh_data};
+pub use mesh::{ChunkMeshData, build_chunk_mesh_data, build_chunk_mesh_data_flat};
+pub use quantize::{quantize_height, quantize_heights, quantize_region};
+pub use scatter::{Placement, ScatterMask, ScatterParams, scatter};
+pub use sidecar::{SidecarError, TerrainData};

--- a/crates/jackdaw_terrain/src/mesh.rs
+++ b/crates/jackdaw_terrain/src/mesh.rs
@@ -6,9 +6,21 @@ pub struct ChunkMeshData {
     pub normals: Vec<[f32; 3]>,
     pub uvs: Vec<[f32; 2]>,
     pub indices: Vec<u32>,
+    /// Grid coordinate each vertex was sampled from, parallel to
+    /// `positions`.
+    ///
+    /// The smooth and flat meshers emit vertices in different orders and
+    /// different counts, so anything that wants a per-vertex attribute of
+    /// its own -- the paint-channel vertex colours, above all -- cannot
+    /// re-derive the order by walking the grid itself. It reads this
+    /// instead and stays in lockstep with whichever mesher ran.
+    pub grid: Vec<[u32; 2]>,
 }
 
-/// Build mesh data for a single chunk of the terrain.
+/// Build smooth-shaded mesh data for a single chunk of the terrain.
+///
+/// One shared vertex per grid point, normals from central differences, so
+/// the surface reads as a continuous landscape.
 ///
 /// `chunk_x` / `chunk_z`: chunk indices (0-based).
 /// `chunk_size`: number of cells per chunk edge.
@@ -36,6 +48,7 @@ pub fn build_chunk_mesh_data(
     let mut positions = Vec::with_capacity((cols * rows) as usize);
     let mut normals = Vec::with_capacity((cols * rows) as usize);
     let mut uvs = Vec::with_capacity((cols * rows) as usize);
+    let mut grid = Vec::with_capacity((cols * rows) as usize);
 
     for lz in 0..rows {
         for lx in 0..cols {
@@ -47,6 +60,7 @@ pub fn build_chunk_mesh_data(
             let world_z = gz as f32 * cell.y - half_size.y;
 
             positions.push([world_x, h, world_z]);
+            grid.push([gx, gz]);
 
             // UV normalized across full terrain
             let u = gx as f32 / (res - 1) as f32;
@@ -109,5 +123,199 @@ pub fn build_chunk_mesh_data(
         normals,
         uvs,
         indices,
+        grid,
+    }
+}
+
+/// Build flat-shaded mesh data for a single chunk of the terrain.
+///
+/// Same grid, same triangles, same winding as [`build_chunk_mesh_data`];
+/// the only difference is that no vertex is shared. Each triangle gets
+/// three of its own and all three carry that triangle's face normal, so
+/// the shading breaks at every cell edge instead of blending across it.
+///
+/// This is what a quantized terrain is meshed with. Snapped heights drawn
+/// with smoothed vertex normals read as a soft ramp -- the terracing is in
+/// the data and invisible on screen -- which defeats the point of turning
+/// quantization on.
+pub fn build_chunk_mesh_data_flat(
+    heightmap: &Heightmap,
+    chunk_x: u32,
+    chunk_z: u32,
+    chunk_size: u32,
+) -> ChunkMeshData {
+    let res = heightmap.resolution;
+    let cell = heightmap.cell_size();
+    let half_size = heightmap.size / 2.0;
+
+    let x_start = chunk_x * chunk_size;
+    let z_start = chunk_z * chunk_size;
+    let x_end = ((chunk_x + 1) * chunk_size + 1).min(res);
+    let z_end = ((chunk_z + 1) * chunk_size + 1).min(res);
+
+    let cols = x_end.saturating_sub(x_start);
+    let rows = z_end.saturating_sub(z_start);
+    let cells_x = cols.saturating_sub(1);
+    let cells_z = rows.saturating_sub(1);
+
+    let vertex_count = (cells_x * cells_z * 6) as usize;
+    let mut positions = Vec::with_capacity(vertex_count);
+    let mut normals = Vec::with_capacity(vertex_count);
+    let mut uvs = Vec::with_capacity(vertex_count);
+    let mut grid = Vec::with_capacity(vertex_count);
+    let mut indices = Vec::with_capacity(vertex_count);
+
+    let vertex_at = |gx: u32, gz: u32| -> ([f32; 3], [f32; 2]) {
+        let h = heightmap.get_height(gx, gz);
+        let world_x = gx as f32 * cell.x - half_size.x;
+        let world_z = gz as f32 * cell.y - half_size.y;
+        let u = gx as f32 / (res - 1) as f32;
+        let v = gz as f32 / (res - 1) as f32;
+        ([world_x, h, world_z], [u, v])
+    };
+
+    for lz in 0..cells_z {
+        for lx in 0..cells_x {
+            let gx = x_start + lx;
+            let gz = z_start + lz;
+
+            let tl = (gx, gz);
+            let tr = (gx + 1, gz);
+            let bl = (gx, gz + 1);
+            let br = (gx + 1, gz + 1);
+
+            for [a, b, c] in [[tl, bl, tr], [tr, bl, br]] {
+                let (pa, ua) = vertex_at(a.0, a.1);
+                let (pb, ub) = vertex_at(b.0, b.1);
+                let (pc, uc) = vertex_at(c.0, c.1);
+                let normal = face_normal(pa, pb, pc);
+
+                for ((p, u), g) in [(pa, ua), (pb, ub), (pc, uc)].into_iter().zip([a, b, c]) {
+                    indices.push(positions.len() as u32);
+                    positions.push(p);
+                    normals.push(normal);
+                    uvs.push(u);
+                    grid.push([g.0, g.1]);
+                }
+            }
+        }
+    }
+
+    ChunkMeshData {
+        positions,
+        normals,
+        uvs,
+        indices,
+        grid,
+    }
+}
+
+/// Normal of the triangle `a, b, c`, wound counter-clockwise when seen
+/// from the front. A degenerate triangle -- two coincident corners on a
+/// zero-size terrain -- reports straight up rather than a NaN that would
+/// blacken the chunk.
+fn face_normal(a: [f32; 3], b: [f32; 3], c: [f32; 3]) -> [f32; 3] {
+    let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    let n = [
+        ab[1] * ac[2] - ab[2] * ac[1],
+        ab[2] * ac[0] - ab[0] * ac[2],
+        ab[0] * ac[1] - ab[1] * ac[0],
+    ];
+    let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+    if len <= f32::EPSILON {
+        return [0.0, 1.0, 0.0];
+    }
+    [n[0] / len, n[1] / len, n[2] / len]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_math::Vec2;
+
+    fn flat_ground(resolution: u32) -> Heightmap {
+        Heightmap::new(resolution, Vec2::splat((resolution - 1) as f32), 10.0)
+    }
+
+    #[test]
+    fn the_smooth_mesher_records_a_grid_coordinate_per_vertex() {
+        let data = build_chunk_mesh_data(&flat_ground(9), 0, 0, 4);
+        assert_eq!(data.grid.len(), data.positions.len());
+        // Row-major over the 5x5 vertex window this chunk owns.
+        assert_eq!(data.grid[0], [0, 0]);
+        assert_eq!(data.grid[4], [4, 0]);
+        assert_eq!(data.grid[5], [0, 1]);
+    }
+
+    #[test]
+    fn the_flat_mesher_emits_three_unshared_vertices_per_triangle() {
+        let data = build_chunk_mesh_data_flat(&flat_ground(9), 0, 0, 4);
+        // 4x4 cells, two triangles each, three vertices each.
+        assert_eq!(data.positions.len(), 4 * 4 * 6);
+        assert_eq!(data.normals.len(), data.positions.len());
+        assert_eq!(data.uvs.len(), data.positions.len());
+        assert_eq!(data.grid.len(), data.positions.len());
+        // Indices are sequential: nothing is reused.
+        let expected: Vec<u32> = (0..data.positions.len() as u32).collect();
+        assert_eq!(data.indices, expected);
+    }
+
+    #[test]
+    fn flat_ground_meshes_with_upward_face_normals() {
+        let data = build_chunk_mesh_data_flat(&flat_ground(9), 0, 0, 4);
+        for n in &data.normals {
+            assert!((n[1] - 1.0).abs() < 1e-5, "normal {n:?} should point up");
+        }
+    }
+
+    #[test]
+    fn a_terrace_edge_gets_two_different_normals_rather_than_one_blended_one() {
+        // A single step: everything at x >= 2 is one unit higher.
+        let mut hm = flat_ground(5);
+        for gz in 0..5 {
+            for gx in 2..5 {
+                hm.set_height(gx, gz, 1.0);
+            }
+        }
+        let data = build_chunk_mesh_data_flat(&hm, 0, 0, 4);
+        let mut distinct: Vec<[f32; 3]> = Vec::new();
+        for n in &data.normals {
+            if !distinct
+                .iter()
+                .any(|d| (d[0] - n[0]).abs() < 1e-4 && (d[2] - n[2]).abs() < 1e-4)
+            {
+                distinct.push(*n);
+            }
+        }
+        assert!(
+            distinct.len() > 1,
+            "the riser and the flats should not share a normal, got {distinct:?}"
+        );
+        // The flats are still exactly level: no smoothing bled the step
+        // into the cells beside it.
+        assert!(
+            data.normals.iter().any(|n| (n[1] - 1.0).abs() < 1e-5),
+            "flat cells should stay flat"
+        );
+    }
+
+    #[test]
+    fn both_meshers_cover_the_same_grid_window() {
+        let hm = flat_ground(9);
+        let smooth = build_chunk_mesh_data(&hm, 1, 1, 4);
+        let flat = build_chunk_mesh_data_flat(&hm, 1, 1, 4);
+
+        let bounds = |grid: &[[u32; 2]]| {
+            let xs = grid.iter().map(|g| g[0]);
+            let zs = grid.iter().map(|g| g[1]);
+            (
+                xs.clone().min().unwrap(),
+                xs.max().unwrap(),
+                zs.clone().min().unwrap(),
+                zs.max().unwrap(),
+            )
+        };
+        assert_eq!(bounds(&smooth.grid), bounds(&flat.grid));
     }
 }

--- a/crates/jackdaw_terrain/src/quantize.rs
+++ b/crates/jackdaw_terrain/src/quantize.rs
@@ -60,9 +60,14 @@ pub fn quantize_region(heights: &mut [f32], resolution: u32, center: Vec2, radiu
         return;
     }
     let (max_x, max_z) = (max_x as u32, max_z as u32);
+    let radius_squared = radius * radius;
 
     for gz in min_z..=max_z {
         for gx in min_x..=max_x {
+            let delta = Vec2::new(gx as f32, gz as f32) - center;
+            if delta.length_squared() >= radius_squared {
+                continue;
+            }
             let idx = (gz * res + gx) as usize;
             if let Some(h) = heights.get_mut(idx) {
                 *h = (*h / step).round() * step;
@@ -130,12 +135,16 @@ mod tests {
     fn a_region_touches_only_the_cells_under_the_brush() {
         // 5x5 grid, every cell off-lattice by the same amount.
         let mut heights = vec![0.3_f32; 25];
-        quantize_region(&mut heights, 5, Vec2::new(1.0, 1.0), 1.0, 0.25);
+        let center = Vec2::new(2.0, 2.0);
+        let radius = 1.5;
+        quantize_region(&mut heights, 5, center, radius, 0.25);
 
-        // The brush at (1,1) with radius 1 owns the 3x3 block 0..=2.
+        // Quantization follows the same circular footprint as sculpting,
+        // not the square used only to bound the iteration.
         for gz in 0..5_usize {
             for gx in 0..5_usize {
-                let inside = gx <= 2 && gz <= 2;
+                let sample = Vec2::new(gx as f32, gz as f32);
+                let inside = sample.distance(center) < radius;
                 let h = heights[gz * 5 + gx];
                 if inside {
                     assert_eq!(h, 0.25, "cell ({gx},{gz}) should have snapped");
@@ -149,11 +158,13 @@ mod tests {
     #[test]
     fn a_region_clamps_to_the_grid_instead_of_wrapping() {
         let mut heights = vec![0.3_f32; 25];
-        // Centre off the near corner: the clamped window is 0..=1.
+        // Centre off the near corner: only (0,0) lies inside the circular
+        // footprint after the iteration bounds clamp to the grid.
         quantize_region(&mut heights, 5, Vec2::new(-0.5, -0.5), 1.0, 0.25);
         assert_eq!(heights[0], 0.25);
-        assert_eq!(heights[1], 0.25);
-        assert_eq!(heights[5 + 1], 0.25);
+        assert_eq!(heights[1], 0.3);
+        assert_eq!(heights[5], 0.3);
+        assert_eq!(heights[5 + 1], 0.3);
         assert_eq!(heights[2], 0.3);
         assert_eq!(heights[24], 0.3);
     }

--- a/crates/jackdaw_terrain/src/quantize.rs
+++ b/crates/jackdaw_terrain/src/quantize.rs
@@ -1,0 +1,176 @@
+//! Snapping terrain heights onto a game's own elevation lattice.
+//!
+//! A quantized terrain is one whose every stored height is an exact
+//! multiple of a step. That is what makes an integer export lossless and
+//! what gives grid-based and tactical games the readable, terraced ground
+//! they want. The arithmetic lives here, away from the ECS, because three
+//! callers need it at three different granularities: a sculpt stroke
+//! snaps only the cells it touched, generate and erode snap a whole fresh
+//! array, and the apply operator snaps an array that already exists.
+//!
+//! A step of zero, a negative step, or a non-finite one is a no-op rather
+//! than an error. The setting ships off with `height_step: 0.0`, so the
+//! disabled case is the common case and it has to be free.
+
+use bevy_math::Vec2;
+
+/// Snap one height onto the lattice of multiples of `step`.
+///
+/// Returns `h` unchanged when the step is not a usable interval. Ties
+/// round away from zero, which is `f32::round`'s rule; the choice is
+/// arbitrary but has to be the same everywhere or two paths would
+/// disagree on a height sitting exactly between terraces.
+pub fn quantize_height(h: f32, step: f32) -> f32 {
+    if !step.is_finite() || step <= 0.0 {
+        return h;
+    }
+    (h / step).round() * step
+}
+
+/// Snap a whole height array in place.
+pub fn quantize_heights(heights: &mut [f32], step: f32) {
+    if !step.is_finite() || step <= 0.0 {
+        return;
+    }
+    for h in heights.iter_mut() {
+        *h = (*h / step).round() * step;
+    }
+}
+
+/// Snap only the cells a brush of this shape touched.
+///
+/// A sculpt stroke fires every frame while the button is held. Rewriting
+/// a 512-resolution array -- 262,144 floats -- on each of those frames to
+/// snap the few hundred cells under the brush is the difference between
+/// terraces forming as the user drags and the editor stuttering. The
+/// bounds are computed the same way [`crate::apply_brush`] computes them,
+/// so the two agree on which cells a stroke owns.
+///
+/// `center` and `radius` are in grid cells, matching the brush.
+pub fn quantize_region(heights: &mut [f32], resolution: u32, center: Vec2, radius: f32, step: f32) {
+    if !step.is_finite() || step <= 0.0 || resolution == 0 || !radius.is_finite() || radius <= 0.0 {
+        return;
+    }
+    let res = resolution;
+    let min_x = ((center.x - radius).floor() as i32).max(0) as u32;
+    let max_x = ((center.x + radius).ceil() as i32).min(res as i32 - 1);
+    let min_z = ((center.y - radius).floor() as i32).max(0) as u32;
+    let max_z = ((center.y + radius).ceil() as i32).min(res as i32 - 1);
+    if max_x < 0 || max_z < 0 {
+        return;
+    }
+    let (max_x, max_z) = (max_x as u32, max_z as u32);
+
+    for gz in min_z..=max_z {
+        for gx in min_x..=max_x {
+            let idx = (gz * res + gx) as usize;
+            if let Some(h) = heights.get_mut(idx) {
+                *h = (*h / step).round() * step;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_multiples_are_left_where_they_are() {
+        for h in [0.0, 0.25, 0.5, 12.75, -3.5] {
+            assert_eq!(quantize_height(h, 0.25), h, "h = {h}");
+        }
+    }
+
+    #[test]
+    fn heights_land_on_the_nearest_step() {
+        assert_eq!(quantize_height(0.3, 0.25), 0.25);
+        assert_eq!(quantize_height(0.4, 0.25), 0.5);
+        assert_eq!(quantize_height(1.2, 1.0), 1.0);
+        assert_eq!(quantize_height(1.7, 1.0), 2.0);
+    }
+
+    #[test]
+    fn negative_heights_snap_the_same_way() {
+        assert_eq!(quantize_height(-0.3, 0.25), -0.25);
+        assert_eq!(quantize_height(-0.4, 0.25), -0.5);
+        assert_eq!(quantize_height(-1.7, 1.0), -2.0);
+    }
+
+    #[test]
+    fn a_step_of_zero_or_less_is_a_no_op() {
+        assert_eq!(quantize_height(0.37, 0.0), 0.37);
+        assert_eq!(quantize_height(0.37, -0.25), 0.37);
+
+        let mut heights = vec![0.37, 1.42];
+        quantize_heights(&mut heights, 0.0);
+        assert_eq!(heights, vec![0.37, 1.42]);
+    }
+
+    #[test]
+    fn a_non_finite_step_is_a_no_op() {
+        assert_eq!(quantize_height(0.37, f32::NAN), 0.37);
+        assert_eq!(quantize_height(0.37, f32::INFINITY), 0.37);
+
+        let mut heights = vec![0.37, 1.42];
+        quantize_heights(&mut heights, f32::NAN);
+        assert_eq!(heights, vec![0.37, 1.42]);
+        quantize_heights(&mut heights, f32::INFINITY);
+        assert_eq!(heights, vec![0.37, 1.42]);
+    }
+
+    #[test]
+    fn every_height_in_the_array_snaps() {
+        let mut heights = vec![0.3, 0.4, -0.3, 1.0];
+        quantize_heights(&mut heights, 0.25);
+        assert_eq!(heights, vec![0.25, 0.5, -0.25, 1.0]);
+    }
+
+    #[test]
+    fn a_region_touches_only_the_cells_under_the_brush() {
+        // 5x5 grid, every cell off-lattice by the same amount.
+        let mut heights = vec![0.3_f32; 25];
+        quantize_region(&mut heights, 5, Vec2::new(1.0, 1.0), 1.0, 0.25);
+
+        // The brush at (1,1) with radius 1 owns the 3x3 block 0..=2.
+        for gz in 0..5_usize {
+            for gx in 0..5_usize {
+                let inside = gx <= 2 && gz <= 2;
+                let h = heights[gz * 5 + gx];
+                if inside {
+                    assert_eq!(h, 0.25, "cell ({gx},{gz}) should have snapped");
+                } else {
+                    assert_eq!(h, 0.3, "cell ({gx},{gz}) should have been left alone");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_region_clamps_to_the_grid_instead_of_wrapping() {
+        let mut heights = vec![0.3_f32; 25];
+        // Centre off the near corner: the clamped window is 0..=1.
+        quantize_region(&mut heights, 5, Vec2::new(-0.5, -0.5), 1.0, 0.25);
+        assert_eq!(heights[0], 0.25);
+        assert_eq!(heights[1], 0.25);
+        assert_eq!(heights[5 + 1], 0.25);
+        assert_eq!(heights[2], 0.3);
+        assert_eq!(heights[24], 0.3);
+    }
+
+    #[test]
+    fn a_region_wholly_off_the_grid_changes_nothing() {
+        let mut heights = vec![0.3_f32; 25];
+        quantize_region(&mut heights, 5, Vec2::new(-40.0, -40.0), 1.0, 0.25);
+        assert!(heights.iter().all(|h| *h == 0.3));
+    }
+
+    #[test]
+    fn a_region_with_a_dead_step_or_radius_is_a_no_op() {
+        let mut heights = vec![0.3_f32; 25];
+        quantize_region(&mut heights, 5, Vec2::splat(2.0), 2.0, 0.0);
+        quantize_region(&mut heights, 5, Vec2::splat(2.0), 0.0, 0.25);
+        quantize_region(&mut heights, 0, Vec2::splat(2.0), 2.0, 0.25);
+        assert!(heights.iter().all(|h| *h == 0.3));
+    }
+}

--- a/crates/jackdaw_terrain/src/scatter.rs
+++ b/crates/jackdaw_terrain/src/scatter.rs
@@ -1,0 +1,766 @@
+//! Deterministic point scatter over a heightmap and its paint channels.
+//!
+//! One pure function, [`scatter`], turns a terrain plus a rule set into a
+//! list of placements. It knows nothing about entities, assets, or the
+//! editor: the caller decides what a placement becomes.
+//!
+//! Determinism is the contract. The same seed and the same
+//! channel data must produce byte-identical placements, on any machine,
+//! in any build, regardless of what order the cells happened to be
+//! visited in. Everything below is arranged around that:
+//!
+//! - Every random draw comes from a stream keyed by `(seed, cell index)`
+//!   and nothing else. There is no shared RNG walking across cells, so a
+//!   cell's output does not depend on how many cells preceded it.
+//! - Cells are visited row-major, and the only order-sensitive step --
+//!   minimum-spacing rejection -- consumes that fixed order.
+//! - No `HashMap`, no thread RNG, no floating-point accumulation across
+//!   cells.
+//!
+//! The PRNG is a hand-rolled `splitmix64` rather than the `rand` crate
+//! even though `rand` is already a dependency of this crate (erosion uses
+//! it). `rand`'s generators do not promise a stable value stream across
+//! versions, and a scatter that silently re-rolls on a `cargo update`
+//! would break the re-run contract that the editor operator is built on.
+//! A hand-rolled splitmix64 pins the stream to this file.
+
+use bevy_math::{Vec2, Vec3};
+
+use crate::channel::ChannelData;
+use crate::heightmap::Heightmap;
+
+/// Which channel gates placement, and which of its values are allowed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ScatterMask {
+    /// Index into the terrain's channel list.
+    pub channel: usize,
+    /// Palette values that accept a cell. An empty set accepts nothing,
+    /// which is the honest reading of "no value is allowed" and keeps a
+    /// half-configured operator from carpeting the terrain.
+    pub accept: Vec<u16>,
+}
+
+impl ScatterMask {
+    fn accepts(&self, value: u16) -> bool {
+        self.accept.contains(&value)
+    }
+}
+
+/// The rule set a scatter run is driven by.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScatterParams {
+    /// The one input every random draw derives from, with the cell index.
+    pub seed: u64,
+    /// Instances per square world unit, before the weight channel.
+    pub density: f32,
+    /// Closest two placements may sit, in world units. 0 disables the
+    /// check.
+    pub min_spacing: f32,
+    /// Which cells may receive instances. `None` accepts every cell.
+    pub mask: Option<ScatterMask>,
+    /// A channel whose per-cell value scales local density.
+    ///
+    /// Values are normalised against the largest value present in that
+    /// channel, so a project's own scale works untranslated -- a channel
+    /// painted 0/1/2 and one painted 0..255 both mean "none to all". A
+    /// channel that is entirely zero therefore scatters nothing, which is
+    /// the reading a user painting a weight map expects.
+    pub weight_channel: Option<usize>,
+    /// Uniform scale range. `scale_min == scale_max` means no variance.
+    pub scale_min: f32,
+    pub scale_max: f32,
+    /// Randomise rotation about Y.
+    pub random_yaw: bool,
+    /// Tilt instances onto the surface instead of standing them upright.
+    pub align_to_normal: bool,
+    /// How many assets the caller's palette holds. Each placement gets an
+    /// index into it; 0 assets still produces placements, all at index 0,
+    /// so the kernel is testable without an asset list.
+    pub asset_count: usize,
+}
+
+impl Default for ScatterParams {
+    fn default() -> Self {
+        Self {
+            seed: 0,
+            density: 1.0,
+            min_spacing: 0.0,
+            mask: None,
+            weight_channel: None,
+            scale_min: 1.0,
+            scale_max: 1.0,
+            random_yaw: true,
+            align_to_normal: false,
+            asset_count: 1,
+        }
+    }
+}
+
+/// One instance the caller should place.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Placement {
+    /// World-space position, sitting on the sampled surface.
+    pub position: Vec3,
+    /// Rotation about Y, radians. 0 when `random_yaw` is off.
+    pub yaw: f32,
+    /// Uniform scale.
+    pub scale: f32,
+    /// The up axis this instance should use: the sampled surface normal
+    /// when `align_to_normal` is on, `Vec3::Y` when it is off. Reporting
+    /// the decision rather than the raw normal means a consumer builds
+    /// one rotation without having to re-read the params.
+    pub normal: Vec3,
+    /// Index into the caller's asset palette.
+    pub asset_index: usize,
+    /// Row-major index of the grid cell this came from, `z * resolution +
+    /// x`. Same indexing as a channel's values, so a caller can look up
+    /// what was painted under any placement.
+    pub cell: u32,
+}
+
+/// Scatter placements across `heightmap` under `params`.
+///
+/// `channels` is the terrain's channel list in declaration order; the
+/// mask and weight indices address it. A mask or weight index that is out
+/// of range produces zero placements rather than silently ignoring the
+/// rule -- a typo in a channel index should be visible, not permissive.
+pub fn scatter(
+    heightmap: &Heightmap,
+    channels: &[ChannelData],
+    params: &ScatterParams,
+) -> Vec<Placement> {
+    let resolution = heightmap.resolution;
+    if resolution < 2 || params.density <= 0.0 {
+        return Vec::new();
+    }
+
+    let mask = match &params.mask {
+        Some(mask) if mask.channel >= channels.len() => return Vec::new(),
+        Some(mask) if mask.accept.is_empty() => return Vec::new(),
+        other => other.as_ref(),
+    };
+    let weight = match params.weight_channel {
+        Some(index) => match channels.get(index) {
+            Some(channel) => {
+                // Normalising against the channel's own peak is what
+                // makes "0/1/2" and "0..255" both mean the same thing.
+                let peak = channel.values.iter().copied().max().unwrap_or(0);
+                if peak == 0 {
+                    return Vec::new();
+                }
+                Some((channel, f32::from(peak)))
+            }
+            None => return Vec::new(),
+        },
+        None => None,
+    };
+
+    let cell_size = heightmap.cell_size();
+    let cell_area = cell_size.x * cell_size.y;
+    let half = heightmap.size / 2.0;
+    let mut spacing = SpacingGrid::new(params.min_spacing, heightmap.size);
+    let mut out = Vec::new();
+
+    // Row-major over cells. The last row and column are vertices with no
+    // cell beyond them, so they are the edge of the last cell, not the
+    // origin of another one.
+    for gz in 0..resolution - 1 {
+        for gx in 0..resolution - 1 {
+            let cell = gz * resolution + gx;
+
+            if let Some(mask) = mask
+                && !mask.accepts(channels[mask.channel].get(resolution, gx, gz))
+            {
+                continue;
+            }
+            let weight_scale = match weight {
+                Some((channel, peak)) => f32::from(channel.get(resolution, gx, gz)) / peak,
+                None => 1.0,
+            };
+            if weight_scale <= 0.0 {
+                continue;
+            }
+
+            let mut rng = CellRng::new(params.seed, cell);
+            // Stochastic rounding: a cell expecting 0.3 instances places
+            // one 30% of the time. Summed over a region that reproduces
+            // `density` exactly in expectation, which is what makes
+            // density scale linearly instead of snapping to whole
+            // instances per cell.
+            let expected = params.density * cell_area * weight_scale;
+            let count = (expected + rng.next_f32()).floor().max(0.0) as u32;
+
+            for _ in 0..count {
+                // Every draw happens whether or not the point survives
+                // the spacing test, so rejecting a point never shifts the
+                // stream for the ones after it.
+                let fx = gx as f32 + rng.next_f32();
+                let fz = gz as f32 + rng.next_f32();
+                let yaw = if params.random_yaw {
+                    rng.next_f32() * std::f32::consts::TAU
+                } else {
+                    0.0
+                };
+                let scale_t = rng.next_f32();
+                let asset_index = if params.asset_count > 1 {
+                    (rng.next_f32() * params.asset_count as f32) as usize
+                } else {
+                    0
+                };
+
+                let world_x = fx * cell_size.x - half.x;
+                let world_z = fz * cell_size.y - half.y;
+                if !spacing.accept(Vec2::new(world_x, world_z)) {
+                    continue;
+                }
+
+                out.push(Placement {
+                    position: Vec3::new(world_x, heightmap.sample_bilinear(fx, fz), world_z),
+                    yaw,
+                    scale: params.scale_min + (params.scale_max - params.scale_min) * scale_t,
+                    normal: if params.align_to_normal {
+                        surface_normal(heightmap, fx, fz)
+                    } else {
+                        Vec3::Y
+                    },
+                    asset_index: asset_index.min(params.asset_count.saturating_sub(1)),
+                    cell,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Surface normal at fractional grid coordinates, by central difference.
+///
+/// The step is one grid cell, so the normal describes the slope the mesh
+/// actually renders rather than the slope of the interpolant at a point.
+pub fn surface_normal(heightmap: &Heightmap, gx: f32, gz: f32) -> Vec3 {
+    let cell = heightmap.cell_size();
+    let dx = heightmap.sample_bilinear(gx + 1.0, gz) - heightmap.sample_bilinear(gx - 1.0, gz);
+    let dz = heightmap.sample_bilinear(gx, gz + 1.0) - heightmap.sample_bilinear(gx, gz - 1.0);
+    Vec3::new(-dx / (2.0 * cell.x), 1.0, -dz / (2.0 * cell.y)).normalize_or(Vec3::Y)
+}
+
+// --- Deterministic random ---
+
+/// The splitmix64 mixing step. Pinned here rather than pulled from a
+/// crate so the value stream can never move under a dependency bump.
+#[inline]
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// A random stream belonging to exactly one grid cell.
+///
+/// Seeded by hashing the cell index and mixing it into the run seed, so
+/// neighbouring cells get uncorrelated streams and no cell's output
+/// depends on any other cell having been visited first.
+struct CellRng(u64);
+
+impl CellRng {
+    fn new(seed: u64, cell: u32) -> Self {
+        let mut hashed = u64::from(cell);
+        let hashed = splitmix64(&mut hashed);
+        Self(seed ^ hashed)
+    }
+
+    /// Uniform in `[0, 1)`, from the top 24 bits so the mantissa is
+    /// filled exactly and the result is representable without rounding.
+    fn next_f32(&mut self) -> f32 {
+        (splitmix64(&mut self.0) >> 40) as f32 / (1u32 << 24) as f32
+    }
+}
+
+// --- Minimum spacing ---
+
+/// Accept/reject against already-placed points, bucketed so the check
+/// stays cheap at a few thousand instances.
+///
+/// The bucket edge is never smaller than `min_spacing`, so every point
+/// within `min_spacing` of a candidate is guaranteed to sit in the
+/// candidate's own bucket or one of its eight neighbours. That is what
+/// makes the grid an optimisation and not a change in behaviour: it
+/// returns exactly what a full pairwise scan would.
+struct SpacingGrid {
+    min_spacing_sq: f32,
+    edge: f32,
+    origin: Vec2,
+    dims: (i32, i32),
+    buckets: Vec<Vec<Vec2>>,
+}
+
+/// Ceiling on buckets per axis. A pathologically small `min_spacing` over
+/// a large terrain would otherwise ask for an unbounded allocation; a
+/// coarser bucket only costs time, never correctness.
+const MAX_BUCKETS_PER_AXIS: i32 = 512;
+
+impl SpacingGrid {
+    fn new(min_spacing: f32, size: Vec2) -> Self {
+        if min_spacing <= 0.0 {
+            return Self {
+                min_spacing_sq: 0.0,
+                edge: 1.0,
+                origin: Vec2::ZERO,
+                dims: (0, 0),
+                buckets: Vec::new(),
+            };
+        }
+        let floor = (size.max_element() / MAX_BUCKETS_PER_AXIS as f32).max(f32::MIN_POSITIVE);
+        let edge = min_spacing.max(floor);
+        let dims = (
+            ((size.x / edge).ceil() as i32 + 1).clamp(1, MAX_BUCKETS_PER_AXIS + 2),
+            ((size.y / edge).ceil() as i32 + 1).clamp(1, MAX_BUCKETS_PER_AXIS + 2),
+        );
+        Self {
+            min_spacing_sq: min_spacing * min_spacing,
+            edge,
+            origin: -size / 2.0,
+            dims,
+            buckets: vec![Vec::new(); (dims.0 * dims.1) as usize],
+        }
+    }
+
+    fn bucket_of(&self, point: Vec2) -> (i32, i32) {
+        let local = (point - self.origin) / self.edge;
+        (
+            (local.x.floor() as i32).clamp(0, self.dims.0 - 1),
+            (local.y.floor() as i32).clamp(0, self.dims.1 - 1),
+        )
+    }
+
+    /// Record `point` and return whether it cleared the spacing rule.
+    fn accept(&mut self, point: Vec2) -> bool {
+        if self.min_spacing_sq <= 0.0 {
+            return true;
+        }
+        let (bx, bz) = self.bucket_of(point);
+        for z in (bz - 1).max(0)..=(bz + 1).min(self.dims.1 - 1) {
+            for x in (bx - 1).max(0)..=(bx + 1).min(self.dims.0 - 1) {
+                for other in &self.buckets[(z * self.dims.0 + x) as usize] {
+                    if point.distance_squared(*other) < self.min_spacing_sq {
+                        return false;
+                    }
+                }
+            }
+        }
+        self.buckets[(bz * self.dims.0 + bx) as usize].push(point);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::ChannelElement;
+
+    fn flat(resolution: u32) -> Heightmap {
+        Heightmap::new(resolution, Vec2::new(32.0, 32.0), 10.0)
+    }
+
+    /// A channel where the left half is 1 and the right half is 2.
+    fn split_channel(resolution: u32) -> Vec<ChannelData> {
+        let mut channel = ChannelData::new("density", ChannelElement::U8, resolution);
+        for z in 0..resolution {
+            for x in 0..resolution {
+                channel.values[(z * resolution + x) as usize] =
+                    if x < resolution / 2 { 1 } else { 2 };
+            }
+        }
+        vec![channel]
+    }
+
+    fn mask(values: &[u16]) -> Option<ScatterMask> {
+        Some(ScatterMask {
+            channel: 0,
+            accept: values.to_vec(),
+        })
+    }
+
+    /// The headline contract. Two runs with the same seed over the same
+    /// data compare equal placement-for-placement, field-for-field --
+    /// position, yaw, scale, normal, asset index and cell -- not merely
+    /// equal in count.
+    #[test]
+    fn the_same_seed_and_data_produce_identical_placements() {
+        let heightmap = flat(64);
+        let channels = split_channel(64);
+        let params = ScatterParams {
+            seed: 0xDEAD_BEEF,
+            density: 0.5,
+            min_spacing: 0.3,
+            mask: mask(&[1, 2]),
+            align_to_normal: true,
+            asset_count: 4,
+            scale_min: 0.7,
+            scale_max: 1.4,
+            ..default_params()
+        };
+        let first = scatter(&heightmap, &channels, &params);
+        let second = scatter(&heightmap, &channels, &params);
+        assert!(!first.is_empty(), "the fixture should place something");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn a_different_seed_produces_different_placements() {
+        let heightmap = flat(64);
+        let channels = split_channel(64);
+        let params = ScatterParams {
+            seed: 1,
+            density: 0.5,
+            mask: mask(&[1, 2]),
+            ..default_params()
+        };
+        let first = scatter(&heightmap, &channels, &params);
+        let second = scatter(&heightmap, &channels, &ScatterParams { seed: 2, ..params });
+        assert_ne!(first, second);
+    }
+
+    /// Changing which palette values are accepted must change *which*
+    /// cells receive instances and nothing about the instances in the
+    /// cells that stayed accepted. This is what makes the mask a filter
+    /// rather than a different random run.
+    #[test]
+    fn narrowing_the_mask_only_removes_cells_and_leaves_the_rest_untouched() {
+        let heightmap = flat(64);
+        let channels = split_channel(64);
+        let base = ScatterParams {
+            seed: 99,
+            density: 0.6,
+            mask: mask(&[1, 2]),
+            ..default_params()
+        };
+        let both = scatter(&heightmap, &channels, &base);
+        let only_two = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                mask: mask(&[2]),
+                ..base.clone()
+            },
+        );
+
+        assert!(!only_two.is_empty());
+        assert!(only_two.len() < both.len());
+        // Every survivor is byte-identical to its counterpart in the
+        // wider run, and every cell it came from carries value 2.
+        let kept: Vec<_> = both
+            .iter()
+            .filter(|p| channels[0].values[p.cell as usize] == 2)
+            .copied()
+            .collect();
+        assert_eq!(kept, only_two);
+    }
+
+    #[test]
+    fn a_mask_that_accepts_nothing_places_nothing() {
+        let heightmap = flat(32);
+        let channels = split_channel(32);
+        let params = ScatterParams {
+            density: 2.0,
+            mask: Some(ScatterMask {
+                channel: 0,
+                accept: Vec::new(),
+            }),
+            ..default_params()
+        };
+        assert!(scatter(&heightmap, &channels, &params).is_empty());
+        // A value nobody painted is the same thing by another route.
+        let params = ScatterParams {
+            mask: mask(&[7]),
+            ..params
+        };
+        assert!(scatter(&heightmap, &channels, &params).is_empty());
+    }
+
+    #[test]
+    fn an_all_zero_weight_channel_places_nothing() {
+        let heightmap = flat(32);
+        let channels = vec![ChannelData::new("weight", ChannelElement::U8, 32)];
+        let params = ScatterParams {
+            density: 4.0,
+            weight_channel: Some(0),
+            ..default_params()
+        };
+        assert!(scatter(&heightmap, &channels, &params).is_empty());
+    }
+
+    /// A weight channel scales density locally: the half painted 2 must
+    /// come out substantially denser than the half painted 1.
+    #[test]
+    fn a_weight_channel_scales_density_per_cell() {
+        let heightmap = flat(64);
+        let channels = split_channel(64);
+        let placements = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                seed: 5,
+                density: 1.0,
+                weight_channel: Some(0),
+                ..default_params()
+            },
+        );
+        let left = placements.iter().filter(|p| p.position.x < 0.0).count();
+        let right = placements.iter().filter(|p| p.position.x >= 0.0).count();
+        // Half-weight against full weight: expect roughly double.
+        assert!(
+            right > left * 3 / 2,
+            "right {right} should clearly exceed left {left}"
+        );
+    }
+
+    #[test]
+    fn minimum_spacing_is_never_violated() {
+        let heightmap = flat(64);
+        let channels = split_channel(64);
+        let spacing = 0.8;
+        let placements = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                seed: 3,
+                // Ask for far more than the spacing can fit, so the
+                // rejection path is what decides the result.
+                density: 8.0,
+                min_spacing: spacing,
+                mask: mask(&[1, 2]),
+                ..default_params()
+            },
+        );
+        assert!(placements.len() > 50, "got {}", placements.len());
+        for (i, a) in placements.iter().enumerate() {
+            for b in &placements[i + 1..] {
+                let d = Vec2::new(a.position.x, a.position.z)
+                    .distance(Vec2::new(b.position.x, b.position.z));
+                assert!(d >= spacing - 1e-4, "pair at {d} is closer than {spacing}");
+            }
+        }
+    }
+
+    /// The bucketed spacing grid must return exactly what a full pairwise
+    /// scan would. Driving it with a bucket edge far larger than the
+    /// spacing exercises the "coarser bucket" fallback.
+    #[test]
+    fn the_spacing_grid_matches_a_brute_force_scan() {
+        let size = Vec2::new(32.0, 32.0);
+        let spacing = 0.5;
+        let mut grid = SpacingGrid::new(spacing, size);
+        let mut brute: Vec<Vec2> = Vec::new();
+        let mut rng = CellRng::new(11, 0);
+        for _ in 0..2000 {
+            let point = Vec2::new(
+                rng.next_f32() * size.x - size.x / 2.0,
+                rng.next_f32() * size.y - size.y / 2.0,
+            );
+            let brute_ok = brute.iter().all(|p| p.distance(point) >= spacing);
+            if brute_ok {
+                brute.push(point);
+            }
+            assert_eq!(grid.accept(point), brute_ok);
+        }
+        assert!(brute.len() > 100, "fixture placed only {}", brute.len());
+    }
+
+    #[test]
+    fn density_scales_the_instance_count_roughly_linearly() {
+        let heightmap = flat(64);
+        let channels = split_channel(64);
+        let count_at = |density: f32| {
+            scatter(
+                &heightmap,
+                &channels,
+                &ScatterParams {
+                    seed: 7,
+                    density,
+                    mask: mask(&[1, 2]),
+                    ..default_params()
+                },
+            )
+            .len() as f32
+        };
+        let one = count_at(0.25);
+        let four = count_at(1.0);
+        assert!(one > 100.0, "fixture is too small to measure: {one}");
+        let ratio = four / one;
+        assert!((3.6..=4.4).contains(&ratio), "ratio {ratio} is not ~4x");
+    }
+
+    /// Instances sit on the ground, not on the Y=0 plane.
+    #[test]
+    fn placements_sample_the_surface_height() {
+        let mut heightmap = flat(32);
+        heightmap.heights.fill(3.0);
+        let channels = split_channel(32);
+        let placements = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                density: 0.2,
+                mask: mask(&[1, 2]),
+                ..default_params()
+            },
+        );
+        assert!(!placements.is_empty());
+        assert!(placements.iter().all(|p| (p.position.y - 3.0).abs() < 1e-5));
+    }
+
+    /// With align-to-normal off, every instance stands upright whatever
+    /// the ground does; with it on, a sloped surface tilts them.
+    #[test]
+    fn align_to_normal_decides_the_reported_up_axis() {
+        let mut heightmap = flat(32);
+        for z in 0..32 {
+            for x in 0..32 {
+                heightmap.heights[(z * 32 + x) as usize] = x as f32 * 0.5;
+            }
+        }
+        let channels = split_channel(32);
+        let base = ScatterParams {
+            density: 0.2,
+            mask: mask(&[1, 2]),
+            ..default_params()
+        };
+        let upright = scatter(&heightmap, &channels, &base);
+        assert!(!upright.is_empty());
+        assert!(upright.iter().all(|p| p.normal == Vec3::Y));
+
+        let tilted = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                align_to_normal: true,
+                ..base
+            },
+        );
+        assert!(tilted.iter().all(|p| p.normal.x < 0.0 && p.normal.y > 0.0));
+        // Same positions either way: aligning changes orientation only.
+        let positions: Vec<_> = upright.iter().map(|p| p.position).collect();
+        let aligned_positions: Vec<_> = tilted.iter().map(|p| p.position).collect();
+        assert_eq!(positions, aligned_positions);
+    }
+
+    #[test]
+    fn asset_indices_stay_inside_the_palette() {
+        let heightmap = flat(48);
+        let channels = split_channel(48);
+        let placements = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                density: 0.5,
+                mask: mask(&[1, 2]),
+                asset_count: 3,
+                ..default_params()
+            },
+        );
+        assert!(!placements.is_empty());
+        assert!(placements.iter().all(|p| p.asset_index < 3));
+        assert!(placements.iter().any(|p| p.asset_index == 2));
+    }
+
+    #[test]
+    fn scale_stays_inside_the_configured_range() {
+        let heightmap = flat(48);
+        let channels = split_channel(48);
+        let placements = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                density: 0.5,
+                mask: mask(&[1, 2]),
+                scale_min: 0.5,
+                scale_max: 2.0,
+                ..default_params()
+            },
+        );
+        assert!(!placements.is_empty());
+        assert!(placements.iter().all(|p| (0.5..=2.0).contains(&p.scale)));
+    }
+
+    #[test]
+    fn an_out_of_range_channel_index_places_nothing() {
+        let heightmap = flat(32);
+        let channels = split_channel(32);
+        assert!(
+            scatter(
+                &heightmap,
+                &channels,
+                &ScatterParams {
+                    density: 1.0,
+                    mask: Some(ScatterMask {
+                        channel: 9,
+                        accept: vec![1],
+                    }),
+                    ..default_params()
+                }
+            )
+            .is_empty()
+        );
+        assert!(
+            scatter(
+                &heightmap,
+                &channels,
+                &ScatterParams {
+                    density: 1.0,
+                    weight_channel: Some(9),
+                    ..default_params()
+                }
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_degenerate_terrain_or_density_places_nothing() {
+        let channels = split_channel(1);
+        assert!(scatter(&flat(1), &channels, &default_params()).is_empty());
+        assert!(
+            scatter(
+                &flat(32),
+                &split_channel(32),
+                &ScatterParams {
+                    density: 0.0,
+                    ..default_params()
+                }
+            )
+            .is_empty()
+        );
+    }
+
+    /// `cell` addresses the channel arrays directly, so a caller can look
+    /// up what was painted under any placement.
+    #[test]
+    fn the_reported_cell_indexes_the_channel_arrays() {
+        let heightmap = flat(32);
+        let channels = split_channel(32);
+        let placements = scatter(
+            &heightmap,
+            &channels,
+            &ScatterParams {
+                density: 0.4,
+                mask: mask(&[2]),
+                ..default_params()
+            },
+        );
+        assert!(!placements.is_empty());
+        assert!(
+            placements
+                .iter()
+                .all(|p| channels[0].values[p.cell as usize] == 2)
+        );
+    }
+
+    fn default_params() -> ScatterParams {
+        ScatterParams {
+            random_yaw: true,
+            ..ScatterParams::default()
+        }
+    }
+}

--- a/crates/jackdaw_terrain/src/scatter.rs
+++ b/crates/jackdaw_terrain/src/scatter.rs
@@ -4,7 +4,7 @@
 //! list of placements. It knows nothing about entities, assets, or the
 //! editor: the caller decides what a placement becomes.
 //!
-//! Determinism is the contract. The same seed and the same
+//! Determinism is the contract, not a nicety. The same seed and the same
 //! channel data must produce byte-identical placements, on any machine,
 //! in any build, regardless of what order the cells happened to be
 //! visited in. Everything below is arranged around that:
@@ -22,7 +22,7 @@
 //! it). `rand`'s generators do not promise a stable value stream across
 //! versions, and a scatter that silently re-rolls on a `cargo update`
 //! would break the re-run contract that the editor operator is built on.
-//! A hand-rolled splitmix64 pins the stream to this file.
+//! Sixteen lines of splitmix64 pin the stream to this file forever.
 
 use bevy_math::{Vec2, Vec3};
 

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -29,6 +29,16 @@
 //! Every integer and float is little-endian. Encoding is a pure function of
 //! the data, so the same terrain always produces the same bytes and a
 //! sidecar can be committed and diffed.
+//!
+//! There is no checksum. A file can be truncated or bit-flipped by
+//! something outside the atomic-write path this format's own writer uses
+//! (a bad disk, a naive sync tool) and still pass magic/version/length
+//! checks while carrying wrong values -- decode only catches structural
+//! corruption (bad magic, an unreadable version, a length that does not
+//! fit the claimed shape), not silent bit rot within otherwise
+//! well-formed bytes. Accepted as a tradeoff for the format staying
+//! trivial to read from any language; revisit if this ever needs to
+//! survive untrusted or unreliable transport.
 
 use std::path::{Component, Path, PathBuf};
 
@@ -280,7 +290,10 @@ pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
         return Err(SidecarError::BadMagic);
     }
     let version = r.u16()?;
-    if version > VERSION {
+    // 0 has never been a version any build wrote (VERSION starts at 1);
+    // accepting it would let a file whose version bytes were zeroed out
+    // by corruption parse as if it were a real, if ancient, format.
+    if version == 0 || version > VERSION {
         return Err(SidecarError::UnsupportedVersion(version));
     }
     if r.u16()? != 0 {
@@ -464,6 +477,16 @@ mod tests {
             decode(&bytes),
             Err(SidecarError::UnsupportedVersion(VERSION + 1))
         );
+    }
+
+    /// M5: version 0 has never been written by any build and must not be
+    /// accepted as if it were a real, if ancient, format -- most likely
+    /// to show up from version bytes zeroed out by corruption.
+    #[test]
+    fn rejects_version_zero() {
+        let mut bytes = encode(&sample()).expect("encodes");
+        bytes[8..10].copy_from_slice(&0u16.to_le_bytes());
+        assert_eq!(decode(&bytes), Err(SidecarError::UnsupportedVersion(0)));
     }
 
     #[test]

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -2,8 +2,8 @@
 //!
 //! A terrain's heights and paint channels are far too large to live in a
 //! text scene file: a 512-resolution heightmap is 262,144 floats, and a
-//! `.bsn` document has to stay readable in a `git diff`. They go in a
-//! versioned binary file beside the scene instead, and the scene
+//! `.bsn` document is meant to be read in a `git diff` without crying. They
+//! go in a versioned binary file beside the scene instead, and the scene
 //! keeps only the small descriptive parts -- resolution, world size, the
 //! channel table.
 //!
@@ -30,6 +30,8 @@
 //! the data, so the same terrain always produces the same bytes and a
 //! sidecar can be committed and diffed.
 
+use std::path::{Component, Path, PathBuf};
+
 use crate::channel::{ChannelData, ChannelElement};
 
 /// Magic bytes at the head of every sidecar.
@@ -40,6 +42,82 @@ pub const VERSION: u16 = 1;
 
 /// Conventional file extension for a terrain sidecar.
 pub const EXTENSION: &str = "jdterrain";
+
+/// Why a terrain sidecar path could not be resolved beneath a scene.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SidecarPathError {
+    /// No sidecar path was provided.
+    Empty,
+    /// The path is absolute or carries a platform-specific prefix.
+    Absolute,
+    /// The path contains a separator or component that is not a plain name.
+    InvalidComponent,
+    /// The path does not end in the exact lowercase `.jdterrain` extension.
+    WrongExtension,
+}
+
+impl core::fmt::Display for SidecarPathError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "terrain sidecar path is empty"),
+            Self::Absolute => write!(f, "terrain sidecar path must be relative to the scene"),
+            Self::InvalidComponent => write!(
+                f,
+                "terrain sidecar path must contain only normal forward-slash-separated components"
+            ),
+            Self::WrongExtension => write!(
+                f,
+                "terrain sidecar path must end in the exact .{EXTENSION} extension"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for SidecarPathError {}
+
+/// Validate `data_path` and resolve it beneath `scene_dir`.
+///
+/// Scene metadata is portable, so validation is deliberately stricter than
+/// the host platform: backslashes and Windows drive prefixes are rejected on
+/// every platform, as are empty, `.` and `..` components.
+pub fn resolve_path(scene_dir: &Path, data_path: &str) -> Result<PathBuf, SidecarPathError> {
+    if data_path.is_empty() {
+        return Err(SidecarPathError::Empty);
+    }
+    if data_path.contains('\\') {
+        return Err(SidecarPathError::InvalidComponent);
+    }
+
+    let path = Path::new(data_path);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::Prefix(_) | Component::RootDir))
+    {
+        return Err(SidecarPathError::Absolute);
+    }
+
+    for (index, component) in data_path.split('/').enumerate() {
+        if component.is_empty() || matches!(component, "." | "..") {
+            return Err(SidecarPathError::InvalidComponent);
+        }
+        if index == 0
+            && component.as_bytes().get(1) == Some(&b':')
+            && component.as_bytes()[0].is_ascii_alphabetic()
+        {
+            return Err(SidecarPathError::Absolute);
+        }
+        if component.contains(':') {
+            return Err(SidecarPathError::InvalidComponent);
+        }
+    }
+
+    if path.extension().and_then(|extension| extension.to_str()) != Some(EXTENSION) {
+        return Err(SidecarPathError::WrongExtension);
+    }
+
+    Ok(scene_dir.join(path))
+}
 
 /// A terrain's bulk per-cell data: the heightmap plus every paint channel.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -263,6 +341,8 @@ pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
 
     fn sample() -> TerrainData {
@@ -435,5 +515,45 @@ mod tests {
         data.normalize();
         assert_eq!(data.heights.len(), 9);
         assert_eq!(data.channels[0].values.len(), 9);
+    }
+
+    #[test]
+    fn resolves_nested_sidecars_beneath_the_scene_directory() {
+        let scene_dir = Path::new("project").join("scenes");
+
+        assert_eq!(
+            resolve_path(&scene_dir, "terrain/chunks/ground.jdterrain"),
+            Ok(scene_dir.join("terrain/chunks/ground.jdterrain")),
+        );
+    }
+
+    #[test]
+    fn rejects_paths_that_can_escape_or_change_meaning_across_platforms() {
+        let scene_dir = Path::new("project/scenes");
+        let invalid = [
+            "",
+            ".",
+            "..",
+            "./ground.jdterrain",
+            "terrain/./ground.jdterrain",
+            "terrain/../ground.jdterrain",
+            "terrain//ground.jdterrain",
+            "/tmp/ground.jdterrain",
+            "//server/share/ground.jdterrain",
+            "C:/terrain/ground.jdterrain",
+            r"C:\terrain\ground.jdterrain",
+            r"terrain\ground.jdterrain",
+            "terrain/ground:stream.jdterrain",
+            "ground.terrain",
+            "ground.jdterrain.bak",
+            "ground.JDTERRAIN",
+        ];
+
+        for data_path in invalid {
+            assert!(
+                resolve_path(scene_dir, data_path).is_err(),
+                "{data_path:?} must not resolve",
+            );
+        }
     }
 }

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -1,0 +1,439 @@
+//! Binary sidecar format for a terrain's bulk per-cell data.
+//!
+//! A terrain's heights and paint channels are far too large to live in a
+//! text scene file: a 512-resolution heightmap is 262,144 floats, and a
+//! `.bsn` document has to stay readable in a `git diff`. They go in a
+//! versioned binary file beside the scene instead, and the scene
+//! keeps only the small descriptive parts -- resolution, world size, the
+//! channel table.
+//!
+//! The format is deliberately plain so an external pipeline can read it in
+//! any language without linking jackdaw:
+//!
+//! ```text
+//! offset  size          field
+//! 0       8             magic, b"JDTERRN\0"
+//! 8       2             format version, u16
+//! 10      2             flags, u16 (reserved, must be 0)
+//! 12      4             resolution, u32
+//! 16      4             channel count, u32
+//! 20      4*res*res     heights, f32
+//! then, per channel:
+//!         4             name length in bytes, u32
+//!         n             name, UTF-8
+//!         1             element tag, u8 (0 = u8, 1 = u16)
+//!         3             padding, must be 0
+//!         w*res*res     values, u8 or u16 per the tag
+//! ```
+//!
+//! Every integer and float is little-endian. Encoding is a pure function of
+//! the data, so the same terrain always produces the same bytes and a
+//! sidecar can be committed and diffed.
+
+use crate::channel::{ChannelData, ChannelElement};
+
+/// Magic bytes at the head of every sidecar.
+pub const MAGIC: [u8; 8] = *b"JDTERRN\0";
+
+/// Format version this build writes.
+pub const VERSION: u16 = 1;
+
+/// Conventional file extension for a terrain sidecar.
+pub const EXTENSION: &str = "jdterrain";
+
+/// A terrain's bulk per-cell data: the heightmap plus every paint channel.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TerrainData {
+    /// Vertices per edge. Every array below is `resolution^2` long.
+    pub resolution: u32,
+    /// Row-major heights.
+    pub heights: Vec<f32>,
+    /// Named integer layers, in the order the project declared them.
+    pub channels: Vec<ChannelData>,
+}
+
+/// Why a sidecar could not be read.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SidecarError {
+    /// The file does not start with [`MAGIC`]. Not a terrain sidecar.
+    BadMagic,
+    /// Written by a newer jackdaw than this one.
+    UnsupportedVersion(u16),
+    /// A reserved field was non-zero, so the file means something this
+    /// build does not understand.
+    ReservedFieldSet,
+    /// The file ended before the declared data did.
+    Truncated,
+    /// A channel declared an element tag this build does not know.
+    UnknownElement(u8),
+    /// A channel name was not valid UTF-8.
+    BadName,
+    /// The declared dimensions do not fit in this platform's address space.
+    TooLarge,
+}
+
+impl core::fmt::Display for SidecarError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BadMagic => write!(f, "not a terrain sidecar (bad magic)"),
+            Self::UnsupportedVersion(v) => {
+                write!(f, "terrain sidecar version {v} is newer than this build")
+            }
+            Self::ReservedFieldSet => write!(f, "terrain sidecar sets a reserved field"),
+            Self::Truncated => write!(f, "terrain sidecar is truncated"),
+            Self::UnknownElement(t) => write!(f, "unknown channel element tag {t}"),
+            Self::BadName => write!(f, "channel name is not valid UTF-8"),
+            Self::TooLarge => write!(f, "terrain sidecar declares more data than fits in memory"),
+        }
+    }
+}
+
+impl core::error::Error for SidecarError {}
+
+impl TerrainData {
+    /// Cell count, or `None` if `resolution^2` overflows `usize`.
+    pub fn cell_count(&self) -> Option<usize> {
+        let res = self.resolution as usize;
+        res.checked_mul(res)
+    }
+
+    /// Bring every array to exactly `resolution^2` entries, zero-filling.
+    ///
+    /// Called after a decode of a file whose arrays disagree with its
+    /// header, and whenever a terrain's resolution changes.
+    pub fn normalize(&mut self) {
+        let Some(cells) = self.cell_count() else {
+            return;
+        };
+        self.heights.resize(cells, 0.0);
+        for channel in &mut self.channels {
+            channel.values.resize(cells, 0);
+        }
+    }
+
+    /// Byte length [`encode`] will produce, or `None` on overflow.
+    pub fn encoded_len(&self) -> Option<usize> {
+        let cells = self.cell_count()?;
+        let mut len = 20usize.checked_add(cells.checked_mul(4)?)?;
+        for channel in &self.channels {
+            len = len
+                .checked_add(8)?
+                .checked_add(channel.name.len())?
+                .checked_add(cells.checked_mul(channel.element.byte_width())?)?;
+        }
+        Some(len)
+    }
+}
+
+/// Serialize a terrain's bulk data.
+///
+/// Arrays shorter than `resolution^2` are zero-padded and longer ones are
+/// truncated, so the output always matches its own header. Returns `None`
+/// only when the declared size overflows `usize`.
+pub fn encode(data: &TerrainData) -> Option<Vec<u8>> {
+    let cells = data.cell_count()?;
+    let mut out = Vec::with_capacity(data.encoded_len()?);
+
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&VERSION.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&data.resolution.to_le_bytes());
+    out.extend_from_slice(&(data.channels.len() as u32).to_le_bytes());
+
+    for i in 0..cells {
+        let h = data.heights.get(i).copied().unwrap_or(0.0);
+        out.extend_from_slice(&h.to_le_bytes());
+    }
+
+    for channel in &data.channels {
+        out.extend_from_slice(&(channel.name.len() as u32).to_le_bytes());
+        out.extend_from_slice(channel.name.as_bytes());
+        out.push(channel.element.tag());
+        out.extend_from_slice(&[0u8; 3]);
+        for i in 0..cells {
+            let v = channel.values.get(i).copied().unwrap_or(0);
+            match channel.element {
+                ChannelElement::U8 => out.push(v.min(u16::from(u8::MAX)) as u8),
+                ChannelElement::U16 => out.extend_from_slice(&v.to_le_bytes()),
+            }
+        }
+    }
+
+    Some(out)
+}
+
+/// Cursor over a sidecar's bytes that refuses to read past the end.
+struct Reader<'a> {
+    bytes: &'a [u8],
+    at: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn take(&mut self, n: usize) -> Result<&'a [u8], SidecarError> {
+        let end = self.at.checked_add(n).ok_or(SidecarError::TooLarge)?;
+        let slice = self
+            .bytes
+            .get(self.at..end)
+            .ok_or(SidecarError::Truncated)?;
+        self.at = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, SidecarError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, SidecarError> {
+        let b = self.take(2)?;
+        Ok(u16::from_le_bytes([b[0], b[1]]))
+    }
+
+    fn u32(&mut self) -> Result<u32, SidecarError> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+}
+
+/// Deserialize a terrain's bulk data.
+pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
+    let mut r = Reader { bytes, at: 0 };
+
+    if r.take(MAGIC.len())? != MAGIC {
+        return Err(SidecarError::BadMagic);
+    }
+    let version = r.u16()?;
+    if version > VERSION {
+        return Err(SidecarError::UnsupportedVersion(version));
+    }
+    if r.u16()? != 0 {
+        return Err(SidecarError::ReservedFieldSet);
+    }
+
+    let resolution = r.u32()?;
+    let channel_count = r.u32()?;
+    let cells = (resolution as usize)
+        .checked_mul(resolution as usize)
+        .ok_or(SidecarError::TooLarge)?;
+
+    // A truncated file must not make us allocate its claimed size, so the
+    // remaining length is checked before every reservation.
+    let heights_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
+    let mut heights = Vec::with_capacity(cells);
+    for chunk in heights_bytes.chunks_exact(4) {
+        heights.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+
+    let mut channels = Vec::new();
+    for _ in 0..channel_count {
+        let name_len = r.u32()? as usize;
+        let name = core::str::from_utf8(r.take(name_len)?)
+            .map_err(|_| SidecarError::BadName)?
+            .to_string();
+        let tag = r.u8()?;
+        let element = ChannelElement::from_tag(tag).ok_or(SidecarError::UnknownElement(tag))?;
+        if r.take(3)? != [0u8; 3] {
+            return Err(SidecarError::ReservedFieldSet);
+        }
+
+        let value_bytes = r.take(
+            cells
+                .checked_mul(element.byte_width())
+                .ok_or(SidecarError::TooLarge)?,
+        )?;
+        let values = match element {
+            ChannelElement::U8 => value_bytes.iter().map(|b| u16::from(*b)).collect(),
+            ChannelElement::U16 => value_bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect(),
+        };
+        channels.push(ChannelData {
+            name,
+            element,
+            values,
+        });
+    }
+
+    Ok(TerrainData {
+        resolution,
+        heights,
+        channels,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> TerrainData {
+        let mut biome = ChannelData::new("biome", ChannelElement::U8, 4);
+        biome.values[5] = 2;
+        biome.values[6] = 255;
+        let mut zoning = ChannelData::new("zoning-\u{e9}", ChannelElement::U16, 4);
+        zoning.values[0] = 40000;
+        TerrainData {
+            resolution: 4,
+            heights: (0..16).map(|i| i as f32 * 0.25).collect(),
+            channels: vec![biome, zoning],
+        }
+    }
+
+    #[test]
+    fn round_trips_heights_and_channels_exactly() {
+        let data = sample();
+        let bytes = encode(&data).expect("encodes");
+        let back = decode(&bytes).expect("decodes");
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn encoding_is_deterministic() {
+        let data = sample();
+        assert_eq!(encode(&data), encode(&data));
+    }
+
+    #[test]
+    fn encoded_len_matches_the_bytes_produced() {
+        let data = sample();
+        let bytes = encode(&data).expect("encodes");
+        assert_eq!(Some(bytes.len()), data.encoded_len());
+    }
+
+    #[test]
+    fn a_u8_channel_costs_half_of_a_u16_channel() {
+        let res = 8;
+        let narrow = TerrainData {
+            resolution: res,
+            heights: vec![0.0; 64],
+            channels: vec![ChannelData::new("c", ChannelElement::U8, res)],
+        };
+        let wide = TerrainData {
+            resolution: res,
+            heights: vec![0.0; 64],
+            channels: vec![ChannelData::new("c", ChannelElement::U16, res)],
+        };
+        let narrow_len = encode(&narrow).expect("encodes").len();
+        let wide_len = encode(&wide).expect("encodes").len();
+        assert_eq!(wide_len - narrow_len, 64);
+    }
+
+    #[test]
+    fn a_512_heightmap_is_a_megabyte_of_binary_not_text_floats() {
+        let res = 512u32;
+        let data = TerrainData {
+            resolution: res,
+            heights: vec![0.5; (res * res) as usize],
+            channels: vec![],
+        };
+        let bytes = encode(&data).expect("encodes");
+        assert_eq!(bytes.len(), 20 + 512 * 512 * 4);
+        assert_eq!(decode(&bytes).expect("decodes").heights.len(), 262_144);
+    }
+
+    #[test]
+    fn u8_channel_values_saturate_rather_than_wrap() {
+        let mut c = ChannelData::new("c", ChannelElement::U8, 2);
+        c.values = vec![300, 0, 0, 0];
+        let data = TerrainData {
+            resolution: 2,
+            heights: vec![0.0; 4],
+            channels: vec![c],
+        };
+        let back = decode(&encode(&data).expect("encodes")).expect("decodes");
+        assert_eq!(back.channels[0].values[0], 255);
+    }
+
+    #[test]
+    fn short_arrays_are_zero_padded_to_the_declared_resolution() {
+        let data = TerrainData {
+            resolution: 3,
+            heights: vec![1.0, 2.0],
+            channels: vec![ChannelData {
+                name: "c".into(),
+                element: ChannelElement::U16,
+                values: vec![7],
+            }],
+        };
+        let back = decode(&encode(&data).expect("encodes")).expect("decodes");
+        assert_eq!(
+            back.heights,
+            vec![1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(back.channels[0].values.len(), 9);
+        assert_eq!(back.channels[0].values[0], 7);
+    }
+
+    #[test]
+    fn an_empty_terrain_round_trips() {
+        let data = TerrainData::default();
+        let back = decode(&encode(&data).expect("encodes")).expect("decodes");
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn rejects_a_file_that_is_not_a_sidecar() {
+        assert_eq!(decode(b"not a terrain at all"), Err(SidecarError::BadMagic));
+        assert_eq!(decode(b""), Err(SidecarError::Truncated));
+    }
+
+    #[test]
+    fn rejects_a_newer_format_version() {
+        let mut bytes = encode(&sample()).expect("encodes");
+        bytes[8..10].copy_from_slice(&(VERSION + 1).to_le_bytes());
+        assert_eq!(
+            decode(&bytes),
+            Err(SidecarError::UnsupportedVersion(VERSION + 1))
+        );
+    }
+
+    #[test]
+    fn rejects_a_set_reserved_flag() {
+        let mut bytes = encode(&sample()).expect("encodes");
+        bytes[10..12].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(decode(&bytes), Err(SidecarError::ReservedFieldSet));
+    }
+
+    #[test]
+    fn rejects_an_unknown_channel_element() {
+        let data = TerrainData {
+            resolution: 2,
+            heights: vec![0.0; 4],
+            channels: vec![ChannelData::new("c", ChannelElement::U8, 2)],
+        };
+        let mut bytes = encode(&data).expect("encodes");
+        // header 20 + heights 16 + name_len 4 + name 1 = 41 is the tag byte.
+        bytes[41] = 9;
+        assert_eq!(decode(&bytes), Err(SidecarError::UnknownElement(9)));
+    }
+
+    #[test]
+    fn a_truncated_file_is_rejected_and_does_not_allocate_its_claim() {
+        let bytes = encode(&sample()).expect("encodes");
+        for cut in [20, 30, bytes.len() - 1] {
+            assert_eq!(decode(&bytes[..cut]), Err(SidecarError::Truncated));
+        }
+    }
+
+    #[test]
+    fn a_header_claiming_a_huge_terrain_over_a_tiny_file_is_rejected() {
+        let mut bytes = encode(&TerrainData::default()).expect("encodes");
+        bytes[12..16].copy_from_slice(&100_000u32.to_le_bytes());
+        assert_eq!(decode(&bytes), Err(SidecarError::Truncated));
+    }
+
+    #[test]
+    fn normalize_squares_every_array_to_the_resolution() {
+        let mut data = TerrainData {
+            resolution: 3,
+            heights: vec![1.0; 2],
+            channels: vec![ChannelData {
+                name: "c".into(),
+                element: ChannelElement::U8,
+                values: vec![1; 20],
+            }],
+        };
+        data.normalize();
+        assert_eq!(data.heights.len(), 9);
+        assert_eq!(data.channels[0].values.len(), 9);
+    }
+}

--- a/examples/author_bake_loop_world.rs
+++ b/examples/author_bake_loop_world.rs
@@ -8,6 +8,12 @@
 //!
 //! Run: `cargo run --example author_bake_loop_world -- <project-dir>`
 
+#![expect(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "the example reports authored output and verification results"
+)]
+
 use std::collections::HashSet;
 use std::path::PathBuf;
 

--- a/examples/author_bake_loop_world.rs
+++ b/examples/author_bake_loop_world.rs
@@ -1,0 +1,472 @@
+//! Headless world-authoring driver.
+//!
+//! Authors a small test world using jackdaw's own kernels (terrain
+//! sculpt/quantize/paint from `jackdaw_terrain`, the BSN writer from
+//! `jackdaw_bsn`) and writes a loadable `scene.bsn` plus its terrain
+//! sidecar into `<project-dir>/assets/`. This is the input to a terrain
+//! export/import pipeline built in a parallel session.
+//!
+//! Run: `cargo run --example author_bake_loop_world -- <project-dir>`
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use bevy::app::App;
+use bevy::ecs::hierarchy::{ChildOf, Children};
+use bevy::prelude::*;
+
+use jackdaw_bsn::BsnWriterConfig;
+use jackdaw_scene_types::{
+    GltfSource, Terrain, TerrainChannel, TerrainChannelElement, TerrainPaletteEntry,
+    TerrainQuantization,
+};
+use jackdaw_terrain::{
+    ChannelData, ChannelElement, Heightmap, SculptTool, TerrainData, apply_brush,
+    apply_channel_brush, quantize_heights, sidecar,
+};
+
+const RESOLUTION: u32 = 129;
+const SIZE: f32 = 128.0;
+const MAX_HEIGHT: f32 = 50.0;
+const HILL_CENTER: Vec2 = Vec2::new(64.0, 64.0);
+const HILL_RADIUS: f32 = 28.0;
+const FOREST_CENTER: Vec2 = Vec2::new(40.0, 88.0);
+const FOREST_RADIUS: f32 = 22.0;
+
+/// Palette values for the `biome` channel.
+///
+/// Deliberately NOT the consuming importer's own biome cell ids (meadow is 1
+/// and forest is 2 over there). The importer resolves palette LABELS, so an
+/// implementation that wrongly read raw pixel values would emit unknown ids
+/// 7 and 3 and be refused loudly, instead of coincidentally producing the
+/// right answer and hiding the bug.
+const MEADOW_VALUE: u16 = 7;
+const FOREST_VALUE: u16 = 3;
+
+fn main() {
+    let project_dir: PathBuf = std::env::args()
+        .nth(1)
+        .expect("usage: author_bake_loop_world <project-dir>")
+        .into();
+    let assets_dir = project_dir.join("assets");
+    std::fs::create_dir_all(&assets_dir).expect("create assets dir");
+
+    // ---- terrain heights: sculpt a hill, then quantize ----
+    let heights = sculpt_heights();
+    let min_h = heights.iter().copied().fold(f32::INFINITY, f32::min);
+    let max_h = heights.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    println!("terrain height range: min={min_h:.3} max={max_h:.3}");
+
+    // ---- biome channel: meadow everywhere, forest patch off-centre ----
+    let biome_values = build_biome_channel();
+    let meadow_count = biome_values.iter().filter(|&&v| v == MEADOW_VALUE).count();
+    let forest_count = biome_values.iter().filter(|&&v| v == FOREST_VALUE).count();
+    println!("biome cells: meadow={meadow_count} forest={forest_count}");
+
+    let terrain_data = TerrainData {
+        resolution: RESOLUTION,
+        heights: heights.clone(),
+        channels: vec![ChannelData {
+            name: "biome".to_string(),
+            element: ChannelElement::U16,
+            values: biome_values.clone(),
+        }],
+    };
+    let sidecar_bytes = sidecar::encode(&terrain_data).expect("terrain data fits in memory");
+    let sidecar_path = assets_dir.join("scene.terrain-0.jdterrain");
+    std::fs::write(&sidecar_path, &sidecar_bytes).expect("write terrain sidecar");
+
+    // ---- scene: build entities in a headless World, emit via jackdaw's own BSN writer ----
+    let (scene_text, expected_transforms) = build_scene(&heights);
+    let scene_path = assets_dir.join("scene.bsn");
+    std::fs::write(&scene_path, &scene_text).expect("write scene.bsn");
+
+    println!(
+        "wrote {} ({} bytes)",
+        scene_path.display(),
+        scene_text.len()
+    );
+    println!(
+        "wrote {} ({} bytes)",
+        sidecar_path.display(),
+        sidecar_bytes.len()
+    );
+
+    // ================= self-verification =================
+    let mut all_ok = true;
+
+    let mut verify_app = App::new();
+    register_types(&mut verify_app);
+    let reloaded_text = std::fs::read_to_string(&scene_path).expect("read scene.bsn back");
+    let load_result = jackdaw_bsn::load_bsn_scene(verify_app.world_mut(), &reloaded_text);
+    all_ok &= check("scene.bsn parses via load_bsn_scene", load_result.is_ok());
+    if let Err(err) = &load_result {
+        println!("  load error: {err}");
+    }
+
+    if load_result.is_ok() {
+        let world = verify_app.world_mut();
+
+        let mut terrain_query = world.query::<&Terrain>();
+        let terrain_count = terrain_query.iter(world).count();
+        all_ok &= check(
+            "exactly one entity has a Terrain component",
+            terrain_count == 1,
+        );
+
+        let mut terrain_query = world.query::<&Terrain>();
+        if let Some(t) = terrain_query.iter(world).next() {
+            all_ok &= check("terrain.resolution == 129", t.resolution == RESOLUTION);
+            all_ok &= check(
+                "terrain.size == (128.0, 128.0)",
+                (t.size - Vec2::new(SIZE, SIZE)).length() < 1e-6,
+            );
+            all_ok &= check(
+                "terrain.max_height == 50.0",
+                (t.max_height - MAX_HEIGHT).abs() < 1e-6,
+            );
+            all_ok &= check(
+                "terrain.data_path == scene.terrain-0.jdterrain",
+                t.data_path == "scene.terrain-0.jdterrain",
+            );
+            all_ok &= check(
+                "terrain has exactly one channel named biome",
+                t.channels.len() == 1 && t.channels[0].name == "biome",
+            );
+            if let Some(ch) = t.channels.first() {
+                all_ok &= check(
+                    "biome channel element is U16",
+                    ch.element == TerrainChannelElement::U16,
+                );
+                all_ok &= check(
+                    "biome palette has exactly two entries",
+                    ch.palette.len() == 2,
+                );
+                let meadow = ch.palette.iter().find(|p| p.value == MEADOW_VALUE);
+                let forest = ch.palette.iter().find(|p| p.value == FOREST_VALUE);
+                all_ok &= check(
+                    "palette value 7 is labeled meadow",
+                    meadow.is_some_and(|p| p.label == "meadow"),
+                );
+                all_ok &= check(
+                    "palette value 3 is labeled forest",
+                    forest.is_some_and(|p| p.label == "forest"),
+                );
+            }
+            all_ok &= check(
+                "terrain.quantization.enabled == true",
+                t.quantization.enabled,
+            );
+            all_ok &= check(
+                "terrain.quantization.cell_size == 1.0",
+                (t.quantization.cell_size - 1.0).abs() < 1e-6,
+            );
+            all_ok &= check(
+                "terrain.quantization.height_step == 0.25",
+                (t.quantization.height_step - 0.25).abs() < 1e-6,
+            );
+            all_ok &= check(
+                "size.x / (resolution - 1) == cell_size exactly",
+                t.size.x / ((t.resolution - 1) as f32) == t.quantization.cell_size,
+            );
+        }
+
+        let mut transform_query = world.query::<&Transform>();
+        let transform_count = transform_query.iter(world).count();
+        all_ok &= check(
+            &format!(
+                "transform count == {expected_transforms} (camera, sun, terrain, 4 props, 1 spawn, root)"
+            ),
+            transform_count == expected_transforms,
+        );
+    } else {
+        all_ok = false;
+    }
+
+    // sidecar round trip
+    match std::fs::read(&sidecar_path)
+        .map_err(|e| e.to_string())
+        .and_then(|bytes| sidecar::decode(&bytes).map_err(|e| e.to_string()))
+    {
+        Ok(decoded) => {
+            all_ok &= check("sidecar decode succeeds", true);
+            all_ok &= check(
+                "decoded heights are byte-identical to what was encoded",
+                decoded.heights == terrain_data.heights,
+            );
+            let decoded_biome = decoded.channels.first().map(|c| c.values.clone());
+            all_ok &= check(
+                "decoded biome channel is byte-identical to what was encoded",
+                decoded_biome.as_deref() == Some(terrain_data.channels[0].values.as_slice()),
+            );
+        }
+        Err(err) => {
+            all_ok = false;
+            println!("[FAIL] sidecar decode: {err}");
+        }
+    }
+
+    let all_quantized = heights.iter().all(|h| {
+        let steps = h / 0.25;
+        (steps - steps.round()).abs() < 1e-4
+    });
+    all_ok &= check(
+        "every quantized height is an exact multiple of 0.25",
+        all_quantized,
+    );
+
+    let unique_biome_values: HashSet<u16> = biome_values.iter().copied().collect();
+    all_ok &= check(
+        "biome channel contains both 1 and 2 and no other values",
+        unique_biome_values.len() == 2
+            && unique_biome_values.contains(&MEADOW_VALUE)
+            && unique_biome_values.contains(&FOREST_VALUE),
+    );
+
+    println!("min height = {min_h:.3}, max height = {max_h:.3}");
+    println!("meadow cells = {meadow_count}, forest cells = {forest_count}");
+
+    if !all_ok {
+        eprintln!("VERIFICATION FAILED");
+        std::process::exit(1);
+    }
+    println!("ALL CHECKS PASSED");
+}
+
+fn check(label: &str, ok: bool) -> bool {
+    println!("[{}] {}", if ok { "PASS" } else { "FAIL" }, label);
+    ok
+}
+
+/// Sculpt a hill with `apply_brush`, then quantize to a 0.25 m step so the
+/// export is lossless.
+fn sculpt_heights() -> Vec<f32> {
+    let mut hm = Heightmap::new(RESOLUTION, Vec2::new(SIZE, SIZE), MAX_HEIGHT);
+
+    for _ in 0..3 {
+        apply_brush(
+            &mut hm,
+            SculptTool::Raise,
+            HILL_CENTER,
+            HILL_RADIUS,
+            5.0,
+            1.5,
+            1.0,
+            None,
+        );
+    }
+    for _ in 0..2 {
+        apply_brush(
+            &mut hm,
+            SculptTool::Smooth,
+            HILL_CENTER,
+            HILL_RADIUS,
+            1.0,
+            1.0,
+            1.0,
+            None,
+        );
+    }
+
+    let mut heights = hm.heights;
+    quantize_heights(&mut heights, 0.25);
+    heights
+}
+
+/// One `biome` channel: filled with [`MEADOW_VALUE`] everywhere, then a
+/// forest patch of [`FOREST_VALUE`] painted off-centre. Filling first is
+/// required: value `0` has no palette entry and the downstream importer
+/// refuses unmapped values.
+fn build_biome_channel() -> Vec<u16> {
+    let mut values = vec![MEADOW_VALUE; (RESOLUTION as usize) * (RESOLUTION as usize)];
+    apply_channel_brush(
+        &mut values,
+        RESOLUTION,
+        ChannelElement::U16,
+        FOREST_CENTER,
+        FOREST_RADIUS,
+        1.0,
+        0.0,
+        FOREST_VALUE,
+    );
+    values
+}
+
+/// Height at fractional grid coordinates, nearest-cell (no interpolation
+/// needed here; this is only used to place props at a plausible elevation).
+fn height_at(heights: &[f32], grid: Vec2) -> f32 {
+    let gx = grid.x.round().clamp(0.0, (RESOLUTION - 1) as f32) as u32;
+    let gz = grid.y.round().clamp(0.0, (RESOLUTION - 1) as f32) as u32;
+    heights[(gz * RESOLUTION + gx) as usize]
+}
+
+/// Grid-space coordinates (as used by `apply_brush`/`apply_channel_brush`)
+/// to terrain-local world XZ. The terrain is centred at its own origin, so
+/// this is the inverse of `Heightmap::world_to_grid` with a 1.0 m cell.
+fn grid_to_local(grid: Vec2) -> Vec2 {
+    grid - Vec2::splat(SIZE / 2.0)
+}
+
+/// Registers every reflected type this scene's components need. Bevy's
+/// `reflect_auto_register` feature (on for this workspace) already derives
+/// most of these automatically, but registering explicitly here removes any
+/// dependency on that being active for a bare `App::new()`.
+fn register_types(app: &mut App) {
+    app.register_type::<Name>()
+        .register_type::<Transform>()
+        .register_type::<ChildOf>()
+        .register_type::<Children>()
+        .register_type::<Visibility>()
+        .register_type::<Camera3d>()
+        .register_type::<DirectionalLight>()
+        .register_type::<GltfSource>()
+        .register_type::<Terrain>()
+        .register_type::<TerrainChannel>()
+        .register_type::<TerrainChannelElement>()
+        .register_type::<TerrainPaletteEntry>()
+        .register_type::<TerrainQuantization>();
+}
+
+/// Builds the scene in a headless `World` and emits it to `.bsn` text via
+/// `jackdaw_bsn::serialize_to_bsn_with_config` -- the same writer the editor
+/// itself uses -- rather than hand-writing the text. Returns the emitted
+/// text and the number of entities that carry a `Transform` (for the
+/// self-verification step).
+fn build_scene(heights: &[f32]) -> (String, usize) {
+    let mut app = App::new();
+    register_types(&mut app);
+    let world = app.world_mut();
+
+    let root = world
+        .spawn((Name::new("Root"), Transform::default(), Visibility::Visible))
+        .id();
+
+    world.spawn((
+        Name::new("Main Camera"),
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 60.0, 90.0).looking_at(Vec3::new(0.0, 8.0, 0.0), Vec3::Y),
+        Visibility::Visible,
+        ChildOf(root),
+    ));
+
+    world.spawn((
+        Name::new("Sun"),
+        DirectionalLight::default(),
+        Transform::default().looking_to(Vec3::new(-0.4, -1.0, -0.3), Vec3::Y),
+        Visibility::Visible,
+        ChildOf(root),
+    ));
+
+    world.spawn((
+        Name::new("Ground"),
+        Transform::default(),
+        Visibility::Visible,
+        Terrain {
+            resolution: RESOLUTION,
+            size: Vec2::new(SIZE, SIZE),
+            max_height: MAX_HEIGHT,
+            channels: vec![TerrainChannel {
+                name: "biome".to_string(),
+                element: TerrainChannelElement::U16,
+                palette: vec![
+                    TerrainPaletteEntry {
+                        value: MEADOW_VALUE,
+                        label: "meadow".to_string(),
+                        color: Color::srgb(0.36, 0.56, 0.28),
+                    },
+                    TerrainPaletteEntry {
+                        value: FOREST_VALUE,
+                        label: "forest".to_string(),
+                        color: Color::srgb(0.14, 0.32, 0.16),
+                    },
+                ],
+            }],
+            data_path: "scene.terrain-0.jdterrain".to_string(),
+            heights: Vec::new(),
+            // resolution 129 => 128 cells; cell_size 1.0 * 128 cells == size
+            // 128.0, so this agrees exactly with `size` above, and
+            // height_step matches the 0.25 m quantize_heights step the
+            // sidecar heights were snapped to.
+            quantization: TerrainQuantization {
+                enabled: true,
+                cell_size: 1.0,
+                height_step: 0.25,
+            },
+        },
+        ChildOf(root),
+    ));
+
+    let props: [(&str, &str, Vec2); 4] = [
+        (
+            "CommonTree_1",
+            "models/quaternius/nature/CommonTree_1.gltf",
+            Vec2::new(78.0, 58.0),
+        ),
+        (
+            "CommonTree_3",
+            "models/quaternius/nature/CommonTree_3.gltf",
+            Vec2::new(46.0, 74.0),
+        ),
+        (
+            "Bush_Common",
+            "models/quaternius/nature/Bush_Common.gltf",
+            Vec2::new(40.0, 82.0),
+        ),
+        (
+            "Fern_1",
+            "models/quaternius/nature/Fern_1.gltf",
+            Vec2::new(70.0, 78.0),
+        ),
+    ];
+    for (name, path, grid_pos) in props {
+        let local = grid_to_local(grid_pos);
+        let y = height_at(heights, grid_pos);
+        world.spawn((
+            Name::new(name),
+            Transform::from_xyz(local.x, y, local.y),
+            GltfSource {
+                path: path.to_string(),
+                scene_index: 0,
+            },
+            ChildOf(root),
+        ));
+    }
+
+    // Spawn-point convention: the entity NAME encodes
+    // "spawn:<species>:<count>:<respawn_seconds>". No game-specific
+    // SpawnPoint component type is registered in a headless jackdaw type
+    // registry, so the consuming importer parses this string instead.
+    let spawn_grid = Vec2::new(90.0, 64.0);
+    let spawn_local = grid_to_local(spawn_grid);
+    let spawn_y = height_at(heights, spawn_grid);
+    world.spawn((
+        Name::new("spawn:moor_deer:3:120"),
+        Transform::from_xyz(spawn_local.x, spawn_y, spawn_local.y),
+        ChildOf(root),
+    ));
+
+    let config = BsnWriterConfig::default()
+        // The editor's default config skips the whole `bevy_camera::visibility::`
+        // module (ViewVisibility/InheritedVisibility/etc, which are runtime-only),
+        // but the authored `Visibility` enum itself belongs in the scene.
+        .always_save("bevy_camera::visibility::Visibility")
+        // Camera3d requires (Camera, Projection); Camera itself further requires
+        // Frustum/CameraMainTextureUsages/VisibleEntities/Transform/Visibility/
+        // RenderTarget. Frustum and VisibleEntities are already covered by the
+        // default config's `bevy_camera::primitives::`/`visibility::` skips; these
+        // two prefixes cover the rest of that require chain so a headless spawn
+        // (with no render plugins narrowing what actually gets attached) still
+        // emits a clean bare `Camera3d`, matching what the real editor emits.
+        .skip_prefix("bevy_camera::camera::")
+        .skip_prefix("bevy_camera::projection::")
+        // DirectionalLight requires Cascades/CascadesFrusta/CascadeShadowConfig/
+        // CascadesVisibleEntities/.../VisibilityClass. CascadesFrusta and
+        // CascadesVisibleEntities/VisibilityClass are already covered by the
+        // default config's `bevy_camera::` skips; this covers the cascade
+        // shadow config types that live in `bevy_light::cascade::`.
+        .skip_prefix("bevy_light::cascade::");
+
+    let text = jackdaw_bsn::serialize_to_bsn_with_config(app.world(), &config);
+    // root + camera + sun + terrain + 4 props + spawn point
+    (text, 1 + 1 + 1 + 1 + 4 + 1)
+}

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -4,6 +4,7 @@ use std::sync::{Mutex, mpsc};
 use bevy::{
     asset::RenderAssetUsages,
     feathers::cursor::{EntityCursor, OverrideCursor},
+    feathers::theme::ThemedText,
     image::{CompressedImageFormats, ImageSampler, ImageType},
     picking::hover::Hovered,
     prelude::*,
@@ -22,6 +23,7 @@ use crate::{
     EditorEntity,
     brush::{Brush, BrushEditMode, BrushSelection, EditMode, LastUsedMaterial},
     material_browser::MaterialRegistry,
+    model_thumbnail::ModelThumbnailSlot,
     prelude::*,
     selection::Selection,
 };
@@ -309,10 +311,10 @@ pub struct AssetBrowserState {
     pub selected_file: Option<String>,
     /// Timestamp of last click for double-click detection.
     pub last_click_time: f64,
-    /// When true, only `.jsn` files that contain a `Prefab` component are
+    /// When true, only scene files that contain a `Prefab` component are
     /// shown in the grid.
     pub prefabs_only: bool,
-    /// Per-path memo of whether a `.jsn` file is a prefab. Keyed by
+    /// Per-path memo of whether a scene file is a prefab. Keyed by
     /// absolute path, valued by `(mtime, is_prefab)`; invalidated when
     /// the file's mtime changes.
     prefab_cache: PrefabCheckCache,
@@ -345,10 +347,50 @@ pub struct DirEntry {
     pub is_prefab: bool,
 }
 
-/// Returns true if `path` is a `.jsn` file whose first scene entity carries
-/// a `jackdaw::prefab::components::Prefab` component. The file is opened and
-/// parsed as JSON; any I/O or parse error returns false.
+/// Returns true if `path` is a prefab: a scene document whose root entity
+/// carries a `jackdaw::prefab::components::Prefab` component.
+///
+/// Both formats the editor can hold a prefab in are recognised. `.bsn` is
+/// what the editor writes today (`crate::prefab::operators::write_prefab_doc`
+/// redirects even a `.jsn` target to a `.bsn` file); `.jsn` is the legacy
+/// form. Anything else, and any I/O or parse error, is not a prefab.
 fn read_is_prefab(path: &Path) -> bool {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) if ext.eq_ignore_ascii_case("bsn") => read_is_bsn_prefab(path),
+        Some(ext) if ext.eq_ignore_ascii_case("jsn") => read_is_jsn_prefab(path),
+        _ => false,
+    }
+}
+
+/// A `.bsn` document is a prefab when one of its roots carries the `Prefab`
+/// marker.
+///
+/// Deliberately *not* routed through `crate::prefab::save_load::read_prefab_ast`:
+/// that calls `normalize_as_prefab_source`, which wraps any plain scene into
+/// an instanceable prefab, so every `.bsn` in the project would answer yes.
+/// Detection has to see the file as authored.
+fn read_is_bsn_prefab(path: &Path) -> bool {
+    use crate::prefab::resolver_bsn::PREFAB_TYPE;
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    // Cheap reject before the parser runs: the marker's type path appears
+    // verbatim in BSN text, so a document that never mentions it cannot be a
+    // prefab. Worth having when a directory holds hundreds of scenes.
+    if !text.contains(PREFAB_TYPE) {
+        return false;
+    }
+    let Ok(ast) = jackdaw_bsn::parse_bsn_text(&text) else {
+        return false;
+    };
+    ast.roots
+        .iter()
+        .any(|&root| ast.find_patch_by_type_path(root, PREFAB_TYPE).is_some())
+}
+
+/// A legacy `.jsn` document is a prefab when its first scene entity carries
+/// the `Prefab` component. Parsed as plain JSON.
+fn read_is_jsn_prefab(path: &Path) -> bool {
     let Ok(text) = std::fs::read_to_string(path) else {
         return false;
     };
@@ -359,7 +401,7 @@ fn read_is_prefab(path: &Path) -> bool {
         .get("scene")
         .and_then(|v| v.get(0))
         .and_then(|e| e.get("components"))
-        .and_then(|c| c.get("jackdaw::prefab::components::Prefab"))
+        .and_then(|c| c.get(crate::prefab::resolver_bsn::PREFAB_TYPE))
         .is_some()
 }
 
@@ -508,7 +550,12 @@ fn refresh_browser_on_change(
                     return None;
                 }
                 let path = entry.path();
-                let is_directory = entry.file_type().ok()?.is_dir();
+                // `DirEntry::file_type` reports the link itself, so a
+                // symlinked directory used to classify as a file and render
+                // as an unopenable row. Ask the path, which follows the
+                // link: symlinking a shared art kit into a project is a
+                // normal way to avoid copying gigabytes of models.
+                let is_directory = path.is_dir();
 
                 let texture_info = if !is_directory && is_image_file_path(&path) {
                     let ext = path
@@ -554,15 +601,15 @@ fn refresh_browser_on_change(
             })
             .collect();
 
-        // Compute is_prefab for `.jsn` files (cached by mtime), then apply
-        // the prefabs_only filter if it's enabled.
+        // Compute is_prefab for scene documents (cached by mtime), then
+        // apply the prefabs_only filter if it's enabled.
         for entry in entries.iter_mut() {
             if !entry.is_directory
                 && entry
                     .path
                     .extension()
                     .and_then(|e| e.to_str())
-                    .is_some_and(|e| e.eq_ignore_ascii_case("jsn"))
+                    .is_some_and(|e| e.eq_ignore_ascii_case("jsn") || e.eq_ignore_ascii_case("bsn"))
             {
                 entry.is_prefab = state.prefab_cache.check(&entry.path);
             }
@@ -762,6 +809,20 @@ fn refresh_browser_on_change(
             };
 
             let item_entity = match state.view_mode {
+                // A `.glb`/`.gltf` grid tile gets a thumbnail slot in place
+                // of the plain glyph. List mode keeps the glyph: a 16px row
+                // is too small for a rendered model to say anything.
+                BrowserViewMode::Grid
+                    if crate::model_thumbnail::is_model_path(&entry.path)
+                        && !entry.is_directory =>
+                {
+                    commands
+                        .spawn((
+                            model_grid_tile(&item, &icon_font, entry.path.clone()),
+                            ChildOf(content_entity),
+                        ))
+                        .id()
+                }
                 BrowserViewMode::Grid => commands
                     .spawn((
                         file_browser::file_browser_item_with_icon(&item, &icon_font, icon_override),
@@ -1004,6 +1065,72 @@ fn unhighlight_on_out(out: On<Pointer<Out>>, mut bg: Query<&mut BackgroundColor>
     if let Ok(mut bg) = bg.get_mut(out.event_target()) {
         bg.0 = Color::NONE;
     }
+}
+
+/// Grid tile for a `.glb` / `.gltf` entry.
+///
+/// Same shape as [`file_browser::file_browser_item_with_icon`] -- and it
+/// carries the same `FileBrowserItem`, so click, double-click, right-click
+/// and drag-to-viewport all keep working through the observers the caller
+/// attaches. The one difference is that the icon sits inside a fixed square
+/// tagged [`ModelThumbnailSlot`], which [`crate::model_thumbnail`] swaps for
+/// the rendered picture once there is one. The glyph is the fallback, so a
+/// pending or failed thumbnail looks exactly like the browser did before.
+fn model_grid_tile(item: &FileBrowserItem, icon_font: &IconFont, path: PathBuf) -> impl Bundle {
+    let slot_size = crate::model_thumbnail::THUMBNAIL_DISPLAY_SIZE;
+    (
+        item.clone(),
+        Node {
+            flex_direction: FlexDirection::Column,
+            align_items: AlignItems::Center,
+            padding: UiRect::all(Val::Px(6.0)),
+            width: Val::Px(80.0),
+            border_radius: BorderRadius::all(Val::Px(tokens::BORDER_RADIUS_MD)),
+            ..default()
+        },
+        BackgroundColor(Color::NONE),
+        children![
+            (
+                ModelThumbnailSlot::new(path),
+                Node {
+                    width: Val::Px(slot_size),
+                    height: Val::Px(slot_size),
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                children![(
+                    Text::new(String::from(
+                        file_browser::file_icon(&item.file_name).unicode()
+                    )),
+                    TextFont {
+                        font: icon_font.0.clone().into(),
+                        font_size: tokens::ICON_LG,
+                        ..default()
+                    },
+                    TextColor(tokens::FILE_ICON_COLOR),
+                )],
+            ),
+            (
+                Text::new(truncate_tile_name(&item.file_name, 12)),
+                TextFont {
+                    font_size: tokens::TEXT_SIZE_SM,
+                    ..default()
+                },
+                ThemedText,
+            ),
+        ],
+    )
+}
+
+/// Shorten a file name to fit a grid tile, cutting on a character boundary
+/// so a non-ASCII name cannot panic the slice.
+fn truncate_tile_name(name: &str, max_len: usize) -> String {
+    if name.chars().count() <= max_len {
+        return name.to_string();
+    }
+    let head: String = name.chars().take(max_len.saturating_sub(3)).collect();
+    format!("{head}...")
 }
 
 fn load_thumbnail(path: &Path, asset_server: &AssetServer) -> Option<Handle<Image>> {
@@ -1742,7 +1869,7 @@ fn prefabs_only_chip(icon_font: Handle<Font>) -> impl Bundle {
         Interaction::default(),
         Hovered::default(),
         Tooltip::title("Prefabs only")
-            .with_description("Show only `.jsn` files that define a prefab."),
+            .with_description("Show only scene files that define a prefab."),
         Node {
             flex_direction: FlexDirection::Row,
             align_items: AlignItems::Center,
@@ -1948,5 +2075,57 @@ mod tests {
         let path = tmp.path().join("g.jsn");
         std::fs::write(&path, "not json at all").unwrap();
         assert!(!read_is_prefab(&path), "invalid JSON returns false");
+    }
+
+    /// `.bsn` is the format the editor actually writes prefabs in, so it is
+    /// the case that matters most; detection used to parse every candidate
+    /// as JSON and missed all of them.
+    #[test]
+    fn read_is_prefab_detects_a_bsn_prefab() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("Cube1.bsn");
+        let body = "jackdaw::prefab::components::Prefab\n\
+                    jackdaw::prefab::components::PrefabEntityId(0)\n\
+                    #Cube1\n\
+                    bevy_camera::visibility::Visibility::Inherited\n";
+        std::fs::write(&path, body).unwrap();
+        assert!(read_is_prefab(&path), "a .bsn prefab is detected");
+    }
+
+    #[test]
+    fn read_is_prefab_rejects_a_plain_bsn_scene() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("scene.bsn");
+        let body = "#Root\n\
+                    bevy_transform::components::transform::Transform\n\
+                    bevy_camera::visibility::Visibility::Inherited\n";
+        std::fs::write(&path, body).unwrap();
+        assert!(
+            !read_is_prefab(&path),
+            "a hand-authored scene is not a prefab"
+        );
+    }
+
+    /// The marker has to be on a root. A document that only mentions the
+    /// type path in passing must not pass the filter.
+    #[test]
+    fn read_is_prefab_rejects_a_bsn_that_only_mentions_the_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("named.bsn");
+        let body = "#\"jackdaw::prefab::components::Prefab\"\n\
+                    bevy_camera::visibility::Visibility::Inherited\n";
+        std::fs::write(&path, body).unwrap();
+        assert!(
+            !read_is_prefab(&path),
+            "the marker as a name is not the marker as a component"
+        );
+    }
+
+    #[test]
+    fn read_is_prefab_returns_false_on_unparseable_bsn() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("broken.bsn");
+        std::fs::write(&path, "jackdaw::prefab::components::Prefab {{{{").unwrap();
+        assert!(!read_is_prefab(&path), "a parse failure is not a prefab");
     }
 }

--- a/src/bin/jd.rs
+++ b/src/bin/jd.rs
@@ -25,6 +25,7 @@ fn main() -> ExitCode {
         Some("import") => exit(jackdaw::scaffold::run_import_cli(&args[1..])),
         Some("open") => exit(jackdaw::scaffold::run_open_cli(&args[1..])),
         Some("upgrade") => exit(jackdaw::scaffold::run_upgrade_cli(&args[1..])),
+        Some("export-terrain") => jackdaw::terrain::export::run_export_terrain_cli(&args[1..]),
         Some("extension") => extension_command(&args[1..]),
         Some("--help" | "-h" | "help") | None => {
             print_usage();
@@ -105,6 +106,13 @@ const SPECS: &[CommandSpec] = &[
         values: &["--project", "-p"],
         usage: "jd doctor [--project <path>]",
     },
+    CommandSpec {
+        name: "export-terrain",
+        flags: &["--raw-heights"],
+        values: &["--out", "--cell-size", "--elevation-step"],
+        usage: "jd export-terrain <scene.bsn> --out <dir> [--cell-size <metres>] \
+                [--elevation-step <metres>] [--raw-heights]",
+    },
 ];
 
 enum OptionCheck {
@@ -184,6 +192,11 @@ fn print_usage() {
          run [--project <path>]     Build and run the game\n  \
          setup                      Prepare the pinned SDK\n  \
          doctor [--project <path>]  Check build prerequisites and a project's setup\n  \
+         export-terrain <scene.bsn> --out <dir>\n    \
+                                    Export a terrain's heightmap/channels/placements\n    \
+           --cell-size <m>            declare the XZ quantization cell size\n    \
+           --elevation-step <m>       declare the elevation quantization step\n    \
+           --raw-heights              also write heights.f32 (raw float heights)\n  \
          extension <command>        Package or manage signed extensions\n\n\
          Start here: `jd new my-game` then `jd open my-game`, or `jd import .` in an \
          existing Bevy project."

--- a/src/boot_ops.rs
+++ b/src/boot_ops.rs
@@ -1,0 +1,250 @@
+//! `JACKDAW_RUN_OP`: run operators once at startup, with no mouse.
+//!
+//! Everything the editor does goes through an operator, and until now
+//! every operator needed a click. That makes half the editor untestable
+//! by anything but a human: a CI job cannot scatter a terrain, a bug
+//! report cannot be replayed, and an agent capturing evidence has to
+//! aim a synthetic pointer at a button.
+//!
+//! ```text
+//! JACKDAW_RUN_OP="terrain.scatter density=1.2 seed=7"
+//! JACKDAW_RUN_OP="terrain.scatter seed=1; viewport.screenshot path=/tmp/a.png"
+//! ```
+//!
+//! Same family as [`crate::project::ENV_OPEN_PROJECT`],
+//! [`crate::screenshot::ENV_SHOT`] and `JACKDAW_AUTO_OPEN`: read once at
+//! startup, acted on after the editor settles. Unlike `JACKDAW_SHOT`
+//! this one does **not** exit afterwards -- an operator run is usually
+//! setup for something else (a screenshot, a manual look), not the whole
+//! job.
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_scene_types::PropertyValue;
+
+/// Names operators to run once the editor has settled.
+pub const ENV_RUN_OP: &str = "JACKDAW_RUN_OP";
+
+/// Frames to let pass after entering the editor before the first
+/// operator runs. Matches [`crate::screenshot`]'s settle count: the
+/// panels, the opened scene and the first rendered frame all have to
+/// exist before an operator that reads the scene means anything.
+const SETTLE_FRAMES: u32 = 90;
+
+/// Frames between one clause and the next.
+///
+/// Not one per frame: a later clause routinely depends on the earlier
+/// one having *finished*, not merely having run. An operator that queues
+/// its real work through `Commands` needs a frame boundary, and one that
+/// spawns glTF instances needs however long the asset server takes to
+/// load and render them before a screenshot of the result means
+/// anything. Same settle budget as the first clause, for the same
+/// reason.
+const GAP_FRAMES: u32 = SETTLE_FRAMES;
+
+pub(crate) fn plugin(app: &mut App) {
+    if let Some(spec) = std::env::var_os(ENV_RUN_OP).and_then(|v| v.into_string().ok()) {
+        let queue = parse_run_ops(&spec);
+        if queue.is_empty() {
+            warn!("{ENV_RUN_OP} is set but names no operator: {spec:?}");
+        }
+        app.insert_resource(BootOpQueue { queue, frames: 0 });
+    }
+    app.add_systems(
+        Update,
+        drive_boot_ops.run_if(in_state(crate::AppState::Editor)),
+    );
+}
+
+/// One parsed `<id> [key=value ...]` clause.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BootOp {
+    pub id: String,
+    pub params: Vec<(String, PropertyValue)>,
+}
+
+/// The pending startup runs. Absent when [`ENV_RUN_OP`] is unset, which
+/// is every interactive launch.
+#[derive(Resource)]
+struct BootOpQueue {
+    queue: Vec<BootOp>,
+    frames: u32,
+}
+
+/// Parse a `JACKDAW_RUN_OP` value.
+///
+/// Clauses are separated by `;`, tokens within a clause by whitespace,
+/// and the first token is the operator id. A token containing `=` is a
+/// parameter; anything else is ignored with a warning rather than
+/// failing the boot, because a typo in an environment variable should
+/// not cost a whole editor launch.
+///
+/// Values are typed by what they look like, not by a declaration:
+/// `true`/`false` become `Bool`, an integer becomes `Int`, a decimal
+/// becomes `Float`, everything else stays `String`. There is no quoting,
+/// so a value cannot contain a space -- comma-separated lists (the shape
+/// every list parameter in the editor already uses) work, sentences do
+/// not.
+pub fn parse_run_ops(spec: &str) -> Vec<BootOp> {
+    let mut out = Vec::new();
+    for clause in spec.split(';') {
+        let mut tokens = clause.split_whitespace();
+        let Some(id) = tokens.next() else {
+            continue;
+        };
+        let mut params = Vec::new();
+        for token in tokens {
+            match token.split_once('=') {
+                Some((key, value)) if !key.is_empty() => {
+                    params.push((key.to_string(), parse_value(value)));
+                }
+                _ => warn!("{ENV_RUN_OP}: ignoring token {token:?}, expected key=value"),
+            }
+        }
+        out.push(BootOp {
+            id: id.to_string(),
+            params,
+        });
+    }
+    out
+}
+
+/// Type a parameter value by its spelling.
+///
+/// `i64` is tried before `f64` so `seed=7` arrives as an `Int` and
+/// matches `OperatorParameters::as_int`; an operator that wants a float
+/// there would read `7` as an int and miss it, which is why every
+/// numeric operator parameter in the editor declares one type or the
+/// other and callers write `1.0` when they mean a float.
+fn parse_value(raw: &str) -> PropertyValue {
+    match raw {
+        "true" => return PropertyValue::Bool(true),
+        "false" => return PropertyValue::Bool(false),
+        _ => {}
+    }
+    if let Ok(int) = raw.parse::<i64>() {
+        return PropertyValue::Int(int);
+    }
+    if let Ok(float) = raw.parse::<f64>() {
+        return PropertyValue::Float(float);
+    }
+    PropertyValue::String(raw.to_string().into())
+}
+
+/// Count settle frames, then drain the queue one clause every
+/// [`GAP_FRAMES`].
+fn drive_boot_ops(world: &mut World) {
+    let Some(queue) = world.get_resource::<BootOpQueue>() else {
+        return;
+    };
+    if queue.queue.is_empty() {
+        return;
+    }
+    let frames = queue.frames + 1;
+    world.resource_mut::<BootOpQueue>().frames = frames;
+    if frames < SETTLE_FRAMES || !(frames - SETTLE_FRAMES).is_multiple_of(GAP_FRAMES) {
+        return;
+    }
+
+    let op = world.resource_mut::<BootOpQueue>().queue.remove(0);
+    let mut call = world.operator(op.id.clone());
+    for (key, value) in op.params {
+        call = call.param(key, value);
+    }
+    match call.call() {
+        Ok(result) => info!("{ENV_RUN_OP}: {} -> {result:?}", op.id),
+        Err(err) => error!("{ENV_RUN_OP}: {} failed: {err}", op.id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn param(key: &str, value: PropertyValue) -> (String, PropertyValue) {
+        (key.to_string(), value)
+    }
+
+    #[test]
+    fn a_bare_operator_id_parses_with_no_parameters() {
+        assert_eq!(
+            parse_run_ops("terrain.scatter"),
+            vec![BootOp {
+                id: "terrain.scatter".to_string(),
+                params: Vec::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parameter_values_are_typed_by_their_spelling() {
+        let ops = parse_run_ops(
+            "terrain.scatter seed=7 density=1.5 random_yaw=true align_to_normal=false \
+             terrain=Ground accept=1,2",
+        );
+        assert_eq!(ops.len(), 1);
+        assert_eq!(
+            ops[0].params,
+            vec![
+                param("seed", PropertyValue::Int(7)),
+                param("density", PropertyValue::Float(1.5)),
+                param("random_yaw", PropertyValue::Bool(true)),
+                param("align_to_normal", PropertyValue::Bool(false)),
+                param("terrain", PropertyValue::String("Ground".into())),
+                param("accept", PropertyValue::String("1,2".into())),
+            ]
+        );
+    }
+
+    #[test]
+    fn semicolons_separate_a_sequence_of_runs() {
+        let ops = parse_run_ops("terrain.scatter seed=3 ; viewport.screenshot path=/tmp/a.png");
+        assert_eq!(ops.len(), 2);
+        assert_eq!(ops[0].id, "terrain.scatter");
+        assert_eq!(ops[0].params, vec![param("seed", PropertyValue::Int(3))]);
+        assert_eq!(ops[1].id, "viewport.screenshot");
+        assert_eq!(
+            ops[1].params,
+            vec![param("path", PropertyValue::String("/tmp/a.png".into()))]
+        );
+    }
+
+    /// A malformed token is skipped rather than failing the whole boot.
+    #[test]
+    fn a_token_without_an_equals_is_dropped_and_the_rest_survives() {
+        let ops = parse_run_ops("terrain.scatter nonsense seed=4");
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].params, vec![param("seed", PropertyValue::Int(4))]);
+    }
+
+    #[test]
+    fn an_empty_or_blank_spec_parses_to_nothing_runnable() {
+        assert!(parse_run_ops("").is_empty());
+        assert!(parse_run_ops("   ;  ").is_empty());
+    }
+
+    /// A negative number still types as an int, so `weight_channel=-1`
+    /// reaches the operator as the "off" value it expects.
+    #[test]
+    fn negative_numbers_stay_numeric() {
+        let ops = parse_run_ops("terrain.scatter weight_channel=-1 offset=-0.5");
+        assert_eq!(
+            ops[0].params,
+            vec![
+                param("weight_channel", PropertyValue::Int(-1)),
+                param("offset", PropertyValue::Float(-0.5)),
+            ]
+        );
+    }
+
+    /// A path with an `=` in it keeps everything after the first one, so
+    /// a query-string-ish value survives.
+    #[test]
+    fn only_the_first_equals_splits_a_parameter() {
+        let ops = parse_run_ops("op.id key=a=b");
+        assert_eq!(
+            ops[0].params,
+            vec![param("key", PropertyValue::String("a=b".into()))]
+        );
+    }
+}

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -324,6 +324,7 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::material_browser::add_to_extension(ctx);
         crate::inspector::ops::add_to_extension(ctx);
         crate::viewport::add_to_extension(ctx);
+        crate::screenshot::add_to_extension(ctx);
         crate::command_palette::add_to_extension(ctx);
         crate::document_ops::add_to_extension(ctx);
         crate::dock_ops::add_to_extension(ctx);

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -316,6 +316,10 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::navmesh::ops::add_to_extension(ctx);
         crate::pie::add_to_extension(ctx);
         crate::terrain::ops::add_to_extension(ctx);
+        crate::terrain::paint::add_to_extension(ctx);
+        crate::terrain::channel_ops::add_to_extension(ctx);
+        crate::terrain::quantize_ops::add_to_extension(ctx);
+        crate::terrain::scatter::add_to_extension(ctx);
         crate::asset_browser::add_to_extension(ctx);
         crate::material_browser::add_to_extension(ctx);
         crate::inspector::ops::add_to_extension(ctx);

--- a/src/grid_ops.rs
+++ b/src/grid_ops.rs
@@ -17,6 +17,7 @@ use crate::snapping::{GRID_POWER_MAX, GRID_POWER_MIN, SnapSettings};
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<GridIncreaseOp>()
         .register_operator::<GridDecreaseOp>()
+        .register_operator::<GridSetIncrementOp>()
         .register_operator::<GridToggleSnapOp>();
 
     ctx.bind_operator::<CoreExtensionInputContext, GridIncreaseOp>([PresetInput::key(
@@ -29,11 +30,18 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.bind_operator::<CoreExtensionInputContext, GridToggleSnapOp>([PresetInput::key("KeyM")]);
 }
 
+/// Stepping the power takes the grid back onto the power-of-two ladder.
+///
+/// The power control and the explicit increment are two ways of saying
+/// the same thing, so touching one has to win outright. Leaving a 1.5
+/// increment in place while the power stepped underneath it would make
+/// the bracket keys look broken.
 #[operator(id = "grid.increase", label = "Increase Grid")]
 pub(crate) fn grid_increase(
     _: In<OperatorParameters>,
     mut snap: ResMut<SnapSettings>,
 ) -> OperatorResult {
+    snap.grid_increment = 0.0;
     snap.grid_power = i32::min(snap.grid_power + 1, GRID_POWER_MAX);
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished
@@ -44,7 +52,36 @@ pub(crate) fn grid_decrease(
     _: In<OperatorParameters>,
     mut snap: ResMut<SnapSettings>,
 ) -> OperatorResult {
+    snap.grid_increment = 0.0;
     snap.grid_power = i32::max(snap.grid_power - 1, GRID_POWER_MIN);
+    snap.translate_increment = snap.grid_size();
+    OperatorResult::Finished
+}
+
+/// Set the grid to an explicit size, off the power-of-two ladder.
+///
+/// A value of `0` or less hands the grid back to `grid_power`, so there
+/// is a way out that does not require guessing which power the game was
+/// on before.
+#[operator(
+    id = "grid.set_increment",
+    label = "Set Grid Increment",
+    description = "Set the grid to an exact size in world units.",
+    params(value(
+        f64,
+        doc = "Grid size in world units. 0 or less restores the power-of-two grid."
+    ))
+)]
+pub(crate) fn grid_set_increment(
+    params: In<OperatorParameters>,
+    mut snap: ResMut<SnapSettings>,
+) -> OperatorResult {
+    let value = params.as_float("value")? as f32;
+    snap.grid_increment = if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        0.0
+    };
     snap.translate_increment = snap.grid_size();
     OperatorResult::Finished
 }

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -124,6 +124,63 @@ pub(crate) fn add_component_displays(
     }
 }
 
+/// Scene-document components that live under `jackdaw_scene_types` and
+/// carry the inspector's dedicated tool surfaces: `Brush` mounts the
+/// mesh card (`brush_display`, and with it the whole Mesh tab), `Terrain`
+/// mounts the scatter / quantization / channel / generation sections.
+///
+/// [`hidden_by_namespace`] exists to keep jackdaw's own bookkeeping
+/// components out of the generic list. These two are not bookkeeping --
+/// they are the scene data the user selected the entity to edit -- so
+/// culling them takes their entire tool surface with them and leaves a
+/// cube or a terrain showing nothing but `Transform`.
+const SCENE_TYPES_WITH_INSPECTOR_CARDS: [&str; 2] = [
+    "jackdaw_scene_types::types::Brush",
+    "jackdaw_scene_types::types::Terrain",
+];
+
+/// Whether a `jackdaw*` type is editor bookkeeping rather than something
+/// the inspector should offer as a card.
+///
+/// A namespace cull with two kinds of hole punched in it: the crates whose
+/// components are user-facing wholesale, and the individual scene-data
+/// types in [`SCENE_TYPES_WITH_INSPECTOR_CARDS`].
+fn hidden_by_namespace(full_path: &str) -> bool {
+    full_path.starts_with("jackdaw")
+        && !full_path.starts_with("jackdaw_jsn")
+        && !full_path.starts_with("jackdaw_geometry")
+        && !full_path.starts_with("jackdaw::reference_image")
+        && !full_path.starts_with("jackdaw_avian_integration")
+        && !full_path.starts_with("jackdaw_animation")
+        && !full_path.starts_with("jackdaw_multiplayer")
+        && !SCENE_TYPES_WITH_INSPECTOR_CARDS.contains(&full_path)
+}
+
+/// Whether the scene document tracks `full_path` on the inspected entity.
+///
+/// A document node records an enum component under its authored VARIANT
+/// path (`bevy_camera::visibility::Visibility::Visible`), never the bare
+/// type path, so an exact set lookup misses every enum component the
+/// scene authors and the AST filter drops it from the inspector. Match a
+/// stored path that is `full_path` plus exactly one `::`-separated
+/// variant segment; requiring a single segment keeps `Foo` from claiming
+/// a nested `Foo::Bar::Baz`.
+///
+/// Same rule `SceneBsnAst::find_patch_by_type_path` applies when it looks
+/// a patch up by type -- this is the string-set twin of it, because
+/// `component_type_paths` hands back raw authored paths.
+fn ast_tracks(jsn_type_paths: &HashSet<String>, full_path: &str) -> bool {
+    if jsn_type_paths.contains(full_path) {
+        return true;
+    }
+    jsn_type_paths.iter().any(|stored| {
+        stored
+            .strip_prefix(full_path)
+            .and_then(|rest| rest.strip_prefix("::"))
+            .is_some_and(|variant| !variant.is_empty() && !variant.contains("::"))
+    })
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "inspector rebuild needs the full system param set; bundling into a struct would just push the problem one frame down"
@@ -216,14 +273,7 @@ pub(crate) fn build_inspector_displays(
             {
                 let table = registration.type_info().type_path_table();
                 let full_path = table.path();
-                if full_path.starts_with("jackdaw")
-                    && !full_path.starts_with("jackdaw_jsn")
-                    && !full_path.starts_with("jackdaw_geometry")
-                    && !full_path.starts_with("jackdaw::reference_image")
-                    && !full_path.starts_with("jackdaw_avian_integration")
-                    && !full_path.starts_with("jackdaw_animation")
-                    && !full_path.starts_with("jackdaw_multiplayer")
-                {
+                if hidden_by_namespace(full_path) {
                     return None;
                 }
                 // AST filter: hide Bevy-internal components that
@@ -246,7 +296,7 @@ pub(crate) fn build_inspector_displays(
                         || full_path.starts_with("jackdaw_multiplayer"));
                 if !is_user_type
                     && !jsn_type_paths.is_empty()
-                    && !jsn_type_paths.contains(full_path)
+                    && !ast_tracks(jsn_type_paths, full_path)
                 {
                     return None;
                 }
@@ -1191,5 +1241,73 @@ pub(crate) fn filter_inspector_components(
                 Display::None
             };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ast_tracks, hidden_by_namespace};
+    use std::collections::HashSet;
+
+    fn set(paths: &[&str]) -> HashSet<String> {
+        paths.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn an_enum_component_authored_as_a_variant_still_counts_as_tracked() {
+        // What a scene document actually stores for `Visibility`.
+        let tracked = set(&[
+            "bevy_transform::components::transform::Transform",
+            "bevy_camera::visibility::Visibility::Visible",
+        ]);
+        assert!(ast_tracks(&tracked, "bevy_camera::visibility::Visibility"));
+        assert!(ast_tracks(
+            &tracked,
+            "bevy_transform::components::transform::Transform"
+        ));
+    }
+
+    #[test]
+    fn a_type_the_document_never_authored_stays_untracked() {
+        let tracked = set(&["bevy_camera::visibility::Visibility::Visible"]);
+        // Computed siblings share a module, not an identity.
+        assert!(!ast_tracks(
+            &tracked,
+            "bevy_camera::visibility::InheritedVisibility"
+        ));
+        // A prefix that is not followed by `::` is not a variant.
+        assert!(!ast_tracks(&tracked, "bevy_camera::visibility::Visib"));
+        // One variant segment only: `Foo` must not claim `Foo::Bar::Baz`.
+        assert!(!ast_tracks(&set(&["a::B::C::D"]), "a::B"));
+        assert!(ast_tracks(&set(&["a::B::C"]), "a::B"));
+    }
+
+    #[test]
+    fn the_scene_data_components_with_their_own_cards_survive_the_namespace_cull() {
+        // Each mounts a dedicated inspector surface; culling either one
+        // takes a whole tool panel out of the editor.
+        assert!(!hidden_by_namespace("jackdaw_scene_types::types::Brush"));
+        assert!(!hidden_by_namespace("jackdaw_scene_types::types::Terrain"));
+    }
+
+    #[test]
+    fn editor_bookkeeping_stays_out_of_the_generic_list() {
+        assert!(hidden_by_namespace(
+            "jackdaw_scene_types::node_id::SceneNodeId"
+        ));
+        assert!(hidden_by_namespace(
+            "jackdaw::draw_brush::stable_id::BrushStableId"
+        ));
+        // The wholesale-allowed crates are untouched by the cull.
+        assert!(!hidden_by_namespace(
+            "jackdaw_avian_integration::AvianCollider"
+        ));
+        assert!(!hidden_by_namespace(
+            "jackdaw_geometry::modifiers::ModifierStack"
+        ));
+        // Non-jackdaw types never reach this rule's business end.
+        assert!(!hidden_by_namespace(
+            "bevy_transform::components::transform::Transform"
+        ));
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -538,8 +538,10 @@ fn format_grid_size(size: f32) -> String {
     if size.fract() == 0.0 {
         format!("{size:.0}")
     } else {
-        // Powers of two below 1 are exact; default formatting renders
-        // them cleanly (e.g. 0.25, 0.0625).
+        // Default `f32` formatting prints the shortest string that reads
+        // back as the same value, so it renders both the power-of-two
+        // sizes (0.25, 0.0625) and an explicit metric increment (1.5,
+        // 2.5) without a trailing tail of digits.
         format!("{size}")
     }
 }
@@ -1747,5 +1749,29 @@ mod live_badge_tests {
             Color::NONE,
             "the viewport border clears back to transparent in Scene mode"
         );
+    }
+}
+
+#[cfg(test)]
+mod grid_readout_tests {
+    use super::*;
+
+    #[test]
+    fn whole_sizes_lose_their_trailing_zero() {
+        assert_eq!(format_grid_size(1.0), "1");
+        assert_eq!(format_grid_size(8.0), "8");
+    }
+
+    #[test]
+    fn power_of_two_fractions_read_exactly() {
+        assert_eq!(format_grid_size(0.25), "0.25");
+        assert_eq!(format_grid_size(0.0625), "0.0625");
+    }
+
+    #[test]
+    fn an_explicit_metric_increment_reads_as_itself() {
+        assert_eq!(format_grid_size(1.5), "1.5");
+        assert_eq!(format_grid_size(2.5), "2.5");
+        assert_eq!(format_grid_size(0.75), "0.75");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod app_ops;
 pub mod asset_browser;
 pub mod asset_catalog;
 pub mod asset_ingest;
+pub mod boot_ops;
 pub mod brush;
 pub mod brush_drag_ops;
 pub mod brush_element_ops;
@@ -71,6 +72,7 @@ pub mod mesh_quick_menu;
 pub mod migrate;
 pub mod modal_inputs;
 pub mod modal_transform;
+pub mod model_thumbnail;
 pub mod modifier_ops;
 pub mod navmesh;
 pub mod new_project;
@@ -98,6 +100,7 @@ pub mod scaffold;
 pub mod scene_io;
 pub mod scene_ops;
 pub mod scenes;
+pub mod screenshot;
 pub mod scrolling_log;
 pub mod sdk_paths;
 pub mod sdk_setup;
@@ -355,12 +358,15 @@ impl Plugin for EditorCorePlugin {
             alignment_guides::AlignmentGuidesPlugin,
             navmesh::NavmeshPlugin,
             terrain::TerrainPlugin,
+            screenshot::plugin,
             reference_image::ReferenceImagePlugin,
             jackdaw_widgets::RadialMenuPlugin,
             mesh_quick_menu::MeshQuickMenuPlugin,
             remote::RemoteConnectionPlugin,
             remote::debug::RemoteDebugPlugin,
         ))
+        .add_plugins(model_thumbnail::plugin)
+        .add_plugins(boot_ops::plugin)
         .add_plugins(jackdaw_avian_integration::PhysicsOverlaysPlugin::<
             selection::Selected,
         >::new())

--- a/src/modal_transform.rs
+++ b/src/modal_transform.rs
@@ -179,11 +179,8 @@ fn viewport_drag_detect(
         return;
     }
 
-    // Block viewport drag during terrain sculpt mode
-    if matches!(
-        *terrain_edit_mode,
-        crate::terrain::TerrainEditMode::Sculpt(_)
-    ) {
+    // Block viewport drag during terrain sculpt or paint mode
+    if terrain_edit_mode.brush_active() {
         return;
     }
 
@@ -295,11 +292,8 @@ fn viewport_drag_update(
         return;
     }
 
-    // Cancel pending drag if terrain sculpt mode became active
-    if matches!(
-        *terrain_edit_mode,
-        crate::terrain::TerrainEditMode::Sculpt(_)
-    ) {
+    // Cancel pending drag if terrain sculpt or paint mode became active
+    if terrain_edit_mode.brush_active() {
         drag_state.pending = None;
         return;
     }

--- a/src/model_thumbnail.rs
+++ b/src/model_thumbnail.rs
@@ -148,6 +148,13 @@ struct CacheEntry {
 /// which memoizes prefab detection the same way.
 #[derive(Default)]
 struct ThumbnailCache {
+    // Grows for the life of the process: entries are replaced on a stale
+    // mtime but never evicted for a path that stops being referenced
+    // (deleted model, browser navigated elsewhere for good). A project
+    // with a very large, high-churn asset set could grow this
+    // unboundedly over a long editor session. Not a problem this round
+    // (one `Handle<Image>` + a mtime per entry), but a real cache would
+    // want an eviction policy if that ever changes.
     entries: HashMap<PathBuf, CacheEntry>,
     queue: VecDeque<PathBuf>,
     queued: HashSet<PathBuf>,
@@ -164,6 +171,16 @@ impl ThumbnailCache {
             },
             _ => None,
         }
+    }
+
+    /// Whether `path` is known to have failed at the mtime it currently
+    /// has. `false` for "never tried" as well as for a stale failure (the
+    /// file changed since), both of which still deserve a fresh attempt.
+    fn is_failed(&self, path: &Path, mtime: SystemTime) -> bool {
+        matches!(
+            self.entries.get(path),
+            Some(entry) if entry.mtime == mtime && matches!(entry.state, ThumbState::Failed)
+        )
     }
 
     /// Ask for a thumbnail. A no-op when one is already known for this mtime
@@ -220,6 +237,23 @@ impl ModelThumbnails {
     /// failed, or the file is unreadable.
     pub fn ready(&self, path: &Path) -> Option<Handle<Image>> {
         self.cache.ready(path, source_mtime(path)?)
+    }
+
+    /// Whether `path` has a cached failure at its current mtime.
+    ///
+    /// One `fs::metadata` call, same as [`Self::ready`]. Callers driving
+    /// a per-frame slot (`update_thumbnail_slots`) should call this only
+    /// until it returns `true` once, then stop asking entirely: without
+    /// that latch, a permanently-broken model on screen paid this
+    /// syscall (and `ready`'s) every single frame for as long as it
+    /// stayed visible.
+    pub fn is_failed(&self, path: &Path) -> bool {
+        match source_mtime(path) {
+            Some(mtime) => self.cache.is_failed(path, mtime),
+            // Cannot even stat it: treat like a permanent failure so the
+            // caller latches and stops asking, same as a render failure.
+            None => true,
+        }
     }
 
     /// Queue `path` for a thumbnail if one is not already known or pending.
@@ -833,6 +867,16 @@ fn update_thumbnail_slots(
         }
 
         let Some(handle) = thumbnails.ready(&slot.path) else {
+            if thumbnails.is_failed(&slot.path) {
+                // Latch: `applied` takes the slot out of this loop
+                // entirely (see its doc), same as a successful install.
+                // Without it, a model that fails to render paid an
+                // fs::metadata call here, and another inside `ready`
+                // above, every single frame for as long as it stayed
+                // visible.
+                slot.applied = true;
+                continue;
+            }
             thumbnails.request(&slot.path);
             continue;
         };
@@ -925,6 +969,29 @@ mod tests {
         // Fixing the file on disk is what makes it eligible again.
         cache.request(path, epoch(2));
         assert_eq!(cache.take_next().as_deref(), Some(path));
+    }
+
+    /// M12 pinning test: `ThumbnailCache::is_failed` (which
+    /// `update_thumbnail_slots` uses to latch `slot.applied` and stop
+    /// hitting the filesystem every frame) must read `true` for a
+    /// failure at the current mtime and `false` for both "never tried"
+    /// and "failed at a stale mtime" -- both of the latter deserve
+    /// another attempt, not a permanent latch.
+    #[test]
+    fn is_failed_reads_true_only_for_a_failure_at_the_current_mtime() {
+        let mut cache = ThumbnailCache::default();
+        let path = Path::new("/kit/broken.gltf");
+        assert!(!cache.is_failed(path, epoch(1)), "never attempted yet");
+
+        cache.record(path, epoch(1), ThumbState::Failed);
+        assert!(cache.is_failed(path, epoch(1)));
+        assert!(
+            !cache.is_failed(path, epoch(2)),
+            "the file changed since the failure; it deserves another try"
+        );
+
+        cache.record(path, epoch(1), ThumbState::Ready(Handle::default()));
+        assert!(!cache.is_failed(path, epoch(1)), "a later success clears it");
     }
 
     #[test]

--- a/src/model_thumbnail.rs
+++ b/src/model_thumbnail.rs
@@ -1,0 +1,978 @@
+//! Rendered thumbnails for `.glb` / `.gltf` entries in the asset browser.
+//!
+//! A folder of models used to browse as a wall of identical font glyphs,
+//! which makes a 300-model kit unusable. This module photographs each model
+//! off-screen once and caches the result as a PNG under the project's
+//! `.jackdaw/thumbnails/`, so the second visit to a folder costs a file read
+//! rather than a scene load and a GPU pass.
+//!
+//! The off-screen setup copies [`crate::material_preview`]: a camera with
+//! `RenderTarget::Image`, its own [`RenderLayers`] so nothing leaks into a
+//! viewport, and its own [`EnvironmentMapLight`] because lighting is
+//! per-view rather than global. It differs in two ways: one target image is
+//! reused for every model (the pixels are read back and written to disk, so
+//! nothing needs to stay resident), and the whole thing is driven by a
+//! bounded work queue rather than by a selection.
+//!
+//! Three rules the queue exists to keep:
+//!
+//! - **Never stall the editor.** At most one model is rendered at a time and
+//!   at most `DISK_LOADS_PER_FRAME` cached PNGs are decoded per frame.
+//! - **Never re-render what is already on disk.** The cache is keyed by path
+//!   *and* source mtime, so an edited model regenerates and an untouched one
+//!   never does, across editor restarts.
+//! - **Never retry a model that failed.** A `.gltf` that cannot load is
+//!   marked failed for that mtime and skipped until the file changes.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use bevy::{
+    asset::{RenderAssetUsages, embedded_asset, load_embedded_asset},
+    camera::{RenderTarget, visibility::RenderLayers},
+    gltf::GltfAssetLabel,
+    image::{CompressedImageFormats, ImageSampler, ImageType},
+    prelude::*,
+    render::render_resource::TextureFormat,
+    render::view::screenshot::{Screenshot, ScreenshotCaptured},
+    ui::UiGlobalTransform,
+    world_serialization::{WorldAsset, WorldAssetRoot},
+};
+use jackdaw_feathers::tokens;
+
+/// Render layer the thumbnail stage owns exclusively. Layer 0 is the world,
+/// layer 1 is the material preview, and per-viewport grids start at layer 3
+/// (`crate::viewport::ViewportLayerCounter`); this one sits between them so
+/// a model being photographed never appears in a viewport, and a viewport's
+/// grid never appears in a thumbnail.
+pub(crate) const THUMBNAIL_LAYER: usize = 2;
+
+/// Edge of the square render target, in pixels. The browser draws the result
+/// at [`THUMBNAIL_DISPLAY_SIZE`]; rendering larger keeps it crisp on a
+/// high-DPI display and costs about 8 KiB of PNG per model on disk.
+const THUMBNAIL_SIZE: u32 = 128;
+
+/// Edge of the thumbnail as drawn in a browser tile. Close to the glyph it
+/// replaces (`tokens::ICON_LG_PX` at 24 px plus its line box) so a folder of
+/// mixed models and other files keeps one grid rhythm. The browser sizes the
+/// glyph's slot to match, so nothing reflows when a thumbnail arrives.
+pub(crate) const THUMBNAIL_DISPLAY_SIZE: f32 = 40.0;
+
+/// Cached PNGs decoded per frame. Decoding a 128x128 PNG takes well under a
+/// millisecond, so this is generous; the point of the cap is that opening a
+/// 364-entry folder cannot turn one frame into a 364-file read.
+const DISK_LOADS_PER_FRAME: usize = 8;
+
+/// Frames a single render job may spend in one state before it is written
+/// off as failed. A model whose asset load never resolves, or whose scene
+/// never spawns a mesh, must not pin the queue forever.
+const JOB_TIMEOUT_FRAMES: u32 = 600;
+
+/// Frames to let the thumbnail camera draw the framed model before the
+/// read-back is queued. `Screenshot` swaps the target's output attachment
+/// and captures the *next* render into it, so there has to be at least one
+/// more render after the model is in place.
+const SETTLE_FRAMES: u32 = 2;
+
+/// How far outside the browser's scroll viewport a tile still counts as
+/// visible, in pixels. Roughly two extra rows above and below, so a slow
+/// scroll meets thumbnails that are already there.
+const VISIBLE_MARGIN_PX: f32 = 160.0;
+
+/// How much bigger than the model the framing is. At 1.0 the bounding
+/// sphere exactly touches the frustum, which clips the corners of a boxy
+/// model; the excess is the margin around the subject.
+const FRAMING_MARGIN: f32 = 1.25;
+
+/// Distance floor, so a degenerate or empty model does not put the camera
+/// inside its own subject.
+const MIN_CAMERA_DISTANCE: f32 = 0.25;
+
+/// The direction the camera looks from, in model space. A three-quarter
+/// view reads as a solid object where a face-on view reads as a silhouette.
+const VIEW_DIRECTION: Vec3 = Vec3::new(1.0, 0.75, 1.0);
+
+pub(crate) fn plugin(app: &mut App) {
+    // Registered here as well as in `viewport`/`material_preview` so this
+    // module owns its own dependency rather than inheriting whichever
+    // plugin happened to run first. Both resolve to the same asset path.
+    embedded_asset!(
+        app,
+        "../assets/environment_maps/voortrekker_interior_1k_diffuse.ktx2"
+    );
+    embedded_asset!(
+        app,
+        "../assets/environment_maps/voortrekker_interior_1k_specular.ktx2"
+    );
+    app.init_resource::<ModelThumbnails>()
+        .add_systems(OnEnter(crate::AppState::Editor), setup_thumbnail_stage)
+        .add_systems(
+            Update,
+            (drive_thumbnail_queue, update_thumbnail_slots)
+                .run_if(in_state(crate::AppState::Editor)),
+        );
+}
+
+/// True when `path` names a glTF model the browser should photograph.
+pub fn is_model_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("glb") || e.eq_ignore_ascii_case("gltf"))
+}
+
+// -- Cache -------------------------------------------------------------------
+
+/// What is known about one model's thumbnail.
+#[derive(Clone, Debug)]
+enum ThumbState {
+    /// Photographed (or read back from disk) and ready to draw.
+    Ready(Handle<Image>),
+    /// The model could not be loaded or photographed. Not retried until the
+    /// file changes on disk.
+    Failed,
+}
+
+/// A cache entry is only valid for the source mtime it was produced from.
+#[derive(Clone, Debug)]
+struct CacheEntry {
+    mtime: SystemTime,
+    state: ThumbState,
+}
+
+/// Mtime-keyed memo of thumbnail results plus the pending work queue.
+///
+/// Split out from the ECS resource so the interesting rules -- mtime
+/// invalidation and "failed once, do not retry" -- are testable without a
+/// GPU or an `App`. Same shape as `AssetBrowserState`'s `PrefabCheckCache`,
+/// which memoizes prefab detection the same way.
+#[derive(Default)]
+struct ThumbnailCache {
+    entries: HashMap<PathBuf, CacheEntry>,
+    queue: VecDeque<PathBuf>,
+    queued: HashSet<PathBuf>,
+}
+
+impl ThumbnailCache {
+    /// The ready thumbnail for `path`, if one was produced for the mtime
+    /// `path` currently has. A stale or failed entry reads as `None`.
+    fn ready(&self, path: &Path, mtime: SystemTime) -> Option<Handle<Image>> {
+        match self.entries.get(path) {
+            Some(entry) if entry.mtime == mtime => match &entry.state {
+                ThumbState::Ready(handle) => Some(handle.clone()),
+                ThumbState::Failed => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Ask for a thumbnail. A no-op when one is already known for this mtime
+    /// (ready *or* failed) or when the path is already queued; a stale entry
+    /// is dropped so the model is photographed again.
+    fn request(&mut self, path: &Path, mtime: SystemTime) {
+        match self.entries.get(path) {
+            Some(entry) if entry.mtime == mtime => return,
+            Some(_) => {
+                self.entries.remove(path);
+            }
+            None => {}
+        }
+        if self.queued.insert(path.to_path_buf()) {
+            self.queue.push_back(path.to_path_buf());
+        }
+    }
+
+    fn is_queued(&self, path: &Path) -> bool {
+        self.queued.contains(path)
+    }
+
+    fn take_next(&mut self) -> Option<PathBuf> {
+        let path = self.queue.pop_front()?;
+        self.queued.remove(&path);
+        Some(path)
+    }
+
+    fn record(&mut self, path: &Path, mtime: SystemTime, state: ThumbState) {
+        self.entries
+            .insert(path.to_path_buf(), CacheEntry { mtime, state });
+    }
+}
+
+/// The thumbnail cache, the pending queue, and the one in-flight render.
+#[derive(Resource, Default)]
+pub struct ModelThumbnails {
+    cache: ThumbnailCache,
+    job: Option<Job>,
+    /// Where cached PNGs live. `None` until the editor knows its project,
+    /// which also disables the whole feature -- there is nowhere to cache.
+    cache_dir: Option<PathBuf>,
+    /// Set by the read-back observer, consumed by [`drive_thumbnail_queue`].
+    /// The observer runs outside this system's ordering, so its result is
+    /// parked here rather than applied from inside it.
+    capture_result: Option<bool>,
+    /// Thumbnails photographed since the editor started. Reported in the log
+    /// so a first pass over a large kit can be measured.
+    rendered: usize,
+}
+
+impl ModelThumbnails {
+    /// The ready thumbnail for `path`, or `None` while it is pending, has
+    /// failed, or the file is unreadable.
+    pub fn ready(&self, path: &Path) -> Option<Handle<Image>> {
+        self.cache.ready(path, source_mtime(path)?)
+    }
+
+    /// Queue `path` for a thumbnail if one is not already known or pending.
+    pub fn request(&mut self, path: &Path) {
+        if self.cache.is_queued(path) {
+            return;
+        }
+        let Some(mtime) = source_mtime(path) else {
+            return;
+        };
+        self.cache.request(path, mtime);
+    }
+}
+
+/// The file's modification time, or `None` when it cannot be read -- an
+/// unreadable model is not worth queueing.
+fn source_mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// File name of the cached PNG for `path` at `mtime`.
+///
+/// The mtime is part of the *name*, not just of the in-memory key, so a
+/// stale PNG can never be mistaken for a fresh one across editor restarts;
+/// the superseded file is simply orphaned. The path is folded with FNV-1a
+/// rather than [`std::hash::DefaultHasher`] because a disk cache outlives
+/// the process that wrote it and `DefaultHasher` is explicitly not stable
+/// across releases.
+fn cache_file_name(path: &Path, mtime: SystemTime) -> String {
+    let stamp = mtime
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "{:016x}-{:x}.png",
+        fnv1a64(path.to_string_lossy().as_bytes()),
+        stamp
+    )
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+// -- Framing -----------------------------------------------------------------
+
+/// How far the camera has to sit from the centre of a bounding sphere of
+/// `radius` for the whole sphere to fit inside a `fov_y` frustum.
+///
+/// The target is square, so the vertical field of view is also the
+/// horizontal one and a single distance fits both axes.
+fn fit_distance(radius: f32, fov_y: f32, margin: f32) -> f32 {
+    let half_fov = (fov_y * 0.5).clamp(1e-3, core::f32::consts::FRAC_PI_2 - 1e-3);
+    (radius * margin / half_fov.sin()).max(MIN_CAMERA_DISTANCE)
+}
+
+/// Where to put the camera, and what to aim it at, to frame the
+/// axis-aligned box `min..max`. Returns `(position, target)`.
+fn frame_bounds(min: Vec3, max: Vec3, fov_y: f32) -> (Vec3, Vec3) {
+    let center = (min + max) * 0.5;
+    let radius = (max - min).length() * 0.5;
+    let distance = fit_distance(radius, fov_y, FRAMING_MARGIN);
+    (center + VIEW_DIRECTION.normalize() * distance, center)
+}
+
+// -- Stage -------------------------------------------------------------------
+
+#[derive(Component)]
+struct ThumbnailCamera;
+
+/// Root of the model currently being photographed. Despawned when the job
+/// ends, whichever way it ends.
+#[derive(Component)]
+struct ThumbnailSubject;
+
+/// Handle of the shared render target, kept in its own resource so the
+/// read-back does not have to go through the camera.
+#[derive(Resource)]
+struct ThumbnailTarget(Handle<Image>);
+
+fn setup_thumbnail_stage(
+    mut commands: Commands,
+    mut images: ResMut<Assets<Image>>,
+    mut thumbnails: ResMut<ModelThumbnails>,
+    project: Option<Res<crate::project::ProjectRoot>>,
+    assets: Res<AssetServer>,
+) {
+    let layer = RenderLayers::layer(THUMBNAIL_LAYER);
+
+    // `Bgra8UnormSrgb` rather than the material preview's `Rgba8Unorm`:
+    // these pixels come back through `ScreenshotCaptured`, and
+    // `Image::try_into_dynamic` (which `screenshot::write_png` calls)
+    // rejects a non-srgb `Rgba8Unorm`. This is the format the viewport's own
+    // capture path already proves out.
+    let target = images.add(Image::new_target_texture(
+        THUMBNAIL_SIZE,
+        THUMBNAIL_SIZE,
+        TextureFormat::Bgra8UnormSrgb,
+        None,
+    ));
+    commands.insert_resource(ThumbnailTarget(target.clone()));
+
+    thumbnails.cache_dir = project.map(|p| p.jackdaw_dir().join("thumbnails"));
+    if let Some(dir) = &thumbnails.cache_dir {
+        let _ = std::fs::create_dir_all(dir);
+    }
+
+    commands.spawn((
+        ThumbnailCamera,
+        crate::EditorEntity,
+        Camera3d::default(),
+        Camera {
+            order: -1,
+            // Solid, not transparent. `write_png` drops alpha (under HDR it
+            // carries brightness, not opacity), so a transparent clear would
+            // encode as black. Clearing to the panel colour instead makes the
+            // tile read as a cutout against the browser background.
+            clear_color: ClearColorConfig::Custom(tokens::PANEL_BG),
+            ..default()
+        },
+        // Per-view, for the same reason the material preview carries its own:
+        // there is no global "current environment map" resource.
+        EnvironmentMapLight {
+            diffuse_map: load_embedded_asset!(
+                &*assets,
+                "../assets/environment_maps/voortrekker_interior_1k_diffuse.ktx2"
+            ),
+            specular_map: load_embedded_asset!(
+                &*assets,
+                "../assets/environment_maps/voortrekker_interior_1k_specular.ktx2"
+            ),
+            intensity: 1500.0,
+            ..default()
+        },
+        RenderTarget::Image(target.into()),
+        Transform::from_translation(Vec3::splat(3.0)).looking_at(Vec3::ZERO, Vec3::Y),
+        layer.clone(),
+    ));
+
+    // A key light on top of the environment map: image-based lighting alone
+    // flattens the untextured, flat-shaded models these kits are made of.
+    commands.spawn((
+        crate::EditorEntity,
+        DirectionalLight {
+            illuminance: 4000.0,
+            shadow_maps_enabled: false,
+            contact_shadows_enabled: false,
+            ..default()
+        },
+        Transform::from_translation(Vec3::new(4.0, 6.0, 4.0)).looking_at(Vec3::ZERO, Vec3::Y),
+        layer,
+    ));
+}
+
+// -- Work queue --------------------------------------------------------------
+
+/// One model's journey from a queued path to a PNG on disk.
+enum Job {
+    /// Waiting on the glTF asset load.
+    Loading {
+        path: PathBuf,
+        mtime: SystemTime,
+        scene: Handle<WorldAsset>,
+        frames: u32,
+    },
+    /// The scene is spawned; waiting for its meshes to exist so the bounds
+    /// can be measured.
+    Spawned {
+        path: PathBuf,
+        mtime: SystemTime,
+        root: Entity,
+        frames: u32,
+    },
+    /// Framed and rendering; counting down to the read-back.
+    Settling {
+        path: PathBuf,
+        mtime: SystemTime,
+        root: Entity,
+        frames: u32,
+    },
+    /// Read-back queued; waiting for the observer to report.
+    Capturing {
+        path: PathBuf,
+        mtime: SystemTime,
+        root: Entity,
+        frames: u32,
+    },
+}
+
+impl Job {
+    fn path(&self) -> &Path {
+        match self {
+            Job::Loading { path, .. }
+            | Job::Spawned { path, .. }
+            | Job::Settling { path, .. }
+            | Job::Capturing { path, .. } => path,
+        }
+    }
+
+    fn mtime(&self) -> SystemTime {
+        match self {
+            Job::Loading { mtime, .. }
+            | Job::Spawned { mtime, .. }
+            | Job::Settling { mtime, .. }
+            | Job::Capturing { mtime, .. } => *mtime,
+        }
+    }
+
+    fn root(&self) -> Option<Entity> {
+        match self {
+            Job::Loading { .. } => None,
+            Job::Spawned { root, .. }
+            | Job::Settling { root, .. }
+            | Job::Capturing { root, .. } => Some(*root),
+        }
+    }
+
+    fn frames(&self) -> u32 {
+        match self {
+            Job::Loading { frames, .. }
+            | Job::Spawned { frames, .. }
+            | Job::Settling { frames, .. }
+            | Job::Capturing { frames, .. } => *frames,
+        }
+    }
+
+    fn tick(&mut self) {
+        match self {
+            Job::Loading { frames, .. }
+            | Job::Spawned { frames, .. }
+            | Job::Settling { frames, .. }
+            | Job::Capturing { frames, .. } => *frames += 1,
+        }
+    }
+}
+
+/// What one step of the state machine decided to do.
+enum Step {
+    /// Stay where you are; try again next frame.
+    Wait,
+    /// Move to this state.
+    Advance(Job),
+    /// The job is over. Despawn `root` if there is one and record `state`.
+    Finish(Option<Entity>, ThumbState),
+}
+
+/// Advance the one in-flight render job, or start a new one if the queue has
+/// work and nothing is in flight. Cached PNGs are picked off the queue first
+/// and never reach the GPU at all.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one system owns the whole job state machine; splitting it would \
+              mean sharing the in-flight job across systems that must not interleave"
+)]
+fn drive_thumbnail_queue(
+    mut commands: Commands,
+    mut thumbnails: ResMut<ModelThumbnails>,
+    mut images: ResMut<Assets<Image>>,
+    assets: Res<AssetServer>,
+    meshes: Res<Assets<Mesh>>,
+    children_query: Query<&Children>,
+    mesh_query: Query<(&Mesh3d, &GlobalTransform)>,
+    mut camera_query: Query<(&mut Transform, &Projection), With<ThumbnailCamera>>,
+    target: Option<Res<ThumbnailTarget>>,
+) {
+    let Some(target) = target else {
+        return;
+    };
+    if thumbnails.cache_dir.is_none() {
+        return;
+    }
+
+    // Taking the job out of the resource for the duration of the step is
+    // what lets the step borrow the resource mutably (to record a result)
+    // without fighting the borrow on the job itself.
+    if let Some(mut job) = thumbnails.job.take() {
+        job.tick();
+        let step = if job.frames() > JOB_TIMEOUT_FRAMES {
+            warn!("model thumbnail: {} timed out", job.path().display());
+            Step::Finish(job.root(), ThumbState::Failed)
+        } else {
+            step_job(
+                &mut commands,
+                &mut thumbnails,
+                &mut images,
+                &assets,
+                &meshes,
+                &children_query,
+                &mesh_query,
+                &mut camera_query,
+                &target.0,
+                &job,
+            )
+        };
+        match step {
+            Step::Wait => thumbnails.job = Some(job),
+            Step::Advance(next) => thumbnails.job = Some(next),
+            Step::Finish(root, state) => {
+                if let Some(root) = root
+                    && let Ok(mut entity) = commands.get_entity(root)
+                {
+                    entity.try_despawn();
+                }
+                thumbnails.cache.record(job.path(), job.mtime(), state);
+            }
+        }
+        return;
+    }
+
+    // Nothing in flight: drain cached entries, and start a render on the
+    // first path that has no PNG on disk.
+    for _ in 0..DISK_LOADS_PER_FRAME {
+        let Some(path) = thumbnails.cache.take_next() else {
+            return;
+        };
+        let Some(mtime) = source_mtime(&path) else {
+            continue;
+        };
+        if let Some(handle) = load_cached(&thumbnails, &path, mtime, &mut images) {
+            thumbnails
+                .cache
+                .record(&path, mtime, ThumbState::Ready(handle));
+            continue;
+        }
+        let scene = assets.load(GltfAssetLabel::Scene(0).from_asset(to_asset_path(&path)));
+        thumbnails.job = Some(Job::Loading {
+            path,
+            mtime,
+            scene,
+            frames: 0,
+        });
+        return;
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "state-machine step; every argument is one stage's dependency"
+)]
+fn step_job(
+    commands: &mut Commands,
+    thumbnails: &mut ModelThumbnails,
+    images: &mut Assets<Image>,
+    assets: &AssetServer,
+    meshes: &Assets<Mesh>,
+    children_query: &Query<&Children>,
+    mesh_query: &Query<(&Mesh3d, &GlobalTransform)>,
+    camera_query: &mut Query<(&mut Transform, &Projection), With<ThumbnailCamera>>,
+    target: &Handle<Image>,
+    job: &Job,
+) -> Step {
+    match job {
+        Job::Loading {
+            path, mtime, scene, ..
+        } => {
+            let state = assets.load_state(scene.id());
+            if state.is_failed() {
+                warn!("model thumbnail: {} failed to load", path.display());
+                return Step::Finish(None, ThumbState::Failed);
+            }
+            if !state.is_loaded() {
+                return Step::Wait;
+            }
+            // Spawned hidden: bevy resolves `RenderLayers` per entity and
+            // does not inherit it, so the glTF's own entities land on layer
+            // 0 -- the main viewport -- until they are tagged a frame later.
+            // `Visibility` *is* inherited, so hiding the root hides them all
+            // until the layer is right.
+            let root = commands
+                .spawn((
+                    ThumbnailSubject,
+                    crate::EditorEntity,
+                    WorldAssetRoot(scene.clone()),
+                    Transform::IDENTITY,
+                    Visibility::Hidden,
+                    RenderLayers::layer(THUMBNAIL_LAYER),
+                ))
+                .id();
+            Step::Advance(Job::Spawned {
+                path: path.clone(),
+                mtime: *mtime,
+                root,
+                frames: 0,
+            })
+        }
+        Job::Spawned {
+            path, mtime, root, ..
+        } => {
+            let mut vertices = Vec::new();
+            crate::viewport_overlays::collect_descendant_mesh_world_vertices(
+                *root,
+                children_query,
+                mesh_query,
+                meshes,
+                &mut vertices,
+            );
+            if vertices.is_empty() {
+                return Step::Wait; // scene not spawned, or meshes not loaded
+            }
+
+            let mut min = Vec3::splat(f32::INFINITY);
+            let mut max = Vec3::splat(f32::NEG_INFINITY);
+            for vertex in &vertices {
+                min = min.min(*vertex);
+                max = max.max(*vertex);
+            }
+
+            let fov = camera_query
+                .iter()
+                .next()
+                .and_then(|(_, projection)| match projection {
+                    Projection::Perspective(perspective) => Some(perspective.fov),
+                    _ => None,
+                })
+                .unwrap_or(core::f32::consts::FRAC_PI_4);
+            let (position, look_at) = frame_bounds(min, max, fov);
+            if let Some((mut transform, _)) = camera_query.iter_mut().next() {
+                *transform = Transform::from_translation(position).looking_at(look_at, Vec3::Y);
+            }
+
+            apply_layer_recursive(commands, *root, children_query);
+            commands.entity(*root).insert(Visibility::Visible);
+
+            Step::Advance(Job::Settling {
+                path: path.clone(),
+                mtime: *mtime,
+                root: *root,
+                frames: 0,
+            })
+        }
+        Job::Settling {
+            path,
+            mtime,
+            root,
+            frames,
+        } => {
+            if *frames < SETTLE_FRAMES {
+                return Step::Wait;
+            }
+            let Some(file) = thumbnails
+                .cache_dir
+                .as_ref()
+                .map(|dir| dir.join(cache_file_name(path, *mtime)))
+            else {
+                return Step::Finish(Some(*root), ThumbState::Failed);
+            };
+            thumbnails.capture_result = None;
+            commands.spawn(Screenshot::image(target.clone())).observe(
+                move |capture: On<ScreenshotCaptured>, mut thumbs: ResMut<ModelThumbnails>| {
+                    thumbs.capture_result =
+                        Some(crate::screenshot::write_png(&capture.image, &file));
+                },
+            );
+            Step::Advance(Job::Capturing {
+                path: path.clone(),
+                mtime: *mtime,
+                root: *root,
+                frames: 0,
+            })
+        }
+        Job::Capturing {
+            path, mtime, root, ..
+        } => {
+            let Some(wrote) = thumbnails.capture_result.take() else {
+                return Step::Wait;
+            };
+            if !wrote {
+                return Step::Finish(Some(*root), ThumbState::Failed);
+            }
+            // Read the thumbnail back through the same path a cache hit
+            // takes, so a freshly rendered tile and a restored one are the
+            // same image asset in the same format -- and so a write that
+            // cannot be read back is caught here rather than next session.
+            match load_cached(thumbnails, path, *mtime, images) {
+                Some(handle) => {
+                    thumbnails.rendered += 1;
+                    debug!(
+                        "model thumbnail: rendered {} ({} this session)",
+                        path.display(),
+                        thumbnails.rendered
+                    );
+                    Step::Finish(Some(*root), ThumbState::Ready(handle))
+                }
+                None => Step::Finish(Some(*root), ThumbState::Failed),
+            }
+        }
+    }
+}
+
+/// Read the cached PNG for `path` at `mtime` back into an image asset, if
+/// one was written by this or an earlier session. This is the whole point of
+/// the disk cache: reopening a 364-model folder costs 364 file reads rather
+/// than 364 scene loads and GPU passes.
+fn load_cached(
+    thumbnails: &ModelThumbnails,
+    path: &Path,
+    mtime: SystemTime,
+    images: &mut Assets<Image>,
+) -> Option<Handle<Image>> {
+    let file = thumbnails
+        .cache_dir
+        .as_ref()?
+        .join(cache_file_name(path, mtime));
+    let bytes = std::fs::read(&file).ok()?;
+    decode_thumbnail(&bytes).map(|image| images.add(image))
+}
+
+/// Decode thumbnail PNG bytes into an image asset.
+///
+/// `RenderAssetUsages::RENDER_WORLD` only: a browser tile never reads these
+/// pixels back, and keeping the CPU copy of a 364-model kit resident would
+/// cost about 24 MiB for nothing.
+fn decode_thumbnail(bytes: &[u8]) -> Option<Image> {
+    Image::from_buffer(
+        bytes,
+        ImageType::Extension("png"),
+        CompressedImageFormats::NONE,
+        true,
+        ImageSampler::linear(),
+        RenderAssetUsages::RENDER_WORLD,
+    )
+    .ok()
+}
+
+/// Map an absolute file path to the asset path the `AssetServer` wants.
+fn to_asset_path(path: &Path) -> String {
+    crate::entity_ops::to_asset_path(&path.to_string_lossy().replace('\\', "/"))
+}
+
+/// Put every entity in the spawned glTF hierarchy on the thumbnail layer.
+/// Bevy resolves `RenderLayers` per entity and does not inherit it down the
+/// hierarchy, so tagging the root alone would leave the meshes on layer 0.
+fn apply_layer_recursive(commands: &mut Commands, entity: Entity, children: &Query<&Children>) {
+    commands
+        .entity(entity)
+        .insert(RenderLayers::layer(THUMBNAIL_LAYER));
+    if let Ok(kids) = children.get(entity) {
+        for child in kids.iter() {
+            apply_layer_recursive(commands, child, children);
+        }
+    }
+}
+
+// -- Browser tiles -----------------------------------------------------------
+
+/// The square of a model tile that holds either the fallback glyph or the
+/// rendered thumbnail. Placed by the asset browser; driven from here so the
+/// browser does not have to know about render state.
+#[derive(Component)]
+pub struct ModelThumbnailSlot {
+    pub path: PathBuf,
+    /// Set once the image is installed, which takes the slot out of the
+    /// per-frame work entirely: scrolling back over a generated thumbnail
+    /// costs nothing.
+    applied: bool,
+}
+
+impl ModelThumbnailSlot {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            applied: false,
+        }
+    }
+}
+
+/// Request thumbnails for the model tiles the user can actually see, and
+/// install the ones that are ready.
+///
+/// Visibility is decided against the browser's scroll viewport rather than
+/// against the directory listing, so opening a 364-model folder queues the
+/// tiles on screen, not all 364. The on-screen test is pure arithmetic and
+/// runs first, so an off-screen tile costs no filesystem call at all.
+fn update_thumbnail_slots(
+    mut commands: Commands,
+    mut thumbnails: ResMut<ModelThumbnails>,
+    mut slots: Query<(
+        Entity,
+        &mut ModelThumbnailSlot,
+        &UiGlobalTransform,
+        &ComputedNode,
+    )>,
+    content: Query<
+        (&UiGlobalTransform, &ComputedNode),
+        With<crate::asset_browser::AssetBrowserContent>,
+    >,
+    children: Query<&Children>,
+) {
+    let visible_band = content.iter().next().map(|(transform, node)| {
+        let half = node.size().y * 0.5 + VISIBLE_MARGIN_PX;
+        let center = transform.translation.y;
+        (center - half, center + half)
+    });
+
+    for (entity, mut slot, transform, node) in &mut slots {
+        if slot.applied {
+            continue;
+        }
+        let on_screen = visible_band.is_none_or(|(top, bottom)| {
+            let half = node.size().y * 0.5;
+            let center = transform.translation.y;
+            center + half >= top && center - half <= bottom
+        });
+        if !on_screen {
+            continue;
+        }
+
+        let Some(handle) = thumbnails.ready(&slot.path) else {
+            thumbnails.request(&slot.path);
+            continue;
+        };
+        if let Ok(kids) = children.get(entity) {
+            for child in kids.iter() {
+                commands.entity(child).try_despawn();
+            }
+        }
+        commands.spawn((
+            ImageNode::new(handle),
+            Node {
+                width: Val::Px(THUMBNAIL_DISPLAY_SIZE),
+                height: Val::Px(THUMBNAIL_DISPLAY_SIZE),
+                ..default()
+            },
+            // The tile above owns the click, the drag and the context menu;
+            // the picture must not swallow any of them.
+            Pickable::IGNORE,
+            ChildOf(entity),
+        ));
+        slot.applied = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::time::Duration;
+
+    // The render half of this module needs a live wgpu backend, which
+    // `tests/util/mod.rs`'s `headless_app()` deliberately does not have
+    // (`WgpuSettings { backends: None }` renders nothing). Everything below
+    // is the pure half: the cache rules and the framing arithmetic. The
+    // rendering is covered by the screenshot evidence run instead.
+
+    fn epoch(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn model_paths_are_gltf_and_glb_only() {
+        assert!(is_model_path(Path::new("/a/tree.glb")));
+        assert!(is_model_path(Path::new("/a/tree.GLTF")));
+        assert!(!is_model_path(Path::new("/a/tree.png")));
+        assert!(!is_model_path(Path::new("/a/tree")));
+    }
+
+    #[test]
+    fn cache_key_changes_with_path_and_with_mtime() {
+        let a = Path::new("/kit/tree.glb");
+        let b = Path::new("/kit/rock.glb");
+        assert_ne!(cache_file_name(a, epoch(1)), cache_file_name(b, epoch(1)));
+        assert_ne!(cache_file_name(a, epoch(1)), cache_file_name(a, epoch(2)));
+        assert_eq!(cache_file_name(a, epoch(1)), cache_file_name(a, epoch(1)));
+        assert!(cache_file_name(a, epoch(1)).ends_with(".png"));
+    }
+
+    #[test]
+    fn a_ready_thumbnail_is_not_requeued() {
+        let mut cache = ThumbnailCache::default();
+        let path = Path::new("/kit/tree.glb");
+        cache.record(path, epoch(1), ThumbState::Ready(Handle::default()));
+        cache.request(path, epoch(1));
+        assert!(cache.take_next().is_none(), "no work was queued");
+        assert!(cache.ready(path, epoch(1)).is_some());
+    }
+
+    #[test]
+    fn a_changed_mtime_invalidates_and_requeues() {
+        let mut cache = ThumbnailCache::default();
+        let path = Path::new("/kit/tree.glb");
+        cache.record(path, epoch(1), ThumbState::Ready(Handle::default()));
+        assert!(
+            cache.ready(path, epoch(2)).is_none(),
+            "the cached thumbnail is stale for the new mtime"
+        );
+        cache.request(path, epoch(2));
+        assert_eq!(cache.take_next().as_deref(), Some(path));
+    }
+
+    #[test]
+    fn a_failed_model_is_never_retried_at_the_same_mtime() {
+        let mut cache = ThumbnailCache::default();
+        let path = Path::new("/kit/broken.gltf");
+        cache.record(path, epoch(1), ThumbState::Failed);
+        cache.request(path, epoch(1));
+        assert!(cache.take_next().is_none(), "a failure is not retried");
+        assert!(cache.ready(path, epoch(1)).is_none(), "and draws no image");
+
+        // Fixing the file on disk is what makes it eligible again.
+        cache.request(path, epoch(2));
+        assert_eq!(cache.take_next().as_deref(), Some(path));
+    }
+
+    #[test]
+    fn requesting_the_same_path_twice_queues_it_once() {
+        let mut cache = ThumbnailCache::default();
+        let path = Path::new("/kit/tree.glb");
+        cache.request(path, epoch(1));
+        cache.request(path, epoch(1));
+        assert_eq!(cache.take_next().as_deref(), Some(path));
+        assert!(cache.take_next().is_none());
+    }
+
+    #[test]
+    fn fit_distance_scales_with_radius_and_shrinks_with_field_of_view() {
+        let fov = core::f32::consts::FRAC_PI_4;
+        let near = fit_distance(1.0, fov, 1.0);
+        let far = fit_distance(2.0, fov, 1.0);
+        assert!((far - near * 2.0).abs() < 1e-4, "{near} {far}");
+        // A 1-unit sphere at a 45-degree fov sits at 1 / sin(22.5 degrees).
+        assert!((near - 1.0 / (fov * 0.5).sin()).abs() < 1e-4, "{near}");
+        assert!(
+            fit_distance(1.0, fov * 2.0, 1.0) < near,
+            "a wider lens can stand closer"
+        );
+    }
+
+    #[test]
+    fn a_degenerate_model_still_gets_a_usable_camera() {
+        let (position, target) = frame_bounds(Vec3::ZERO, Vec3::ZERO, core::f32::consts::FRAC_PI_4);
+        assert_eq!(target, Vec3::ZERO);
+        assert!(position.is_finite(), "{position}");
+        assert!(
+            position.length() >= MIN_CAMERA_DISTANCE,
+            "the camera is not inside its subject: {position}"
+        );
+    }
+
+    #[test]
+    fn framing_centres_an_off_origin_model() {
+        let min = Vec3::new(10.0, 0.0, -4.0);
+        let max = Vec3::new(12.0, 3.0, -2.0);
+        let (position, target) = frame_bounds(min, max, core::f32::consts::FRAC_PI_4);
+        assert_eq!(target, (min + max) * 0.5);
+        let radius = (max - min).length() * 0.5;
+        let expected = fit_distance(radius, core::f32::consts::FRAC_PI_4, FRAMING_MARGIN);
+        assert!(
+            ((position - target).length() - expected).abs() < 1e-3,
+            "{position} {expected}"
+        );
+    }
+}

--- a/src/model_thumbnail.rs
+++ b/src/model_thumbnail.rs
@@ -991,7 +991,10 @@ mod tests {
         );
 
         cache.record(path, epoch(1), ThumbState::Ready(Handle::default()));
-        assert!(!cache.is_failed(path, epoch(1)), "a later success clears it");
+        assert!(
+            !cache.is_failed(path, epoch(1)),
+            "a later success clears it"
+        );
     }
 
     #[test]

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -313,7 +313,13 @@ pub(crate) fn import_terrain_sidecars(world: &mut World, scene_path: &str, mode:
     }
 
     for (data_path, no_inline_heights) in wanted {
-        let full = scene_dir.join(&data_path);
+        let full = match sidecar::resolve_path(&scene_dir, &data_path) {
+            Ok(path) => path,
+            Err(err) => {
+                warn!("Skipping invalid terrain data path {data_path:?}: {err}");
+                continue;
+            }
+        };
         match std::fs::read(&full) {
             Ok(bytes) => match sidecar::decode(&bytes) {
                 Ok(mut data) => {
@@ -406,8 +412,11 @@ pub(super) fn on_new_scene_save(
         if world.remove_resource::<PendingNewScene>().is_none() {
             return;
         }
-        save_scene(world);
-        do_new_scene(world);
+        if save_scene(world) {
+            do_new_scene(world);
+        } else {
+            warn!("new scene cancelled because the current scene was not saved");
+        }
     });
 }
 

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -328,7 +328,17 @@ pub(crate) fn import_terrain_sidecars(world: &mut World, scene_path: &str, mode:
                         .resource_mut::<crate::terrain::TerrainDataStore>()
                         .insert(data_path, data);
                 }
-                Err(err) => warn!("Terrain data {} is unreadable: {err}", full.display()),
+                Err(err) => {
+                    warn!(
+                        "Terrain data {} is unreadable ({err}); edits to this terrain \
+                         are refused and save will not overwrite the file until it is \
+                         fixed and reloaded",
+                        full.display()
+                    );
+                    world
+                        .resource_mut::<crate::terrain::TerrainDataStore>()
+                        .mark_load_failed(data_path);
+                }
             },
             // A legacy scene names no sidecar it ever wrote, so only a
             // terrain that expected one is worth warning about.

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -12,7 +12,7 @@ use serde::de::DeserializeSeed;
 use crate::EditorEntity;
 
 use super::registration::{register_entities_in_ast, register_entity_in_ast};
-use super::save::{save_scene, save_scene_inner};
+use super::save::{SaveOutcome, save_scene_inner, save_scene_with_outcome};
 use super::{SceneDirtyState, SceneFilePath, SceneMetadata, get_window_handle, is_scene_dirty};
 
 /// Marker resource: a "save before new scene?" dialog is currently open.
@@ -419,13 +419,26 @@ pub(super) fn on_new_scene_save(
     mut commands: Commands,
 ) {
     commands.queue(|world: &mut World| {
-        if world.remove_resource::<PendingNewScene>().is_none() {
+        if !world.contains_resource::<PendingNewScene>() {
             return;
         }
-        if save_scene(world) {
-            do_new_scene(world);
-        } else {
-            warn!("new scene cancelled because the current scene was not saved");
+        // Untitled active tab: `save_scene` opens a Save As dialog rather
+        // than writing anything, and returns before the user has picked
+        // a file. `PendingNewScene` is deliberately left in place for
+        // that case (not removed here) so `poll_scene_dialog` can create
+        // the new scene once that dialog actually resolves; removing it
+        // unconditionally lost the "and then start a new scene" intent
+        // the moment the active tab had no path.
+        match save_scene_with_outcome(world) {
+            SaveOutcome::Saved => {
+                world.remove_resource::<PendingNewScene>();
+                do_new_scene(world);
+            }
+            SaveOutcome::DialogOpened => {}
+            SaveOutcome::Failed => {
+                world.remove_resource::<PendingNewScene>();
+                warn!("new scene cancelled because the current scene was not saved");
+            }
         }
     });
 }
@@ -442,13 +455,22 @@ pub(super) fn on_new_scene_discard(
     });
 }
 
-/// If `PendingNewScene` exists but no dialog is open, the user dismissed via Esc/Cancel.
+/// If `PendingNewScene` exists but no dialog is open, the user dismissed
+/// via Esc/Cancel -- or a Save As dialog that `PendingNewScene` is
+/// waiting on (see `on_new_scene_save`) was itself cancelled, since that
+/// leaves the same "pending with nothing left to resolve it" state. A
+/// still-open Save As dialog is a native file picker, not an
+/// `EditorDialog` entity, so it has to be checked separately: without
+/// that check, this system would clear `PendingNewScene` out from under
+/// `poll_scene_dialog` on the very next frame, before the user had a
+/// chance to pick a file.
 pub(super) fn cleanup_pending_new_scene(
     pending: Option<Res<PendingNewScene>>,
     dialogs: Query<(), With<jackdaw_feathers::dialog::EditorDialog>>,
+    dialog_task: Option<Res<SceneDialogTask>>,
     mut commands: Commands,
 ) {
-    if pending.is_some() && dialogs.is_empty() {
+    if pending.is_some() && dialogs.is_empty() && dialog_task.is_none() {
         commands.remove_resource::<PendingNewScene>();
     }
 }
@@ -593,8 +615,17 @@ pub(super) fn poll_scene_dialog(world: &mut World) {
                     }
                 }
 
-                if let Err(err) = save_scene_inner(world) {
-                    error!("scene save (after Save As dialog) failed: {err}");
+                match save_scene_inner(world) {
+                    Ok(()) => {
+                        // "Save & New Scene" on an until-now-untitled tab
+                        // deferred creating the new scene to here: the
+                        // Save As dialog had to actually resolve first.
+                        // See `on_new_scene_save`.
+                        if world.remove_resource::<PendingNewScene>().is_some() {
+                            do_new_scene(world);
+                        }
+                    }
+                    Err(err) => error!("scene save (after Save As dialog) failed: {err}"),
                 }
             }
         }
@@ -760,5 +791,61 @@ mod terrain_sidecar_import_tests {
             "a missing sidecar leaves the terrain flat",
         );
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+}
+
+/// Tests for the "Save & New Scene" hand-off: `on_new_scene_save` used to
+/// remove `PendingNewScene` unconditionally, so a Save on an untitled
+/// active tab (which opens a Save As dialog rather than writing anything)
+/// lost the "and then start a new scene" intent the moment the dialog
+/// opened. `PendingNewScene` now survives until something actually
+/// resolves it -- a completed save (`poll_scene_dialog`) or a
+/// cancelled/dismissed one (`cleanup_pending_new_scene`).
+#[cfg(test)]
+mod cleanup_pending_new_scene_tests {
+    use bevy::tasks::AsyncComputeTaskPool;
+
+    use super::*;
+
+    /// I10(a) pinning test, the exact scenario from the review finding:
+    /// while a Save As dialog opened by "Save & New Scene" is still in
+    /// flight, `PendingNewScene` must not be cleared out from under it.
+    /// A native file picker has no `EditorDialog` entity, so the
+    /// dialog-emptiness check alone used to look identical to an
+    /// Esc/Cancel.
+    #[test]
+    fn pending_new_scene_survives_while_a_save_dialog_is_in_flight() {
+        AsyncComputeTaskPool::get_or_init(|| bevy::tasks::TaskPoolBuilder::new().build());
+
+        let mut world = World::new();
+        world.insert_resource(PendingNewScene);
+        let task = AsyncComputeTaskPool::get().spawn(async { None });
+        world.insert_resource(SceneDialogTask::Save(task));
+
+        world
+            .run_system_cached(cleanup_pending_new_scene)
+            .expect("system runs");
+
+        assert!(
+            world.contains_resource::<PendingNewScene>(),
+            "must not be cleared while the Save As dialog is still open",
+        );
+    }
+
+    /// The original Esc/Cancel case this system exists for: nothing left
+    /// to resolve `PendingNewScene`, so it must still be cleared.
+    #[test]
+    fn pending_new_scene_is_cleared_once_nothing_is_left_to_resolve_it() {
+        let mut world = World::new();
+        world.insert_resource(PendingNewScene);
+
+        world
+            .run_system_cached(cleanup_pending_new_scene)
+            .expect("system runs");
+
+        assert!(
+            !world.contains_resource::<PendingNewScene>(),
+            "with no dialog and no in-flight task, this is an Esc/Cancel and must clear",
+        );
     }
 }

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -243,10 +243,98 @@ fn finish_load_scene(world: &mut World, chosen: &std::path::Path) {
         }
     }
 
+    // Terrain bulk data lives beside the scene rather than in it. An
+    // explicit load means disk is the truth, so this overwrites whatever
+    // the store held for these paths.
+    import_terrain_sidecars(world, &path, SidecarImport::Reload);
+
     world.resource_mut::<SceneFilePath>().path = Some(path);
 
     // Stacks were cleared by clear_scene_entities, so dirty baseline is 0
     world.resource_mut::<SceneDirtyState>().undo_len_at_save = 0;
+}
+
+/// Whether a sidecar import may overwrite data the store already holds.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SidecarImport {
+    /// Disk wins. Used when the user explicitly loads or reloads a scene.
+    Reload,
+    /// Only fill paths the store has never heard of. Used on tab
+    /// activation, where the store may be holding unsaved sculpting that
+    /// the file on disk does not have yet.
+    FillMissing,
+}
+
+/// Read each terrain's binary sidecar into the store.
+///
+/// A missing or unreadable sidecar warns and leaves the terrain flat
+/// rather than failing the load: a scene whose data file was not copied
+/// alongside it should still open, so the user can see what happened and
+/// fix it. A legacy scene carrying inline `heights` has no sidecar and is
+/// left alone here -- `ensure_terrain_data_path` drains the inline values
+/// into the store, and the next save writes them out properly.
+///
+/// Called from two places, because there are two ways a terrain reaches
+/// the world: `finish_load_scene` for an explicit open, and
+/// `scenes::swap::activate_tab` for a tab that was opened by pushing a
+/// parsed document straight onto the tab strip. Wiring only the first
+/// leaves every scene opened from the tab strip flat.
+pub(crate) fn import_terrain_sidecars(world: &mut World, scene_path: &str, mode: SidecarImport) {
+    use jackdaw_terrain::sidecar;
+
+    if world
+        .get_resource::<crate::terrain::TerrainDataStore>()
+        .is_none()
+    {
+        return;
+    }
+    let scene_dir = std::path::Path::new(scene_path)
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
+
+    let mut wanted: Vec<(String, bool)> = Vec::new();
+    let mut query = world.query::<&jackdaw_scene_types::Terrain>();
+    for terrain in query.iter(world) {
+        if terrain.data_path.is_empty() {
+            continue;
+        }
+        if wanted.iter().any(|(path, _)| path == &terrain.data_path) {
+            continue;
+        }
+        wanted.push((terrain.data_path.clone(), terrain.heights.is_empty()));
+    }
+    if mode == SidecarImport::FillMissing {
+        let store = world.resource::<crate::terrain::TerrainDataStore>();
+        wanted.retain(|(path, _)| !store.contains(path));
+    }
+    if wanted.is_empty() {
+        return;
+    }
+
+    for (data_path, no_inline_heights) in wanted {
+        let full = scene_dir.join(&data_path);
+        match std::fs::read(&full) {
+            Ok(bytes) => match sidecar::decode(&bytes) {
+                Ok(mut data) => {
+                    data.normalize();
+                    world
+                        .resource_mut::<crate::terrain::TerrainDataStore>()
+                        .insert(data_path, data);
+                }
+                Err(err) => warn!("Terrain data {} is unreadable: {err}", full.display()),
+            },
+            // A legacy scene names no sidecar it ever wrote, so only a
+            // terrain that expected one is worth warning about.
+            Err(err) if no_inline_heights => {
+                warn!(
+                    "Terrain data {} is missing ({err}); loading a flat terrain",
+                    full.display()
+                );
+            }
+            Err(_) => {}
+        }
+    }
 }
 
 pub fn new_scene(world: &mut World) {
@@ -505,5 +593,153 @@ pub(super) fn poll_scene_dialog(world: &mut World) {
                 );
             }
         }
+    }
+}
+
+/// Tests for reading terrain sidecars back into the store.
+///
+/// The mode distinction is the substance here. A terrain reaches the
+/// world by two routes -- `finish_load_scene` for an explicit open, and
+/// `scenes::swap::activate_tab` for a tab pushed straight onto the strip
+/// by `scene_open_system` -- and only the first is an instruction to take
+/// disk as the truth. Wiring the second as a reload would silently throw
+/// away unsaved sculpting on every tab switch.
+#[cfg(test)]
+mod terrain_sidecar_import_tests {
+    use std::path::PathBuf;
+
+    use bevy::prelude::*;
+    use jackdaw_terrain::{TerrainData, sidecar};
+
+    use super::{SidecarImport, import_terrain_sidecars};
+    use crate::terrain::TerrainDataStore;
+
+    fn unique_tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("jd_terrin_{}_{label}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn on_disk() -> TerrainData {
+        TerrainData {
+            resolution: 4,
+            heights: (0..16).map(|i| i as f32).collect(),
+            channels: vec![],
+        }
+    }
+
+    /// A world with one terrain naming `data_path`, and a sidecar for it
+    /// written beside `zone.bsn` in a fresh temp dir.
+    fn world_and_scene(label: &str, data_path: &str) -> (World, PathBuf) {
+        let tmp = unique_tmp_dir(label);
+        let bytes = sidecar::encode(&on_disk()).expect("encodes");
+        std::fs::write(tmp.join(data_path), bytes).expect("write sidecar");
+
+        let mut world = World::new();
+        world.insert_resource(TerrainDataStore::default());
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 4,
+            data_path: data_path.to_string(),
+            ..default()
+        });
+        (world, tmp.join("zone.bsn"))
+    }
+
+    #[test]
+    fn a_terrain_with_no_stored_data_is_hydrated_from_its_sidecar() {
+        let (mut world, scene) = world_and_scene("fill", "zone.terrain-0.jdterrain");
+        import_terrain_sidecars(
+            &mut world,
+            &scene.to_string_lossy(),
+            SidecarImport::FillMissing,
+        );
+        assert_eq!(
+            world
+                .resource::<TerrainDataStore>()
+                .heights("zone.terrain-0.jdterrain"),
+            on_disk().heights.as_slice(),
+        );
+        let _ = std::fs::remove_dir_all(scene.parent().expect("temp dir"));
+    }
+
+    /// The regression this mode exists for: sculpt, switch tabs without
+    /// saving, switch back. The store is the truth, not the older file.
+    #[test]
+    fn fill_missing_leaves_unsaved_edits_alone() {
+        let (mut world, scene) = world_and_scene("unsaved", "zone.terrain-0.jdterrain");
+        let unsaved = TerrainData {
+            resolution: 4,
+            heights: vec![99.0; 16],
+            channels: vec![],
+        };
+        world
+            .resource_mut::<TerrainDataStore>()
+            .insert("zone.terrain-0.jdterrain".to_string(), unsaved);
+
+        import_terrain_sidecars(
+            &mut world,
+            &scene.to_string_lossy(),
+            SidecarImport::FillMissing,
+        );
+        assert_eq!(
+            world
+                .resource::<TerrainDataStore>()
+                .heights("zone.terrain-0.jdterrain"),
+            vec![99.0; 16].as_slice(),
+            "a tab swap must not re-read over unsaved sculpting",
+        );
+        let _ = std::fs::remove_dir_all(scene.parent().expect("temp dir"));
+    }
+
+    /// An explicit open, by contrast, is exactly a request for what is on
+    /// disk.
+    #[test]
+    fn reload_overwrites_what_the_store_was_holding() {
+        let (mut world, scene) = world_and_scene("reload", "zone.terrain-0.jdterrain");
+        world.resource_mut::<TerrainDataStore>().insert(
+            "zone.terrain-0.jdterrain".to_string(),
+            TerrainData {
+                resolution: 4,
+                heights: vec![99.0; 16],
+                channels: vec![],
+            },
+        );
+
+        import_terrain_sidecars(&mut world, &scene.to_string_lossy(), SidecarImport::Reload);
+        assert_eq!(
+            world
+                .resource::<TerrainDataStore>()
+                .heights("zone.terrain-0.jdterrain"),
+            on_disk().heights.as_slice(),
+        );
+        let _ = std::fs::remove_dir_all(scene.parent().expect("temp dir"));
+    }
+
+    /// A scene whose sidecar was never copied alongside it opens flat with
+    /// a warning rather than failing.
+    #[test]
+    fn a_missing_sidecar_loads_flat_rather_than_erroring() {
+        let tmp = unique_tmp_dir("missing");
+        let mut world = World::new();
+        world.insert_resource(TerrainDataStore::default());
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 4,
+            data_path: "gone.jdterrain".to_string(),
+            ..default()
+        });
+
+        import_terrain_sidecars(
+            &mut world,
+            &tmp.join("zone.bsn").to_string_lossy(),
+            SidecarImport::Reload,
+        );
+        assert!(
+            world
+                .resource::<TerrainDataStore>()
+                .heights("gone.jdterrain")
+                .is_empty(),
+            "a missing sidecar leaves the terrain flat",
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use load::{
 };
 pub use load::{load_scene, load_scene_from_file, new_scene, spawn_default_lighting};
 pub use registration::{register_entities_in_ast, register_entity_in_ast};
-pub(crate) use save::{emit_bsn_entities_with_inline_assets, export_terrain_sidecars};
+pub(crate) use save::{emit_bsn_entities_with_inline_assets, save_scene_inner};
 pub use save::{
     emit_bsn_scene_with_inline_assets, save_layout_to_project, save_scene, save_scene_as,
 };

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -24,7 +24,8 @@ pub use load::{load_scene, load_scene_from_file, new_scene, spawn_default_lighti
 pub use registration::{register_entities_in_ast, register_entity_in_ast};
 pub(crate) use save::{emit_bsn_entities_with_inline_assets, save_scene_inner};
 pub use save::{
-    emit_bsn_scene_with_inline_assets, save_layout_to_project, save_scene, save_scene_as,
+    SaveOutcome, emit_bsn_scene_with_inline_assets, save_layout_to_project, save_scene,
+    save_scene_as, save_scene_with_outcome,
 };
 
 use load::{cleanup_pending_new_scene, on_new_scene_discard, on_new_scene_save, poll_scene_dialog};

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -22,11 +22,11 @@ pub(crate) use load::{
 };
 pub use load::{load_scene, load_scene_from_file, new_scene, spawn_default_lighting};
 pub use registration::{register_entities_in_ast, register_entity_in_ast};
-pub(crate) use save::{emit_bsn_entities_with_inline_assets, save_scene_inner};
 pub use save::{
     SaveOutcome, emit_bsn_scene_with_inline_assets, save_layout_to_project, save_scene,
     save_scene_as, save_scene_with_outcome,
 };
+pub(crate) use save::{emit_bsn_entities_with_inline_assets, save_scene_inner};
 
 use load::{cleanup_pending_new_scene, on_new_scene_discard, on_new_scene_save, poll_scene_dialog};
 

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -17,10 +17,12 @@ mod save;
 pub mod stamp;
 
 pub use legacy::{load_inline_assets, load_scene_from_jsn};
-pub(crate) use load::{clear_scene_entities, despawn_scene_entities};
+pub(crate) use load::{
+    SidecarImport, clear_scene_entities, despawn_scene_entities, import_terrain_sidecars,
+};
 pub use load::{load_scene, load_scene_from_file, new_scene, spawn_default_lighting};
 pub use registration::{register_entities_in_ast, register_entity_in_ast};
-pub(crate) use save::emit_bsn_entities_with_inline_assets;
+pub(crate) use save::{emit_bsn_entities_with_inline_assets, export_terrain_sidecars};
 pub use save::{
     emit_bsn_scene_with_inline_assets, save_layout_to_project, save_scene, save_scene_as,
 };

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -16,6 +16,38 @@ use super::{
     structural_skip_type_ids,
 };
 
+/// Write `contents` to `path` atomically: write to a temp file beside
+/// `path`, then rename over the target. `std::fs::write` truncates the
+/// destination in place, so a crash or a full disk mid-write would leave
+/// a truncated file where the last-known-good copy used to be; a rename
+/// within one directory is a single filesystem operation and cannot
+/// observe a half-written state.
+///
+/// The temp file is created in `path`'s own directory rather than a
+/// system temp dir: a rename across filesystems (e.g. `/tmp` to a
+/// project on another mount) is not atomic and fails outright on most
+/// platforms.
+fn write_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other(format!("{} has no file name", path.display())))?;
+    let temp_path = parent.join(format!(
+        ".{}.tmp-{}",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+    if let Err(err) = std::fs::write(&temp_path, contents) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    if let Err(err) = std::fs::rename(&temp_path, path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    Ok(())
+}
+
 fn spawn_save_dialog(world: &mut World) {
     let raw_handle = get_window_handle(world);
     let last_dir = world.resource::<SceneFilePath>().last_directory.clone();
@@ -171,7 +203,12 @@ pub(crate) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
     // Terrain heights and paint channels are authoritative authored data.
     // Complete those writes before the scene text is committed and before
     // the tab is marked clean, so failures remain visible and repeated saves
-    // cannot finish out of order.
+    // cannot finish out of order. Each write lands via write_atomic, so a
+    // sidecar failure partway through never truncates one that already
+    // landed; the scene text below is written the same way. There is no
+    // cross-file rollback if the scene text write fails after sidecars
+    // already landed -- the sidecars stay updated and the tab stays dirty,
+    // so the next save retries the scene text with the same sidecars.
     export_terrain_sidecars(world, &path)?;
 
     // A redirected save renames the legacy source to `.jsn.bak` first so a
@@ -184,7 +221,7 @@ pub(crate) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
             ))
         })?;
     }
-    std::fs::write(&path, &contents)
+    write_atomic(Path::new(&path), contents.as_bytes())
         .map_err(|err| BevyError::from(format!("failed to write scene file {path}: {err}")))?;
     info!("Scene saved to {path}");
 
@@ -272,10 +309,11 @@ fn export_navmesh_sibling(world: &World, scene_path: &str) {
 /// Write every terrain's bulk data to its sidecar beside the scene.
 ///
 /// A scene with no terrain is a clean no-op. Each write completes before
-/// returning, and an invalid path, encoding failure, or filesystem error
-/// is returned to the save boundary so the tab stays dirty. One file per
-/// terrain is named by the scene-relative `data_path` the `Terrain`
-/// component carries, so a scene and its terrain data move together.
+/// returning (atomically, via `write_atomic`), and an invalid path,
+/// encoding failure, or filesystem error is returned to the save boundary
+/// so the tab stays dirty. One file per terrain is named by the
+/// scene-relative `data_path` the `Terrain` component carries, so a scene
+/// and its terrain data move together.
 ///
 /// A path with no store entry (never loaded -- its sidecar was missing --
 /// and never edited) is silently skipped: there is nothing to write and
@@ -356,7 +394,7 @@ pub(crate) fn export_terrain_sidecars(
                 ))
             })?;
         }
-        std::fs::write(&path, &bytes).map_err(|err| {
+        write_atomic(&path, &bytes).map_err(|err| {
             BevyError::from(format!(
                 "failed to write terrain data {}: {err}",
                 path.display()
@@ -1017,6 +1055,39 @@ mod tests {
             .expect("successful save has already reached disk on return");
         assert!(saved.contains("bevy_transform::components::transform::Transform"));
         assert!(!world.resource::<crate::scenes::Scenes>().tabs[0].dirty);
+    }
+
+    /// C2: `write_atomic` must fully replace an existing file's content
+    /// (proving the write goes through a rename, not an in-place
+    /// truncate) and must not leave its temp file behind.
+    #[test]
+    fn write_atomic_replaces_existing_content_and_cleans_up_its_temp_file() {
+        let tmp = tempfile::tempdir().expect("temp directory");
+        let target = tmp.path().join("scene.bsn");
+        std::fs::write(&target, b"old contents, much longer than the new ones")
+            .expect("seed original file");
+
+        write_atomic(&target, b"new").expect("atomic write succeeds");
+
+        assert_eq!(std::fs::read(&target).expect("read back"), b"new");
+        let stray_temp = std::fs::read_dir(tmp.path())
+            .expect("read temp dir")
+            .filter_map(Result::ok)
+            .any(|entry| entry.path() != target);
+        assert!(!stray_temp, "no temp file may remain beside the target");
+    }
+
+    /// C2: a failed write must not touch the destination at all -- the
+    /// crash-safety property this exists for is that a partial write can
+    /// only ever land in the temp file, never in the file callers read.
+    #[test]
+    fn write_atomic_leaves_the_destination_untouched_on_failure() {
+        let tmp = tempfile::tempdir().expect("temp directory");
+        let missing_parent = tmp.path().join("does-not-exist").join("scene.bsn");
+
+        let err = write_atomic(&missing_parent, b"new").expect_err("parent dir is missing");
+        assert!(!missing_parent.exists());
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }
 

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -212,6 +212,10 @@ pub(super) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
     // `<scene>.nav` file so it survives reload. No-op when nothing is baked.
     export_navmesh_sibling(world, &path);
 
+    // Terrain heights and paint channels live beside the scene, not in
+    // it. No-op for a scene with no terrain.
+    export_terrain_sidecars(world, &path);
+
     // Save catalog alongside scene if dirty
     crate::asset_catalog::save_catalog(world);
 
@@ -263,6 +267,74 @@ fn export_navmesh_sibling(world: &World, scene_path: &str) {
             match result {
                 Ok(()) => info!("Navmesh exported to {}", nav_path.display()),
                 Err(err) => warn!("Failed to export navmesh: {err}"),
+            }
+        })
+        .detach();
+}
+
+/// Write every terrain's bulk data to its sidecar beside the scene.
+///
+/// Same contract as [`export_navmesh_sibling`]: a clean no-op when the
+/// scene has no terrain, detached onto the `IoTaskPool`, and it never
+/// fails the scene save. One file per terrain, named by the
+/// scene-relative `data_path` the `Terrain` component carries, so a
+/// scene and its terrain data move together.
+///
+/// Only terrains that are actually in the scene are written. The store
+/// can outlive them -- an undo can bring one back, and other tabs keep
+/// their own entries -- so writing the whole store would scatter files
+/// for terrains this scene does not own.
+pub(crate) fn export_terrain_sidecars(world: &mut World, scene_path: &str) {
+    use jackdaw_terrain::sidecar;
+
+    if world
+        .get_resource::<crate::terrain::TerrainDataStore>()
+        .is_none()
+    {
+        return;
+    }
+    let scene_dir = Path::new(scene_path)
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
+
+    let mut paths: Vec<String> = Vec::new();
+    let mut query = world.query::<&jackdaw_scene_types::Terrain>();
+    for terrain in query.iter(world) {
+        if !terrain.data_path.is_empty() && !paths.contains(&terrain.data_path) {
+            paths.push(terrain.data_path.clone());
+        }
+    }
+
+    let store = world.resource::<crate::terrain::TerrainDataStore>();
+    let mut writes: Vec<(PathBuf, Vec<u8>)> = Vec::new();
+    for data_path in paths {
+        let Some(data) = store.get(&data_path) else {
+            continue;
+        };
+        let Some(bytes) = sidecar::encode(data) else {
+            warn!("terrain sidecar {data_path} declares more data than fits in memory");
+            continue;
+        };
+        writes.push((scene_dir.join(&data_path), bytes));
+    }
+    if writes.is_empty() {
+        return;
+    }
+
+    IoTaskPool::get()
+        .spawn(async move {
+            for (path, bytes) in writes {
+                let result = (|| -> std::io::Result<()> {
+                    if let Some(parent) = path.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    std::fs::write(&path, &bytes)
+                })();
+                match result {
+                    Ok(()) => info!("Terrain data written to {}", path.display()),
+                    Err(err) => warn!("Failed to write terrain data {}: {err}", path.display()),
+                }
             }
         })
         .detach();
@@ -993,6 +1065,237 @@ mod navmesh_export_tests {
             !nav_path.exists(),
             "no .nav must be written when nothing is baked: {}",
             nav_path.display()
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}
+
+/// Tests for the terrain sidecar sibling writer.
+///
+/// Same shape as `navmesh_export_tests` above and for the same reason:
+/// the write is detached onto `IoTaskPool`, so the file appears before its
+/// bytes are flushed and `exists()` alone races the writer. A successful
+/// `sidecar::decode` is the real readiness signal.
+#[cfg(test)]
+mod terrain_sidecar_tests {
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use bevy::prelude::*;
+    use bevy::tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder};
+    use jackdaw_terrain::{TerrainData, sidecar};
+
+    use super::{emit_bsn_scene_with_inline_assets, export_terrain_sidecars};
+    use crate::terrain::TerrainDataStore;
+
+    fn unique_tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("jd_terr_{}_{label}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// The production write runs on `IoTaskPool`, and the poll loop below
+    /// nudges the main thread with `tick_global_task_pools_on_main_thread`,
+    /// which unwraps *all three* global pools. These tests drive a bare
+    /// `World` rather than an `App`, so nothing has initialized them.
+    /// `get_or_init` is idempotent, so this is safe alongside any other
+    /// test that already did it.
+    fn init_task_pools() {
+        ComputeTaskPool::get_or_init(|| TaskPoolBuilder::new().build());
+        AsyncComputeTaskPool::get_or_init(|| TaskPoolBuilder::new().build());
+        IoTaskPool::get_or_init(|| TaskPoolBuilder::new().build());
+    }
+
+    /// A sculpted 4x4 terrain, distinctive enough that a zeroed or
+    /// truncated round-trip fails loudly.
+    fn sculpted() -> TerrainData {
+        TerrainData {
+            resolution: 4,
+            heights: (0..16).map(|i| i as f32 * 0.5).collect(),
+            channels: vec![],
+        }
+    }
+
+    fn world_with_terrain(data_path: &str, data: TerrainData) -> World {
+        let mut world = World::new();
+        let mut store = TerrainDataStore::default();
+        store.insert(data_path.to_string(), data);
+        world.insert_resource(store);
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 4,
+            data_path: data_path.to_string(),
+            ..default()
+        });
+        world
+    }
+
+    /// Poll for a sidecar to appear and fully decode, bounded at ~3s.
+    fn poll_decode(path: &std::path::Path) -> Option<TerrainData> {
+        for _ in 0..300 {
+            if path.exists()
+                && let Ok(bytes) = std::fs::read(path)
+                && let Ok(data) = sidecar::decode(&bytes)
+            {
+                return Some(data);
+            }
+            bevy::tasks::tick_global_task_pools_on_main_thread();
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        None
+    }
+
+    #[test]
+    fn writes_a_sidecar_that_decodes_back_to_the_sculpted_heights() {
+        init_task_pools();
+
+        let tmp = unique_tmp_dir("roundtrip");
+        let scene_path = tmp.join("zone.bsn");
+        let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
+
+        let mut world = world_with_terrain("zone.terrain-0.jdterrain", sculpted());
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+
+        let decoded = poll_decode(&sidecar_path)
+            .unwrap_or_else(|| panic!("sidecar not written: {}", sidecar_path.display()));
+        assert_eq!(decoded, sculpted());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Saving twice with no edits in between must produce the same bytes,
+    /// so a sidecar can be committed and diffed like any other artifact.
+    #[test]
+    fn saving_twice_produces_identical_bytes() {
+        init_task_pools();
+
+        let tmp = unique_tmp_dir("stable");
+        let scene_path = tmp.join("zone.bsn");
+        let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
+
+        let mut world = world_with_terrain("zone.terrain-0.jdterrain", sculpted());
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+        assert!(poll_decode(&sidecar_path).is_some(), "first write landed");
+        let first = std::fs::read(&sidecar_path).expect("read first write");
+
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+        // The second write overwrites in place, so poll until the bytes
+        // are decodable again rather than for the file's existence.
+        assert!(poll_decode(&sidecar_path).is_some(), "second write landed");
+        let second = std::fs::read(&sidecar_path).expect("read second write");
+
+        assert_eq!(first, second);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A scene with no terrain must not litter the project with an empty
+    /// sidecar, exactly as the navmesh writer no-ops when nothing is baked.
+    #[test]
+    fn no_sidecar_when_the_scene_has_no_terrain() {
+        init_task_pools();
+
+        let tmp = unique_tmp_dir("bare");
+        let scene_path = tmp.join("bare.bsn");
+
+        let mut world = World::new();
+        world.insert_resource(TerrainDataStore::default());
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+
+        for _ in 0..20 {
+            bevy::tasks::tick_global_task_pools_on_main_thread();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let stray = std::fs::read_dir(&tmp)
+            .expect("temp dir readable")
+            .filter_map(Result::ok)
+            .any(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == sidecar::EXTENSION)
+            });
+        assert!(!stray, "no sidecar may be written for a terrain-less scene");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The defect this whole design exists to fix: a 512-resolution
+    /// terrain used to write 262,144 text floats into the scene file on
+    /// every save. `.bsn` is sold as a format you can read in a `git
+    /// diff`, so the terrain's contribution has to be a handful of lines.
+    #[test]
+    fn a_512_terrain_contributes_almost_nothing_to_the_scene_text() {
+        use bevy::ecs::reflect::AppTypeRegistry;
+        use jackdaw_bsn::SceneBsnAst;
+
+        let mut world = World::new();
+        world.init_resource::<AppTypeRegistry>();
+        {
+            let registry = world.resource::<AppTypeRegistry>().clone();
+            let mut writer = registry.write();
+            writer.register::<Name>();
+            writer.register::<jackdaw_scene_types::Terrain>();
+            writer.register::<jackdaw_scene_types::SceneNodeId>();
+        }
+        world.init_resource::<SceneBsnAst>();
+
+        let mut store = TerrainDataStore::default();
+        store.insert(
+            "zone.terrain-0.jdterrain".to_string(),
+            TerrainData {
+                resolution: 512,
+                heights: vec![0.75; 512 * 512],
+                channels: vec![],
+            },
+        );
+        world.insert_resource(store);
+
+        let entity = world
+            .spawn((
+                Name::new("ground"),
+                jackdaw_scene_types::Terrain {
+                    resolution: 512,
+                    data_path: "zone.terrain-0.jdterrain".to_string(),
+                    ..default()
+                },
+            ))
+            .id();
+        crate::scene_io::register_entity_in_ast(&mut world, entity);
+
+        let text = emit_bsn_scene_with_inline_assets(&mut world, std::path::Path::new("."));
+        assert!(
+            text.contains("zone.terrain-0.jdterrain"),
+            "the scene must name the sidecar it depends on:\n{text}"
+        );
+        assert!(
+            text.len() < 2048,
+            "a 512 terrain must not bloat the scene text; got {} bytes:\n{text}",
+            text.len()
+        );
+    }
+
+    /// Store entries whose terrain is not in this scene belong to another
+    /// tab (or to an undone delete) and must not be written beside it.
+    #[test]
+    fn only_terrains_present_in_the_scene_are_written() {
+        init_task_pools();
+
+        let tmp = unique_tmp_dir("scoped");
+        let scene_path = tmp.join("zone.bsn");
+
+        let mut world = world_with_terrain("zone.terrain-0.jdterrain", sculpted());
+        world
+            .resource_mut::<TerrainDataStore>()
+            .insert("other-scene.terrain-0.jdterrain".to_string(), sculpted());
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+
+        assert!(
+            poll_decode(&tmp.join("zone.terrain-0.jdterrain")).is_some(),
+            "this scene's terrain is written"
+        );
+        assert!(
+            !tmp.join("other-scene.terrain-0.jdterrain").exists(),
+            "another scene's terrain must not be written here"
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -105,6 +105,26 @@ pub fn save_scene_as(world: &mut World) {
     spawn_save_dialog(world);
 }
 
+/// Save the active tab's scene text and terrain sidecars, synchronously,
+/// on the calling (main) thread.
+///
+/// This used to spawn the write onto an async task. It does not anymore:
+/// ordering has to hold across the whole boundary -- sidecars before
+/// scene text, dirty state cleared only after every authoritative write
+/// lands (see the ordering comments below) -- and that is far simpler to
+/// reason about, and to keep correct under future edits, as a single
+/// synchronous call than as a task whose completion has to be raced
+/// against the next save, the next tab swap, or the app closing mid-write.
+///
+/// The tradeoff: this blocks the main thread for the duration of the
+/// write, and `scene.save_all` (`scenes/operators.rs`) calls this once
+/// per dirty tab in a loop, so the block time is `O(tabs)`, not `O(1)`.
+/// Scene text and terrain sidecars are not sized to make that
+/// noticeable in practice, but a project with many large open tabs is
+/// the case to watch. If it ever needs revisiting, the fix is a
+/// different concurrency shape for `scene.save_all` specifically, not
+/// bringing async back to this function -- the ordering argument above
+/// still applies to any single save.
 pub(crate) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
     // If the active tab is a prefab, flush the live AST into the cache
     // and persist via the prefab-aware writer. Reflect-serializing the

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -37,7 +37,8 @@ fn spawn_save_dialog(world: &mut World) {
     world.insert_resource(SceneDialogTask::Save(task));
 }
 
-pub fn save_scene(world: &mut World) {
+/// Save the active scene, returning whether its authoritative files reached disk.
+pub fn save_scene(world: &mut World) -> bool {
     // The active scene tab is the source of truth for which file to
     // save to. Re-sync the global `SceneFilePath` from it so a stale
     // path from a previous tab can never cause us to overwrite the
@@ -53,11 +54,15 @@ pub fn save_scene(world: &mut World) {
     let has_path = world.resource::<SceneFilePath>().path.is_some();
     if !has_path {
         save_scene_as(world);
-        return;
+        return false;
     }
 
-    if let Err(err) = save_scene_inner(world) {
-        error!("scene save failed: {err}");
+    match save_scene_inner(world) {
+        Ok(()) => true,
+        Err(err) => {
+            error!("scene save failed: {err}");
+            false
+        }
     }
 }
 
@@ -68,7 +73,7 @@ pub fn save_scene_as(world: &mut World) {
     spawn_save_dialog(world);
 }
 
-pub(super) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
+pub(crate) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
     // If the active tab is a prefab, flush the live AST into the cache
     // and persist via the prefab-aware writer. Reflect-serializing the
     // live world would drop the `Prefab` marker (its deserializer fails,
@@ -100,9 +105,8 @@ pub(super) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
             }
             Err(err) => warn!("scene.save: prefab snapshot parse failed: {err}"),
         }
-        if let Err(err) = crate::prefab::operators::save_prefab_to_disk(world, &path) {
-            warn!("scene.save: prefab save failed: {err}");
-        }
+        crate::prefab::operators::save_prefab_to_disk(world, &path)
+            .map_err(|err| BevyError::from(format!("prefab save failed: {err}")))?;
         // Clear dirty bit + sync history depth so the tab stops showing
         // as unsaved.
         let history_len = world
@@ -151,31 +155,6 @@ pub(super) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
     if scene_path.metadata.name.is_empty() {
         scene_path.metadata.name = "Untitled".to_string();
     }
-    if legacy_backup.is_some() {
-        scene_path.path = Some(path.clone());
-    }
-
-    // Mark scene as clean
-    let history_len = world
-        .resource::<jackdaw_commands::CommandHistory>()
-        .undo_stack
-        .len();
-    world.resource_mut::<SceneDirtyState>().undo_len_at_save = history_len;
-
-    // Clear the active scene tab's dirty flag, resync its history depth
-    // marker so `mark_active_dirty_on_history_growth` does not immediately
-    // re-dirty the tab on the next frame, and retarget a redirected tab at
-    // its new `.bsn` path.
-    if let Some(mut scenes) = world.get_resource_mut::<crate::scenes::Scenes>() {
-        let active = scenes.active;
-        if let Some(tab) = scenes.tabs.get_mut(active) {
-            tab.dirty = false;
-            tab.history_depth_at_last_check = history_len;
-            if legacy_backup.is_some() {
-                tab.path = Some(PathBuf::from(&path));
-            }
-        }
-    }
 
     let contents = {
         let parent_path = Path::new(&path)
@@ -189,32 +168,50 @@ pub(super) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
         crate::scene_io::stamp::with_stamp(&body)
     };
 
-    // Write to disk on the IO task pool. A redirected save renames the
-    // legacy source to `.jsn.bak` first so a stale `.jsn` cannot shadow the
-    // fresh `.bsn` on the next open.
-    let path_clone = path.clone();
-    IoTaskPool::get()
-        .spawn(async move {
-            if let Some(old_path) = legacy_backup {
-                let backup = format!("{old_path}.bak");
-                if let Err(err) = std::fs::rename(&old_path, &backup) {
-                    warn!("Could not back up legacy scene {old_path} to {backup}: {err}");
-                }
-            }
-            match std::fs::write(&path_clone, &contents) {
-                Ok(()) => info!("Scene saved to {path_clone}"),
-                Err(err) => warn!("Failed to write scene file: {err}"),
-            }
-        })
-        .detach();
+    // Terrain heights and paint channels are authoritative authored data.
+    // Complete those writes before the scene text is committed and before
+    // the tab is marked clean, so failures remain visible and repeated saves
+    // cannot finish out of order.
+    export_terrain_sidecars(world, &path)?;
+
+    // A redirected save renames the legacy source to `.jsn.bak` first so a
+    // stale `.jsn` cannot shadow the fresh `.bsn` on the next open.
+    if let Some(old_path) = legacy_backup.as_ref() {
+        let backup = format!("{old_path}.bak");
+        std::fs::rename(old_path, &backup).map_err(|err| {
+            BevyError::from(format!(
+                "could not back up legacy scene {old_path} to {backup}: {err}"
+            ))
+        })?;
+    }
+    std::fs::write(&path, &contents)
+        .map_err(|err| BevyError::from(format!("failed to write scene file {path}: {err}")))?;
+    info!("Scene saved to {path}");
 
     // Also persist the in-memory baked navmesh (if any) to a sibling
     // `<scene>.nav` file so it survives reload. No-op when nothing is baked.
     export_navmesh_sibling(world, &path);
 
-    // Terrain heights and paint channels live beside the scene, not in
-    // it. No-op for a scene with no terrain.
-    export_terrain_sidecars(world, &path);
+    // The authoritative scene and sidecars are now on disk. Only now clear
+    // dirty state and retarget a redirected tab at its new `.bsn` path.
+    let history_len = world
+        .resource::<jackdaw_commands::CommandHistory>()
+        .undo_stack
+        .len();
+    world.resource_mut::<SceneDirtyState>().undo_len_at_save = history_len;
+    if legacy_backup.is_some() {
+        world.resource_mut::<SceneFilePath>().path = Some(path.clone());
+    }
+    if let Some(mut scenes) = world.get_resource_mut::<crate::scenes::Scenes>() {
+        let active = scenes.active;
+        if let Some(tab) = scenes.tabs.get_mut(active) {
+            tab.dirty = false;
+            tab.history_depth_at_last_check = history_len;
+            if legacy_backup.is_some() {
+                tab.path = Some(PathBuf::from(&path));
+            }
+        }
+    }
 
     // Save catalog alongside scene if dirty
     crate::asset_catalog::save_catalog(world);
@@ -274,24 +271,28 @@ fn export_navmesh_sibling(world: &World, scene_path: &str) {
 
 /// Write every terrain's bulk data to its sidecar beside the scene.
 ///
-/// Same contract as [`export_navmesh_sibling`]: a clean no-op when the
-/// scene has no terrain, detached onto the `IoTaskPool`, and it never
-/// fails the scene save. One file per terrain, named by the
-/// scene-relative `data_path` the `Terrain` component carries, so a
-/// scene and its terrain data move together.
+/// A scene with no terrain is a clean no-op. Each write completes before
+/// returning, and any invalid path, missing store entry, encoding failure,
+/// or filesystem error is returned to the save boundary so the tab stays
+/// dirty. One file per terrain is named by the scene-relative `data_path`
+/// the `Terrain` component carries, so a scene and its terrain data move
+/// together.
 ///
 /// Only terrains that are actually in the scene are written. The store
 /// can outlive them -- an undo can bring one back, and other tabs keep
 /// their own entries -- so writing the whole store would scatter files
 /// for terrains this scene does not own.
-pub(crate) fn export_terrain_sidecars(world: &mut World, scene_path: &str) {
+pub(crate) fn export_terrain_sidecars(
+    world: &mut World,
+    scene_path: &str,
+) -> Result<(), BevyError> {
     use jackdaw_terrain::sidecar;
 
     if world
         .get_resource::<crate::terrain::TerrainDataStore>()
         .is_none()
     {
-        return;
+        return Ok(());
     }
     let scene_dir = Path::new(scene_path)
         .parent()
@@ -309,35 +310,46 @@ pub(crate) fn export_terrain_sidecars(world: &mut World, scene_path: &str) {
     let store = world.resource::<crate::terrain::TerrainDataStore>();
     let mut writes: Vec<(PathBuf, Vec<u8>)> = Vec::new();
     for data_path in paths {
-        let Some(data) = store.get(&data_path) else {
-            continue;
+        let path = match sidecar::resolve_path(&scene_dir, &data_path) {
+            Ok(path) => path,
+            Err(err) => {
+                return Err(BevyError::from(format!(
+                    "invalid terrain data path {data_path:?}: {err}"
+                )));
+            }
         };
-        let Some(bytes) = sidecar::encode(data) else {
-            warn!("terrain sidecar {data_path} declares more data than fits in memory");
-            continue;
-        };
-        writes.push((scene_dir.join(&data_path), bytes));
-    }
-    if writes.is_empty() {
-        return;
+        let data = store.get(&data_path).ok_or_else(|| {
+            BevyError::from(format!(
+                "terrain sidecar {data_path:?} has no in-memory data"
+            ))
+        })?;
+        let bytes = sidecar::encode(data).ok_or_else(|| {
+            BevyError::from(format!(
+                "terrain sidecar {data_path:?} declares more data than fits in memory"
+            ))
+        })?;
+        writes.push((path, bytes));
     }
 
-    IoTaskPool::get()
-        .spawn(async move {
-            for (path, bytes) in writes {
-                let result = (|| -> std::io::Result<()> {
-                    if let Some(parent) = path.parent() {
-                        std::fs::create_dir_all(parent)?;
-                    }
-                    std::fs::write(&path, &bytes)
-                })();
-                match result {
-                    Ok(()) => info!("Terrain data written to {}", path.display()),
-                    Err(err) => warn!("Failed to write terrain data {}: {err}", path.display()),
-                }
-            }
-        })
-        .detach();
+    for (path, bytes) in writes {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                BevyError::from(format!(
+                    "failed to create terrain data directory {} for {}: {err}",
+                    parent.display(),
+                    path.display()
+                ))
+            })?;
+        }
+        std::fs::write(&path, &bytes).map_err(|err| {
+            BevyError::from(format!(
+                "failed to write terrain data {}: {err}",
+                path.display()
+            ))
+        })?;
+        info!("Terrain data written to {}", path.display());
+    }
+    Ok(())
 }
 
 pub fn save_layout_to_project(world: &mut World) {
@@ -846,7 +858,7 @@ pub(crate) fn emit_bsn_entities_with_inline_assets(
 mod tests {
     use super::*;
 
-    /// In Live view the preview world carries streamed game values, so a save    /// In Live view the preview world carries streamed game values, so a save
+    /// In Live view the preview world carries streamed game values, so a save
     /// must persist the AST's authored entity payload, not the live overlay.
     /// Authored Transform is `[1, 2, 3]`; the live ECS Transform is `[9, 9, 9]`.
     /// The save must write the authored values.
@@ -918,6 +930,78 @@ mod tests {
             matches!(translation, Some(jackdaw_bsn::BsnValue::Float(x)) if (x - 1.0).abs() < 1e-6),
             "Live save must persist authored values, not the live overlay",
         );
+    }
+
+    #[test]
+    fn failed_authoritative_write_keeps_the_scene_dirty() {
+        let mut world = build_live_save_world();
+        let tmp = tempfile::tempdir().expect("temp directory");
+        let blocked_parent = tmp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file blocks directory creation")
+            .expect("create blocking file");
+        let scene_path = blocked_parent.join("zone.bsn");
+
+        let mut tab = crate::scenes::SceneTab::new_untitled(1);
+        tab.path = Some(scene_path.clone());
+        tab.dirty = true;
+        world.insert_resource(crate::scenes::Scenes {
+            tabs: vec![tab],
+            active: 0,
+        });
+        world.resource_mut::<SceneFilePath>().path =
+            Some(scene_path.to_string_lossy().into_owned());
+
+        let data_path = "zone.terrain-0.jdterrain";
+        let mut store = crate::terrain::TerrainDataStore::default();
+        store.insert(
+            data_path.to_string(),
+            jackdaw_terrain::TerrainData {
+                resolution: 2,
+                heights: vec![0.0; 4],
+                channels: vec![],
+            },
+        );
+        world.insert_resource(store);
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 2,
+            data_path: data_path.to_string(),
+            ..default()
+        });
+
+        let baseline = world.resource::<SceneDirtyState>().undo_len_at_save;
+        let error = save_scene_inner(&mut world).expect_err("the blocked sidecar fails the save");
+
+        assert!(error.to_string().contains(data_path));
+        assert!(world.resource::<crate::scenes::Scenes>().tabs[0].dirty);
+        assert_eq!(
+            world.resource::<SceneDirtyState>().undo_len_at_save,
+            baseline,
+            "failed saves must not advance the clean-history baseline",
+        );
+    }
+
+    #[test]
+    fn successful_scene_write_finishes_before_the_tab_becomes_clean() {
+        let mut world = build_live_save_world();
+        let tmp = tempfile::tempdir().expect("temp directory");
+        let scene_path = tmp.path().join("zone.bsn");
+
+        let mut tab = crate::scenes::SceneTab::new_untitled(1);
+        tab.path = Some(scene_path.clone());
+        tab.dirty = true;
+        world.insert_resource(crate::scenes::Scenes {
+            tabs: vec![tab],
+            active: 0,
+        });
+        world.resource_mut::<SceneFilePath>().path =
+            Some(scene_path.to_string_lossy().into_owned());
+
+        save_scene_inner(&mut world).expect("scene write succeeds");
+
+        let saved = std::fs::read_to_string(&scene_path)
+            .expect("successful save has already reached disk on return");
+        assert!(saved.contains("bevy_transform::components::transform::Transform"));
+        assert!(!world.resource::<crate::scenes::Scenes>().tabs[0].dirty);
     }
 }
 
@@ -1073,17 +1157,13 @@ mod navmesh_export_tests {
 
 /// Tests for the terrain sidecar sibling writer.
 ///
-/// Same shape as `navmesh_export_tests` above and for the same reason:
-/// the write is detached onto `IoTaskPool`, so the file appears before its
-/// bytes are flushed and `exists()` alone races the writer. A successful
-/// `sidecar::decode` is the real readiness signal.
+/// These drive the synchronous save boundary directly: success means the
+/// bytes are already durable enough to read back, and failure is returned.
 #[cfg(test)]
 mod terrain_sidecar_tests {
     use std::path::PathBuf;
-    use std::time::Duration;
 
     use bevy::prelude::*;
-    use bevy::tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder};
     use jackdaw_terrain::{TerrainData, sidecar};
 
     use super::{emit_bsn_scene_with_inline_assets, export_terrain_sidecars};
@@ -1093,18 +1173,6 @@ mod terrain_sidecar_tests {
         let dir = std::env::temp_dir().join(format!("jd_terr_{}_{label}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
-    }
-
-    /// The production write runs on `IoTaskPool`, and the poll loop below
-    /// nudges the main thread with `tick_global_task_pools_on_main_thread`,
-    /// which unwraps *all three* global pools. These tests drive a bare
-    /// `World` rather than an `App`, so nothing has initialized them.
-    /// `get_or_init` is idempotent, so this is safe alongside any other
-    /// test that already did it.
-    fn init_task_pools() {
-        ComputeTaskPool::get_or_init(|| TaskPoolBuilder::new().build());
-        AsyncComputeTaskPool::get_or_init(|| TaskPoolBuilder::new().build());
-        IoTaskPool::get_or_init(|| TaskPoolBuilder::new().build());
     }
 
     /// A sculpted 4x4 terrain, distinctive enough that a zeroed or
@@ -1130,33 +1198,23 @@ mod terrain_sidecar_tests {
         world
     }
 
-    /// Poll for a sidecar to appear and fully decode, bounded at ~3s.
-    fn poll_decode(path: &std::path::Path) -> Option<TerrainData> {
-        for _ in 0..300 {
-            if path.exists()
-                && let Ok(bytes) = std::fs::read(path)
-                && let Ok(data) = sidecar::decode(&bytes)
-            {
-                return Some(data);
-            }
-            bevy::tasks::tick_global_task_pools_on_main_thread();
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        None
+    fn read_decode(path: &std::path::Path) -> Option<TerrainData> {
+        std::fs::read(path)
+            .ok()
+            .and_then(|bytes| sidecar::decode(&bytes).ok())
     }
 
     #[test]
     fn writes_a_sidecar_that_decodes_back_to_the_sculpted_heights() {
-        init_task_pools();
-
         let tmp = unique_tmp_dir("roundtrip");
         let scene_path = tmp.join("zone.bsn");
         let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
 
         let mut world = world_with_terrain("zone.terrain-0.jdterrain", sculpted());
-        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("sidecar write succeeds");
 
-        let decoded = poll_decode(&sidecar_path)
+        let decoded = read_decode(&sidecar_path)
             .unwrap_or_else(|| panic!("sidecar not written: {}", sidecar_path.display()));
         assert_eq!(decoded, sculpted());
 
@@ -1167,24 +1225,43 @@ mod terrain_sidecar_tests {
     /// so a sidecar can be committed and diffed like any other artifact.
     #[test]
     fn saving_twice_produces_identical_bytes() {
-        init_task_pools();
-
         let tmp = unique_tmp_dir("stable");
         let scene_path = tmp.join("zone.bsn");
         let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
 
         let mut world = world_with_terrain("zone.terrain-0.jdterrain", sculpted());
-        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
-        assert!(poll_decode(&sidecar_path).is_some(), "first write landed");
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("first write succeeds");
         let first = std::fs::read(&sidecar_path).expect("read first write");
 
-        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
-        // The second write overwrites in place, so poll until the bytes
-        // are decodable again rather than for the file's existence.
-        assert!(poll_decode(&sidecar_path).is_some(), "second write landed");
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("second write succeeds");
         let second = std::fs::read(&sidecar_path).expect("read second write");
 
         assert_eq!(first, second);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn a_sidecar_write_failure_is_returned_to_the_save_caller() {
+        let tmp = unique_tmp_dir("write-failure");
+        let blocked_parent = tmp.join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file blocks directory creation")
+            .expect("create blocking file");
+        let scene_path = blocked_parent.join("zone.bsn");
+        let sidecar_path = blocked_parent.join("zone.terrain-0.jdterrain");
+
+        let mut world = world_with_terrain("zone.terrain-0.jdterrain", sculpted());
+        let error = export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect_err("the write failure must reach the save boundary");
+
+        assert!(
+            error
+                .to_string()
+                .contains(&sidecar_path.display().to_string()),
+            "the error names the failed sidecar: {error}",
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
@@ -1193,19 +1270,13 @@ mod terrain_sidecar_tests {
     /// sidecar, exactly as the navmesh writer no-ops when nothing is baked.
     #[test]
     fn no_sidecar_when_the_scene_has_no_terrain() {
-        init_task_pools();
-
         let tmp = unique_tmp_dir("bare");
         let scene_path = tmp.join("bare.bsn");
 
         let mut world = World::new();
         world.insert_resource(TerrainDataStore::default());
-        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
-
-        for _ in 0..20 {
-            bevy::tasks::tick_global_task_pools_on_main_thread();
-            std::thread::sleep(Duration::from_millis(5));
-        }
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("terrain-less scene is a no-op");
         let stray = std::fs::read_dir(&tmp)
             .expect("temp dir readable")
             .filter_map(Result::ok)
@@ -1278,8 +1349,6 @@ mod terrain_sidecar_tests {
     /// tab (or to an undone delete) and must not be written beside it.
     #[test]
     fn only_terrains_present_in_the_scene_are_written() {
-        init_task_pools();
-
         let tmp = unique_tmp_dir("scoped");
         let scene_path = tmp.join("zone.bsn");
 
@@ -1287,10 +1356,11 @@ mod terrain_sidecar_tests {
         world
             .resource_mut::<TerrainDataStore>()
             .insert("other-scene.terrain-0.jdterrain".to_string(), sculpted());
-        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy());
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("this scene's sidecar writes");
 
         assert!(
-            poll_decode(&tmp.join("zone.terrain-0.jdterrain")).is_some(),
+            read_decode(&tmp.join("zone.terrain-0.jdterrain")).is_some(),
             "this scene's terrain is written"
         );
         assert!(

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -272,11 +272,17 @@ fn export_navmesh_sibling(world: &World, scene_path: &str) {
 /// Write every terrain's bulk data to its sidecar beside the scene.
 ///
 /// A scene with no terrain is a clean no-op. Each write completes before
-/// returning, and any invalid path, missing store entry, encoding failure,
-/// or filesystem error is returned to the save boundary so the tab stays
-/// dirty. One file per terrain is named by the scene-relative `data_path`
-/// the `Terrain` component carries, so a scene and its terrain data move
-/// together.
+/// returning, and an invalid path, encoding failure, or filesystem error
+/// is returned to the save boundary so the tab stays dirty. One file per
+/// terrain is named by the scene-relative `data_path` the `Terrain`
+/// component carries, so a scene and its terrain data move together.
+///
+/// A path with no store entry (never loaded -- its sidecar was missing --
+/// and never edited) is silently skipped: there is nothing to write and
+/// nothing lost. A path marked load-failed (a sidecar existed but could
+/// not decode) is also skipped, with a warning: writing zeroed data over
+/// a real, if damaged, file would be worse than leaving it alone. Neither
+/// case fails the save.
 ///
 /// Only terrains that are actually in the scene are written. The store
 /// can outlive them -- an undo can bring one back, and other tabs keep
@@ -318,11 +324,20 @@ pub(crate) fn export_terrain_sidecars(
                 )));
             }
         };
-        let data = store.get(&data_path).ok_or_else(|| {
-            BevyError::from(format!(
-                "terrain sidecar {data_path:?} has no in-memory data"
-            ))
-        })?;
+        if store.is_load_failed(&data_path) {
+            warn!(
+                "Not saving terrain data {data_path:?}: it failed to load, so writing \
+                 would overwrite the original file with empty data. Fix or replace the \
+                 sidecar and reload the scene."
+            );
+            continue;
+        }
+        // No entry means this path was never loaded (its sidecar was
+        // missing, and the load stayed lenient) and never edited since:
+        // nothing to write, and nothing lost by skipping it.
+        let Some(data) = store.get(&data_path) else {
+            continue;
+        };
         let bytes = sidecar::encode(data).ok_or_else(|| {
             BevyError::from(format!(
                 "terrain sidecar {data_path:?} declares more data than fits in memory"
@@ -1366,6 +1381,111 @@ mod terrain_sidecar_tests {
         assert!(
             !tmp.join("other-scene.terrain-0.jdterrain").exists(),
             "another scene's terrain must not be written here"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// C1 pinning test, the finding's exact scenario: a teammate's sidecar
+    /// was written by a newer build (`SidecarError::UnsupportedVersion`),
+    /// this build cannot read it, the user paints a stroke anyway, then
+    /// saves. Before the fix this wrote a zeroed `TerrainData` straight
+    /// over the real file.
+    #[test]
+    fn an_unreadable_sidecar_is_never_overwritten_by_a_save() {
+        let tmp = unique_tmp_dir("unreadable");
+        let scene_path = tmp.join("zone.bsn");
+        let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
+
+        let mut original = sidecar::encode(&sculpted()).expect("encodes");
+        original[8..10].copy_from_slice(&(sidecar::VERSION + 1).to_le_bytes());
+        std::fs::write(&sidecar_path, &original).expect("write sidecar");
+
+        let mut world = World::new();
+        world.insert_resource(TerrainDataStore::default());
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 4,
+            data_path: "zone.terrain-0.jdterrain".to_string(),
+            ..default()
+        });
+
+        crate::scene_io::import_terrain_sidecars(
+            &mut world,
+            &scene_path.to_string_lossy(),
+            crate::scene_io::SidecarImport::Reload,
+        );
+        assert!(
+            world
+                .resource::<TerrainDataStore>()
+                .is_load_failed("zone.terrain-0.jdterrain"),
+            "a decode failure must mark the entry load-failed",
+        );
+
+        // The stroke: an edit attempt must be refused, not minted as
+        // zeroed data.
+        let brushed = jackdaw_scene_types::Terrain {
+            resolution: 4,
+            data_path: "zone.terrain-0.jdterrain".to_string(),
+            ..default()
+        };
+        assert!(
+            world
+                .resource_mut::<TerrainDataStore>()
+                .entry_for(&brushed)
+                .is_none(),
+            "edits to a load-failed terrain must be refused",
+        );
+
+        // Ctrl+S: the save must succeed and must not touch the file.
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("save must not hard-error on a load-failed entry");
+        assert_eq!(
+            std::fs::read(&sidecar_path).expect("sidecar still on disk"),
+            original,
+            "the unreadable original must survive the save byte-for-byte",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// C1 pinning test for the twin bug: a scene whose sidecar was never
+    /// copied alongside it (missing, not corrupt) loads flat and must
+    /// stay saveable indefinitely, not hard-error on every save attempt.
+    #[test]
+    fn a_never_loaded_missing_sidecar_stays_saveable() {
+        let tmp = unique_tmp_dir("never-loaded");
+        let scene_path = tmp.join("zone.bsn");
+        let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
+
+        let mut world = World::new();
+        world.insert_resource(TerrainDataStore::default());
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 4,
+            data_path: "zone.terrain-0.jdterrain".to_string(),
+            ..default()
+        });
+
+        crate::scene_io::import_terrain_sidecars(
+            &mut world,
+            &scene_path.to_string_lossy(),
+            crate::scene_io::SidecarImport::Reload,
+        );
+        assert!(
+            !world
+                .resource::<TerrainDataStore>()
+                .contains("zone.terrain-0.jdterrain")
+        );
+        assert!(
+            !world
+                .resource::<TerrainDataStore>()
+                .is_load_failed("zone.terrain-0.jdterrain")
+        );
+
+        export_terrain_sidecars(&mut world, &scene_path.to_string_lossy())
+            .expect("a scene with a never-loaded terrain must remain saveable");
+        assert!(
+            !sidecar_path.exists(),
+            "nothing should be written for data that never existed"
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -69,8 +69,34 @@ fn spawn_save_dialog(world: &mut World) {
     world.insert_resource(SceneDialogTask::Save(task));
 }
 
-/// Save the active scene, returning whether its authoritative files reached disk.
+/// What happened when [`save_scene`] or [`save_scene_with_outcome`] ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveOutcome {
+    /// The authoritative files reached disk.
+    Saved,
+    /// The active tab had no path, so a Save As dialog was opened
+    /// instead of writing anything. Whether the scene ends up saved
+    /// depends on what the user picks and is only known once
+    /// `poll_scene_dialog` observes the dialog resolve -- a caller that
+    /// needs to act on an eventual success (not just "a save was
+    /// attempted") has to defer that action to there, not treat this
+    /// outcome as failure and give up.
+    DialogOpened,
+    /// The save was attempted and failed.
+    Failed,
+}
+
+/// Save the active scene, returning whether its authoritative files
+/// reached disk. A thin `bool` view over [`save_scene_with_outcome`] for
+/// callers that only care about "did the save happen right now" and have
+/// no work to defer past an opened Save As dialog.
 pub fn save_scene(world: &mut World) -> bool {
+    save_scene_with_outcome(world) == SaveOutcome::Saved
+}
+
+/// Save the active scene, distinguishing an opened Save As dialog from
+/// an outright failure. See [`SaveOutcome`].
+pub fn save_scene_with_outcome(world: &mut World) -> SaveOutcome {
     // The active scene tab is the source of truth for which file to
     // save to. Re-sync the global `SceneFilePath` from it so a stale
     // path from a previous tab can never cause us to overwrite the
@@ -86,14 +112,14 @@ pub fn save_scene(world: &mut World) -> bool {
     let has_path = world.resource::<SceneFilePath>().path.is_some();
     if !has_path {
         save_scene_as(world);
-        return false;
+        return SaveOutcome::DialogOpened;
     }
 
     match save_scene_inner(world) {
-        Ok(()) => true,
+        Ok(()) => SaveOutcome::Saved,
         Err(err) => {
             error!("scene save failed: {err}");
-            false
+            SaveOutcome::Failed
         }
     }
 }
@@ -1051,6 +1077,46 @@ mod tests {
             baseline,
             "failed saves must not advance the clean-history baseline",
         );
+    }
+
+    /// I10(a): `save_scene_with_outcome` must distinguish a genuine
+    /// failure from "opened a dialog instead" so a caller with work to
+    /// defer (see `scene_io::load::on_new_scene_save`) does not give up
+    /// on a save that has not actually finished yet.
+    #[test]
+    fn save_scene_with_outcome_reports_saved_on_success() {
+        let mut world = build_live_save_world();
+        let tmp = tempfile::tempdir().expect("temp directory");
+        let scene_path = tmp.path().join("zone.bsn");
+
+        let mut tab = crate::scenes::SceneTab::new_untitled(1);
+        tab.path = Some(scene_path);
+        tab.dirty = true;
+        world.insert_resource(crate::scenes::Scenes {
+            tabs: vec![tab],
+            active: 0,
+        });
+
+        assert_eq!(save_scene_with_outcome(&mut world), SaveOutcome::Saved);
+    }
+
+    #[test]
+    fn save_scene_with_outcome_reports_failed_on_a_blocked_write() {
+        let mut world = build_live_save_world();
+        let tmp = tempfile::tempdir().expect("temp directory");
+        let blocked_parent = tmp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"blocks directory creation").expect("seed blocker");
+        let scene_path = blocked_parent.join("zone.bsn");
+
+        let mut tab = crate::scenes::SceneTab::new_untitled(1);
+        tab.path = Some(scene_path);
+        tab.dirty = true;
+        world.insert_resource(crate::scenes::Scenes {
+            tabs: vec![tab],
+            active: 0,
+        });
+
+        assert_eq!(save_scene_with_outcome(&mut world), SaveOutcome::Failed);
     }
 
     #[test]

--- a/src/scenes/confirm_dialog.rs
+++ b/src/scenes/confirm_dialog.rs
@@ -463,8 +463,7 @@ fn apply_confirm_dialog_action(world: &mut World, action: ConfirmDialogButton, t
 
                 // Point SceneFilePath at this tab so save works correctly.
                 let path_str = path.to_string_lossy().into_owned();
-                if let Some(mut sfp) = world.get_resource_mut::<crate::scene_io::SceneFilePath>()
-                {
+                if let Some(mut sfp) = world.get_resource_mut::<crate::scene_io::SceneFilePath>() {
                     sfp.path = Some(path_str);
                 }
 
@@ -508,7 +507,7 @@ fn apply_confirm_dialog_action(world: &mut World, action: ConfirmDialogButton, t
 #[cfg(test)]
 mod apply_confirm_dialog_action_tests {
     use crate::scene_io::SceneFilePath;
-    use crate::scenes::{Scenes, SceneTab};
+    use crate::scenes::{SceneTab, Scenes};
 
     use super::*;
 

--- a/src/scenes/confirm_dialog.rs
+++ b/src/scenes/confirm_dialog.rs
@@ -383,10 +383,13 @@ pub fn on_quit_dialog_button_click(
 
         match action {
             ConfirmQuitButton::SaveAll => {
-                crate::scenes::operators::scene_save_all_system(world);
-                world
-                    .resource_mut::<bevy::ecs::message::Messages<bevy::app::AppExit>>()
-                    .write(bevy::app::AppExit::Success);
+                if crate::scenes::operators::scene_save_all_system(world) {
+                    world
+                        .resource_mut::<bevy::ecs::message::Messages<bevy::app::AppExit>>()
+                        .write(bevy::app::AppExit::Success);
+                } else {
+                    warn!("quit cancelled because one or more scenes could not be saved");
+                }
             }
             ConfirmQuitButton::DiscardAll => {
                 world
@@ -457,21 +460,15 @@ pub fn on_dialog_button_click(
                         sfp.path = Some(path_str);
                     }
 
-                    crate::scene_io::save_scene(world);
+                    if crate::scene_io::save_scene(world) {
+                        world.resource_mut::<PendingTabClose>().tab_index = None;
 
-                    // Mark not-dirty after save.
-                    if let Some(tab) = world
-                        .resource_mut::<crate::scenes::Scenes>()
-                        .tabs
-                        .get_mut(target)
-                    {
-                        tab.dirty = false;
+                        // The save boundary cleared dirty state only after
+                        // every authoritative file reached disk.
+                        crate::scenes::operators::scene_close_system_unprompted(world, target);
+                    } else {
+                        warn!("confirm_dialog: save failed; keeping tab {target} open");
                     }
-
-                    world.resource_mut::<PendingTabClose>().tab_index = None;
-
-                    // Now close the (now-clean) tab.
-                    crate::scenes::operators::scene_close_system_unprompted(world, target);
                 } else {
                     // Untitled tab: no path available.
                     // Deviation: falling back to Discard with a warning.

--- a/src/scenes/confirm_dialog.rs
+++ b/src/scenes/confirm_dialog.rs
@@ -432,64 +432,132 @@ pub fn on_dialog_button_click(
         let Some(target) = world.resource::<PendingTabClose>().tab_index else {
             return;
         };
-
-        match action {
-            ConfirmDialogButton::Save => {
-                let tab_count = world.resource::<crate::scenes::Scenes>().tabs.len();
-                if target >= tab_count {
-                    world.resource_mut::<PendingTabClose>().tab_index = None;
-                    return;
-                }
-
-                let tab_path = world.resource::<crate::scenes::Scenes>().tabs[target]
-                    .path
-                    .clone();
-
-                if let Some(path) = tab_path {
-                    // Swap to the target tab if it is not active.
-                    let active = world.resource::<crate::scenes::Scenes>().active;
-                    if active != target {
-                        crate::scenes::swap::swap_active_tab(world, target);
-                    }
-
-                    // Point SceneFilePath at this tab so save works correctly.
-                    let path_str = path.to_string_lossy().into_owned();
-                    if let Some(mut sfp) =
-                        world.get_resource_mut::<crate::scene_io::SceneFilePath>()
-                    {
-                        sfp.path = Some(path_str);
-                    }
-
-                    if crate::scene_io::save_scene(world) {
-                        world.resource_mut::<PendingTabClose>().tab_index = None;
-
-                        // The save boundary cleared dirty state only after
-                        // every authoritative file reached disk.
-                        crate::scenes::operators::scene_close_system_unprompted(world, target);
-                    } else {
-                        warn!("confirm_dialog: save failed; keeping tab {target} open");
-                    }
-                } else {
-                    // Untitled tab: no path available.
-                    // Deviation: falling back to Discard with a warning.
-                    // A full file-save-dialog sub-flow for this case is deferred.
-                    warn!(
-                        "confirm_dialog: tab {} is untitled; treating Save as Discard (deferred)",
-                        target
-                    );
-                    world.resource_mut::<PendingTabClose>().tab_index = None;
-                    crate::scenes::operators::scene_close_system_unprompted(world, target);
-                }
-            }
-            ConfirmDialogButton::Discard => {
-                world.resource_mut::<PendingTabClose>().tab_index = None;
-                crate::scenes::operators::scene_close_system_unprompted(world, target);
-            }
-            ConfirmDialogButton::Cancel => {
-                world.resource_mut::<PendingTabClose>().tab_index = None;
-            }
-        }
+        apply_confirm_dialog_action(world, action, target);
     });
 
     Ok(())
+}
+
+/// The Save / Discard / Cancel decision for a pending tab close, factored
+/// out of the click observer so it is callable (and testable) directly
+/// with a target index rather than only through `PendingTabClose`.
+fn apply_confirm_dialog_action(world: &mut World, action: ConfirmDialogButton, target: usize) {
+    match action {
+        ConfirmDialogButton::Save => {
+            let tab_count = world.resource::<crate::scenes::Scenes>().tabs.len();
+            if target >= tab_count {
+                world.resource_mut::<PendingTabClose>().tab_index = None;
+                return;
+            }
+
+            let tab_path = world.resource::<crate::scenes::Scenes>().tabs[target]
+                .path
+                .clone();
+
+            if let Some(path) = tab_path {
+                // Swap to the target tab if it is not active.
+                let active = world.resource::<crate::scenes::Scenes>().active;
+                if active != target {
+                    crate::scenes::swap::swap_active_tab(world, target);
+                }
+
+                // Point SceneFilePath at this tab so save works correctly.
+                let path_str = path.to_string_lossy().into_owned();
+                if let Some(mut sfp) = world.get_resource_mut::<crate::scene_io::SceneFilePath>()
+                {
+                    sfp.path = Some(path_str);
+                }
+
+                // Cleared regardless of outcome: siblings (untitled tab,
+                // Discard, Cancel) all clear it unconditionally, and
+                // leaving it set on a failed save here used to make
+                // scene_close_system treat every later close request on
+                // any dirty tab as "a dialog is already up" and silently
+                // ignore it.
+                world.resource_mut::<PendingTabClose>().tab_index = None;
+
+                if crate::scene_io::save_scene(world) {
+                    // The save boundary cleared dirty state only after
+                    // every authoritative file reached disk.
+                    crate::scenes::operators::scene_close_system_unprompted(world, target);
+                } else {
+                    warn!("confirm_dialog: save failed; keeping tab {target} open");
+                }
+            } else {
+                // Untitled tab: no path available.
+                // Deviation: falling back to Discard with a warning.
+                // A full file-save-dialog sub-flow for this case is deferred.
+                warn!(
+                    "confirm_dialog: tab {} is untitled; treating Save as Discard (deferred)",
+                    target
+                );
+                world.resource_mut::<PendingTabClose>().tab_index = None;
+                crate::scenes::operators::scene_close_system_unprompted(world, target);
+            }
+        }
+        ConfirmDialogButton::Discard => {
+            world.resource_mut::<PendingTabClose>().tab_index = None;
+            crate::scenes::operators::scene_close_system_unprompted(world, target);
+        }
+        ConfirmDialogButton::Cancel => {
+            world.resource_mut::<PendingTabClose>().tab_index = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod apply_confirm_dialog_action_tests {
+    use crate::scene_io::SceneFilePath;
+    use crate::scenes::{Scenes, SceneTab};
+
+    use super::*;
+
+    /// A world with one dirty tab pointed at `path`, and a confirm dialog
+    /// already pending on it -- enough for the Save branch of
+    /// `apply_confirm_dialog_action` to run without touching BSN AST or
+    /// asset-catalog machinery (both are optional resources that
+    /// `save_scene_inner` tolerates being absent).
+    fn world_with_dirty_tab_at(path: std::path::PathBuf) -> World {
+        let mut world = World::new();
+        world.init_resource::<jackdaw_commands::CommandHistory>();
+        world.init_resource::<crate::scene_io::SceneDirtyState>();
+        world.init_resource::<SceneFilePath>();
+
+        let mut tab = SceneTab::new_untitled(1);
+        tab.path = Some(path);
+        tab.dirty = true;
+        world.insert_resource(Scenes {
+            tabs: vec![tab],
+            active: 0,
+        });
+        world.insert_resource(PendingTabClose { tab_index: Some(0) });
+        world
+    }
+
+    /// I10(b) pinning test, the exact scenario from the review finding:
+    /// a failed save from the tab-close confirm dialog used to leave
+    /// `PendingTabClose.tab_index` set, which made `scene_close_system`
+    /// treat every later close request on any dirty tab as "a dialog is
+    /// already up" and silently ignore it.
+    #[test]
+    fn a_failed_save_still_clears_pending_tab_close() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let blocked_parent = tmp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"blocks directory creation").expect("seed blocker");
+        let scene_path = blocked_parent.join("zone.bsn");
+
+        let mut world = world_with_dirty_tab_at(scene_path);
+
+        apply_confirm_dialog_action(&mut world, ConfirmDialogButton::Save, 0);
+
+        assert_eq!(
+            world.resource::<PendingTabClose>().tab_index,
+            None,
+            "a failed save must still clear tab_index so later closes are not ignored",
+        );
+        assert!(
+            world.resource::<Scenes>().tabs[0].dirty,
+            "a failed save must leave the tab dirty",
+        );
+    }
 }

--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -13,6 +13,7 @@ use bevy::prelude::*;
 
 use crate::commands::CommandHistory;
 use crate::project::ProjectRoot;
+use crate::terrain::TerrainDataStore;
 
 pub struct ScenesPlugin;
 
@@ -126,6 +127,9 @@ pub struct SceneTab {
     pub content: TabContent,
     pub view_state: ViewState,
     pub history: CommandHistory,
+    /// Decoded terrain sidecars owned by this tab while it is inactive.
+    /// The active tab's store lives in the world as a resource instead.
+    pub terrain_data_store: TerrainDataStore,
     /// Recorded `CommandHistory.undo_stack.len()` as of the last time
     /// the dirty-tracking system ran (or the tab was activated, or
     /// saved). If the live history is deeper than this, the user has
@@ -144,6 +148,7 @@ impl SceneTab {
             content: TabContent::default(),
             view_state: ViewState::with_default_camera(),
             history: CommandHistory::default(),
+            terrain_data_store: TerrainDataStore::default(),
             history_depth_at_last_check: 0,
         }
     }

--- a/src/scenes/operators.rs
+++ b/src/scenes/operators.rs
@@ -390,6 +390,11 @@ pub fn scene_save_all_system(world: &mut World) {
         }
         match std::fs::write(&target_path, &contents) {
             Ok(()) => {
+                // Save All inlines its own emit + write instead of going
+                // through `save_scene_inner`, so it skips every sibling
+                // export hanging off that path. Terrain data has to be
+                // written here too or a Save All silently drops it.
+                crate::scene_io::export_terrain_sidecars(world, &path_str);
                 let depth = world
                     .resource::<crate::commands::CommandHistory>()
                     .undo_stack

--- a/src/scenes/operators.rs
+++ b/src/scenes/operators.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::keymap::PresetInput;
 
-use crate::scene_io::{SceneDirtyState, SceneFilePath};
+use crate::scene_io::SceneFilePath;
 use crate::scenes::{SceneTab, Scenes, swap::swap_active_tab};
 
 /// Counter for default `untitled-N` names. Persists across the editor
@@ -338,20 +338,33 @@ pub fn scene_switch_system(world: &mut World, target: usize) {
 
 #[operator(id = "scene.save_all", label = "Save All", allows_undo = false)]
 pub fn scene_save_all(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
-    commands.queue(scene_save_all_system);
+    commands.queue(|world: &mut World| {
+        scene_save_all_system(world);
+    });
     OperatorResult::Finished
 }
 
 /// Iterate tabs, switching to each in turn, serializing tabs with a path
 /// to disk synchronously, then return to the originally-active tab.
 ///
-/// Tabs without a path (untitled) are skipped.
-pub fn scene_save_all_system(world: &mut World) {
+/// Clean tabs without a path (untitled) are skipped. A dirty untitled tab or
+/// any authoritative write failure makes the result `false` and leaves that
+/// tab dirty, allowing callers such as quit confirmation to refuse to exit.
+pub fn scene_save_all_system(world: &mut World) -> bool {
     let original_active = world.resource::<Scenes>().active;
     let count = world.resource::<Scenes>().tabs.len();
+    let mut all_saved = true;
 
     for i in 0..count {
-        let Some(path) = world.resource::<Scenes>().tabs[i].path.clone() else {
+        let (path, dirty) = {
+            let scenes = world.resource::<Scenes>();
+            (scenes.tabs[i].path.clone(), scenes.tabs[i].dirty)
+        };
+        let Some(path) = path else {
+            if dirty {
+                warn!("scene.save_all: cannot save dirty untitled tab {i} without a path");
+                all_saved = false;
+            }
             continue;
         };
 
@@ -359,61 +372,17 @@ pub fn scene_save_all_system(world: &mut World) {
             swap_active_tab(world, i);
         }
 
-        // A legacy `.jsn` path redirects to its `.bsn` sibling, keeping the
-        // original as a `.jsn.bak` backup, the same convention the single
-        // save uses.
-        let jsn_redirect = path.extension().is_some_and(|e| e == "jsn");
-        let target_path = if jsn_redirect {
-            path.with_extension("bsn")
-        } else {
-            path.clone()
-        };
-
-        // Point SceneFilePath at this tab's path so the emit resolves
-        // relative asset references correctly.
-        let path_str = target_path.to_string_lossy().into_owned();
+        // Use the same persistence boundary as a single-scene save: terrain
+        // sidecars complete before scene text, legacy paths redirect safely,
+        // and dirty state only clears after every authoritative write.
+        let path_str = path.to_string_lossy().into_owned();
         if let Some(mut sfp) = world.get_resource_mut::<SceneFilePath>() {
-            sfp.path = Some(path_str.clone());
+            sfp.path = Some(path_str);
         }
 
-        let parent = target_path
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_default();
-        let contents = crate::scene_io::emit_bsn_scene_with_inline_assets(world, &parent);
-        if jsn_redirect {
-            let backup = format!("{}.bak", path.to_string_lossy());
-            if let Err(err) = std::fs::rename(&path, &backup) {
-                warn!("scene.save_all: could not back up {path:?} to {backup}: {err}");
-            }
-            world.resource_mut::<Scenes>().tabs[i].path = Some(target_path.clone());
-        }
-        match std::fs::write(&target_path, &contents) {
-            Ok(()) => {
-                // Save All inlines its own emit + write instead of going
-                // through `save_scene_inner`, so it skips every sibling
-                // export hanging off that path. Terrain data has to be
-                // written here too or a Save All silently drops it.
-                crate::scene_io::export_terrain_sidecars(world, &path_str);
-                let depth = world
-                    .resource::<crate::commands::CommandHistory>()
-                    .undo_stack
-                    .len();
-                {
-                    let mut scenes = world.resource_mut::<Scenes>();
-                    scenes.tabs[i].dirty = false;
-                    scenes.tabs[i].history_depth_at_last_check = depth;
-                }
-                // Sync the dirty state counter.
-                if let Some(history_len) = world
-                    .get_resource::<jackdaw_commands::CommandHistory>()
-                    .map(|h| h.undo_stack.len())
-                    && let Some(mut ds) = world.get_resource_mut::<SceneDirtyState>()
-                {
-                    ds.undo_len_at_save = history_len;
-                }
-            }
-            Err(err) => warn!("scene.save_all: failed to write {target_path:?}: {err}"),
+        if let Err(err) = crate::scene_io::save_scene_inner(world) {
+            warn!("scene.save_all: failed to save {path:?}: {err}");
+            all_saved = false;
         }
     }
 
@@ -429,6 +398,8 @@ pub fn scene_save_all_system(world: &mut World) {
     if let Some(mut sfp) = world.get_resource_mut::<SceneFilePath>() {
         sfp.path = active_path;
     }
+
+    all_saved
 }
 
 #[operator(id = "scene.cycle_next", label = "Next Scene Tab", allows_undo = false)]

--- a/src/scenes/swap.rs
+++ b/src/scenes/swap.rs
@@ -203,6 +203,20 @@ pub fn activate_tab(world: &mut World, target: usize) {
         spath.path = tab_path.as_ref().map(|p| p.to_string_lossy().into_owned());
     }
 
+    // Hydrate any terrain sidecar the store has not seen yet. A tab opened
+    // by `scene_open_system` pushes a parsed document straight onto the
+    // tab strip and never goes through `finish_load_scene`, so this is the
+    // only place its bulk data gets read. `FillMissing` is deliberate: a
+    // swap back to a tab the user has been sculpting must keep the unsaved
+    // edits the store holds rather than re-reading the older file.
+    if let Some(path) = tab_path.as_ref() {
+        crate::scene_io::import_terrain_sidecars(
+            world,
+            &path.to_string_lossy(),
+            crate::scene_io::SidecarImport::FillMissing,
+        );
+    }
+
     let mut scenes = world.resource_mut::<Scenes>();
     scenes.active = target;
     scenes.tabs[target].history_depth_at_last_check = history_depth;

--- a/src/scenes/swap.rs
+++ b/src/scenes/swap.rs
@@ -113,16 +113,23 @@ pub(crate) fn capture_active_tab(world: &mut World) {
         scenes.tabs[active].content = TabContent::Scene(Some(Box::new(doc)));
     }
 
+    let terrain_data_store = world
+        .get_resource_mut::<crate::terrain::TerrainDataStore>()
+        .map(|mut store| std::mem::take(&mut *store));
     let mut scenes = world.resource_mut::<Scenes>();
     let tab = &mut scenes.tabs[active];
     tab.view_state = view_state;
     tab.history = history;
+    if let Some(terrain_data_store) = terrain_data_store {
+        tab.terrain_data_store = terrain_data_store;
+    }
 }
 
 /// Spawn the target tab's document into the live world and restore per-tab
 /// history and view state.
 pub fn activate_tab(world: &mut World, target: usize) {
-    let (mut content, view_state, history, tab_path) = {
+    let has_terrain_data_store = world.contains_resource::<crate::terrain::TerrainDataStore>();
+    let (mut content, view_state, history, tab_path, terrain_data_store) = {
         let mut scenes = world.resource_mut::<Scenes>();
         let tab = &mut scenes.tabs[target];
         (
@@ -130,8 +137,16 @@ pub fn activate_tab(world: &mut World, target: usize) {
             std::mem::take(&mut tab.view_state),
             std::mem::take(&mut tab.history),
             tab.path.clone(),
+            has_terrain_data_store.then(|| std::mem::take(&mut tab.terrain_data_store)),
         )
     };
+
+    // Restore the target tab's bulk terrain data before spawning its scene
+    // and importing any sidecars. `FillMissing` can now preserve unsaved
+    // edits without confusing a same-named sidecar from another tab.
+    if let Some(terrain_data_store) = terrain_data_store {
+        *world.resource_mut::<crate::terrain::TerrainDataStore>() = terrain_data_store;
+    }
 
     // Materialize the document to install. For `Prefab` tabs, clone from
     // the cache; for `Scene` tabs, take the captured document (or default).

--- a/src/scenes/ui.rs
+++ b/src/scenes/ui.rs
@@ -456,13 +456,6 @@ pub fn on_scene_tab_context_action(event: On<ContextMenuAction>, mut commands: C
                 spath.path = Some(path.to_string_lossy().into_owned());
             }
             crate::scene_io::save_scene(world);
-            if let Some(tab) = world
-                .resource_mut::<crate::scenes::Scenes>()
-                .tabs
-                .get_mut(idx)
-            {
-                tab.dirty = false;
-            }
         }
         "scene.tab.save_as" => {
             let current = world.resource::<crate::scenes::Scenes>().active;

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -1,0 +1,279 @@
+//! Viewport screenshot capture.
+//!
+//! The 3D viewport already renders off-screen into a dedicated `Image`
+//! (`crate::viewport::build_viewport_panel`), so a capture is a
+//! [`Screenshot::image`] against a render target that already exists --
+//! no second render pass and no window grab. Capturing therefore works
+//! when the editor window is unfocused, partly covered, or never had a
+//! cursor over it.
+//!
+//! Two entry points, one capture path ([`queue_capture`]):
+//!
+//! - the `viewport.screenshot` operator, for interactive use;
+//! - the `JACKDAW_SHOT=<path>` environment variable, which waits for the
+//!   editor to settle, captures once, and exits.
+
+use std::path::{Path, PathBuf};
+
+use bevy::camera::RenderTarget;
+use bevy::prelude::*;
+use bevy::render::view::screenshot::{Screenshot, ScreenshotCaptured};
+
+use crate::prelude::*;
+use crate::viewport::MainViewportCamera;
+
+/// Names a PNG the editor writes once the viewport has settled, then
+/// exits. Matches the other `JACKDAW_*` boot switches
+/// (`JACKDAW_OPEN_PROJECT`, `JACKDAW_AUTO_OPEN`, `JACKDAW_PIE_WINDOWLESS`).
+pub const ENV_SHOT: &str = "JACKDAW_SHOT";
+
+/// Frames to let pass after entering the editor before an unattended
+/// capture fires. The first frames after the state transition have no
+/// meshes in them, and `ViewportNode` resizes the render target to the
+/// panel a frame or two later still, so this counts frames rather than
+/// keying off `OnEnter(AppState::Editor)`.
+const SETTLE_FRAMES: u32 = 90;
+
+/// Frames an unattended run keeps retrying a capture it could not start
+/// before it gives up and exits non-zero. Without it, a boot that never
+/// opens a viewport panel would hang a CI job forever.
+const CAPTURE_TIMEOUT_FRAMES: u32 = 900;
+
+pub(crate) fn plugin(app: &mut App) {
+    if let Some(path) = std::env::var_os(ENV_SHOT) {
+        app.insert_resource(ShotProbe {
+            path: PathBuf::from(path),
+            frames: 0,
+            queued: false,
+        });
+    }
+    app.add_systems(
+        Update,
+        drive_shot_probe.run_if(in_state(crate::AppState::Editor)),
+    );
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<ViewportScreenshotOp>();
+    ctx.register_menu_entry::<ViewportScreenshotOp>(TopLevelMenu::Tools);
+}
+
+/// The pending one-shot capture requested by [`ENV_SHOT`]. Absent when
+/// the variable is unset, which is every interactive run.
+#[derive(Resource)]
+struct ShotProbe {
+    path: PathBuf,
+    frames: u32,
+    queued: bool,
+}
+
+/// Why a capture could not be started.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CaptureError {
+    /// No viewport panel is open, so there is no camera to capture.
+    NoViewport,
+    /// A viewport camera exists but does not render to an image.
+    NotAnImageTarget,
+}
+
+impl core::fmt::Display for CaptureError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NoViewport => write!(f, "no viewport panel is open to capture"),
+            Self::NotAnImageTarget => {
+                write!(f, "the viewport camera does not render to an image")
+            }
+        }
+    }
+}
+
+impl core::error::Error for CaptureError {}
+
+/// Queue a capture of the main viewport's render target, written to
+/// `path` as a PNG once the GPU readback lands.
+///
+/// The render target is read off [`MainViewportCamera`] and never off
+/// [`crate::viewport::ActiveViewport`]: `ActiveViewport` tracks the
+/// viewport *under the cursor*, and in an unattended run no cursor has
+/// entered a viewport, so both its fields are `None`.
+///
+/// With `exit_when_done`, the app exits as soon as the file is written --
+/// success when it landed, failure when it did not. That is the one-shot
+/// `JACKDAW_SHOT` path; interactive captures pass `false`.
+pub fn queue_capture(
+    world: &mut World,
+    path: PathBuf,
+    exit_when_done: bool,
+) -> Result<(), CaptureError> {
+    let mut cameras = world.query_filtered::<&RenderTarget, With<MainViewportCamera>>();
+    let target = cameras.iter(world).next().ok_or(CaptureError::NoViewport)?;
+    let handle = target
+        .as_image()
+        .cloned()
+        .ok_or(CaptureError::NotAnImageTarget)?;
+
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    world.spawn(Screenshot::image(handle)).observe(
+        move |capture: On<ScreenshotCaptured>, mut exit: MessageWriter<AppExit>| {
+            // Writing the PNG here rather than through bevy's
+            // `save_to_disk` observer keeps write-then-exit in one
+            // observer. Two observers on the same entity have no
+            // ordering guarantee between them, so an exit hook added
+            // alongside `save_to_disk` could run before the bytes
+            // reached the disk.
+            let wrote = write_png(&capture.image, &path);
+            if exit_when_done {
+                exit.write(if wrote {
+                    AppExit::Success
+                } else {
+                    AppExit::error()
+                });
+            }
+        },
+    );
+    Ok(())
+}
+
+/// Encode a captured frame as a PNG on disk. Returns whether it landed.
+///
+/// Shared with [`crate::model_thumbnail`], which writes its off-screen
+/// model renders through the same encoder rather than a second one.
+pub(crate) fn write_png(image: &Image, path: &Path) -> bool {
+    let dynamic = match image.clone().try_into_dynamic() {
+        Ok(dynamic) => dynamic,
+        Err(err) => {
+            error!("screenshot: cannot convert the captured frame: {err}");
+            return false;
+        }
+    };
+    // Drop alpha: with HDR on it carries brightness rather than opacity,
+    // and saving it straight through comes out looking wrong.
+    let rgb = dynamic.to_rgb8();
+    match rgb.save_with_format(path, ::image::ImageFormat::Png) {
+        Ok(()) => {
+            info!("screenshot: wrote {}", path.display());
+            true
+        }
+        Err(err) => {
+            error!("screenshot: cannot write {}: {err}", path.display());
+            false
+        }
+    }
+}
+
+/// Count settle frames for an unattended run, then fire exactly one
+/// capture. A capture that cannot start yet (the viewport panel is still
+/// building) is retried until [`CAPTURE_TIMEOUT_FRAMES`] runs out.
+fn drive_shot_probe(world: &mut World) {
+    let Some(probe) = world.get_resource::<ShotProbe>() else {
+        return;
+    };
+    if probe.queued {
+        return;
+    }
+    let frames = probe.frames + 1;
+    world.resource_mut::<ShotProbe>().frames = frames;
+    if frames < SETTLE_FRAMES {
+        return;
+    }
+
+    let path = world.resource::<ShotProbe>().path.clone();
+    match queue_capture(world, path, true) {
+        Ok(()) => world.resource_mut::<ShotProbe>().queued = true,
+        Err(err) if frames > SETTLE_FRAMES + CAPTURE_TIMEOUT_FRAMES => {
+            error!("{ENV_SHOT}: {err}");
+            world.write_message(AppExit::error());
+        }
+        Err(_) => {}
+    }
+}
+
+/// Capture the viewport to a PNG.
+#[operator(
+    id = "viewport.screenshot",
+    label = "Screenshot Viewport",
+    description = "Save what the 3D viewport is showing to a PNG file.",
+    allows_undo = false,
+    params(path(
+        String,
+        doc = "Where to write the PNG. Defaults to a timestamped file in the project."
+    ))
+)]
+pub(crate) fn viewport_screenshot(
+    params: In<OperatorParameters>,
+    project: Option<Res<crate::project::ProjectRoot>>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let path = match params.as_str("path").filter(|p| !p.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => default_shot_path(project.as_deref()),
+    };
+    commands.queue(move |world: &mut World| {
+        if let Err(err) = queue_capture(world, path, false) {
+            error!("viewport.screenshot: {err}");
+        }
+    });
+    OperatorResult::Finished
+}
+
+/// Where an unnamed capture goes: `screenshots/<timestamp>.png` under the
+/// open project, or under the working directory when no project is open.
+fn default_shot_path(project: Option<&crate::project::ProjectRoot>) -> PathBuf {
+    let stamp = crate::timestamps::utc_rfc3339_now().replace(':', "-");
+    let dir = project
+        .map(|p| p.root.join("screenshots"))
+        .unwrap_or_else(|| PathBuf::from("screenshots"));
+    dir.join(format!("viewport-{stamp}.png"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A capture against a world with no viewport camera reports it
+    /// rather than panicking or silently doing nothing -- the operator's
+    /// whole job is producing a file, so a miss has to be visible.
+    #[test]
+    fn capturing_without_a_viewport_reports_no_viewport() {
+        let mut world = World::new();
+        let err = queue_capture(&mut world, PathBuf::from("unused.png"), false)
+            .expect_err("no viewport camera exists");
+        assert_eq!(err, CaptureError::NoViewport);
+    }
+
+    /// A viewport camera that renders to a window (rather than to its
+    /// own image) is not capturable through this path.
+    #[test]
+    fn capturing_a_window_target_reports_not_an_image_target() {
+        let mut world = World::new();
+        world.spawn((
+            MainViewportCamera,
+            RenderTarget::Window(bevy::window::WindowRef::Primary),
+        ));
+        let err = queue_capture(&mut world, PathBuf::from("unused.png"), false)
+            .expect_err("the target is a window");
+        assert_eq!(err, CaptureError::NotAnImageTarget);
+    }
+
+    /// The default path lands inside the open project, so an
+    /// interactive capture does not scatter files across the cwd.
+    #[test]
+    fn default_path_is_a_png_under_the_project() {
+        let root = PathBuf::from("/tmp/some-project");
+        let project = crate::project::ProjectRoot {
+            root: root.clone(),
+            config: crate::project::ProjectConfig::default(),
+        };
+        let path = default_shot_path(Some(&project));
+        assert!(path.starts_with(root.join("screenshots")), "{path:?}");
+        assert_eq!(path.extension().and_then(|e| e.to_str()), Some("png"));
+        // Colons are legal on unix and illegal on Windows; a timestamped
+        // default has to be writable on both.
+        assert!(!path.to_string_lossy().contains(':'), "{path:?}");
+    }
+}

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -284,8 +284,8 @@ mod tests {
 
     /// M12 pinning test: a capture that never gets a viewport keeps
     /// failing every frame past the timeout. Before the latch,
-    /// drive_shot_probe re-entered the timeout arm on every subsequent
-    /// call and wrote a fresh AppExit each time.
+    /// `drive_shot_probe` re-entered the timeout arm on every subsequent
+    /// call and wrote a fresh `AppExit` each time.
     #[test]
     fn a_capture_that_never_starts_emits_app_exit_only_once() {
         let mut world = World::new();

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -187,6 +187,11 @@ fn drive_shot_probe(world: &mut World) {
         Ok(()) => world.resource_mut::<ShotProbe>().queued = true,
         Err(err) if frames > SETTLE_FRAMES + CAPTURE_TIMEOUT_FRAMES => {
             error!("{ENV_SHOT}: {err}");
+            // Latch: `queued` doubles as "nothing left to do here", so
+            // without setting it a capture that keeps failing past the
+            // timeout re-entered this arm and re-emitted AppExit every
+            // frame from then on.
+            world.resource_mut::<ShotProbe>().queued = true;
             world.write_message(AppExit::error());
         }
         Err(_) => {}
@@ -275,5 +280,36 @@ mod tests {
         // Colons are legal on unix and illegal on Windows; a timestamped
         // default has to be writable on both.
         assert!(!path.to_string_lossy().contains(':'), "{path:?}");
+    }
+
+    /// M12 pinning test: a capture that never gets a viewport keeps
+    /// failing every frame past the timeout. Before the latch,
+    /// drive_shot_probe re-entered the timeout arm on every subsequent
+    /// call and wrote a fresh AppExit each time.
+    #[test]
+    fn a_capture_that_never_starts_emits_app_exit_only_once() {
+        let mut world = World::new();
+        world.init_resource::<bevy::ecs::message::Messages<AppExit>>();
+        world.insert_resource(ShotProbe {
+            path: PathBuf::from("unused.png"),
+            frames: SETTLE_FRAMES + CAPTURE_TIMEOUT_FRAMES,
+            queued: false,
+        });
+
+        for _ in 0..5 {
+            drive_shot_probe(&mut world);
+        }
+
+        assert_eq!(
+            world
+                .resource::<bevy::ecs::message::Messages<AppExit>>()
+                .len(),
+            1,
+            "AppExit must be written exactly once, not once per frame",
+        );
+        assert!(
+            world.resource::<ShotProbe>().queued,
+            "must latch so drive_shot_probe stops retrying",
+        );
     }
 }

--- a/src/snapping.rs
+++ b/src/snapping.rs
@@ -97,13 +97,9 @@ fn handle_grid_size_scroll(
     let alt = keyboard.any_pressed([KeyCode::AltLeft, KeyCode::AltRight]);
     let shift = keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);
 
-    // Shift+Scroll is used for brush resize when terrain sculpt is active;
-    // only allow grid resize via Shift+Scroll when NOT sculpting.
-    let shift_grid = shift
-        && !matches!(
-            *terrain_edit_mode,
-            crate::terrain::TerrainEditMode::Sculpt(_)
-        );
+    // Shift+Scroll is used for brush resize when terrain sculpt or paint
+    // is active; only allow grid resize via Shift+Scroll when neither is.
+    let shift_grid = shift && !terrain_edit_mode.brush_active();
 
     if !((ctrl && alt) || shift_grid) {
         return;

--- a/src/terrain/channel_ops.rs
+++ b/src/terrain/channel_ops.rs
@@ -1,0 +1,233 @@
+//! Operators for editing a terrain's channel table.
+//!
+//! Channel descriptors -- name, width, palette -- are small reflected data
+//! that lives inline in the scene document, so every mutation here syncs
+//! the component back to the AST. The per-cell values the descriptors
+//! describe are bulk data and never come near it.
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement, TerrainPaletteEntry};
+
+use super::ops::has_selected_terrain;
+use super::{TerrainDataStore, TerrainDirtyChunks, TerrainPaintState};
+use crate::selection::Selection;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<TerrainChannelAddOp>()
+        .register_operator::<TerrainChannelRemoveOp>()
+        .register_operator::<TerrainChannelSelectOp>()
+        .register_operator::<TerrainChannelValueAddOp>()
+        .register_operator::<TerrainChannelValueSelectOp>()
+        .register_operator::<TerrainChannelToggleViewOp>();
+}
+
+/// Colours a fresh palette entry cycles through.
+///
+/// Distinct hues so consecutive entries are told apart at a glance on a
+/// tile grid. Jackdaw picks the first colour only so the swatch is not
+/// born invisible; the user is expected to change it.
+const SEED_COLORS: [Srgba; 6] = [
+    Srgba::new(0.42, 0.62, 0.32, 1.0),
+    Srgba::new(0.76, 0.62, 0.35, 1.0),
+    Srgba::new(0.35, 0.52, 0.72, 1.0),
+    Srgba::new(0.70, 0.40, 0.42, 1.0),
+    Srgba::new(0.55, 0.42, 0.68, 1.0),
+    Srgba::new(0.38, 0.66, 0.64, 1.0),
+];
+
+fn seed_color(index: usize) -> Color {
+    SEED_COLORS[index % SEED_COLORS.len()].into()
+}
+
+/// Push the terrain's channel table back into the scene document and
+/// force a mesh rebuild, so a table edit is both saved and visible.
+fn commit_channels(world: &mut World, entity: Entity) {
+    let Some(terrain) = world.get::<jackdaw_scene_types::Terrain>(entity) else {
+        return;
+    };
+    let terrain = terrain.clone();
+    // Reconciling here is what zeroes a newly added channel at
+    // `resolution^2` and carries a renamed one's values across.
+    world.resource_mut::<TerrainDataStore>().entry_for(&terrain);
+    crate::commands::sync_component_to_ast(
+        world,
+        entity,
+        "jackdaw_scene_types::types::Terrain",
+        &terrain,
+    );
+    if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(entity) {
+        dirty.rebuild_all = true;
+    }
+}
+
+/// Add a channel to the selected terrain and make it active.
+#[operator(
+    id = "terrain.channel.add",
+    label = "Add Channel",
+    description = "Add a paint channel to this terrain.",
+    is_available = has_selected_terrain
+)]
+pub(crate) fn terrain_channel_add(
+    _: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut terrains: Query<&mut jackdaw_scene_types::Terrain>,
+    mut paint: ResMut<TerrainPaintState>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let entity = selection.primary()?;
+    let mut terrain = terrains.get_mut(entity)?;
+
+    let index = terrain.channels.len();
+    terrain.channels.push(TerrainChannel {
+        name: format!("channel-{index}"),
+        element: TerrainChannelElement::U8,
+        // A channel is born with an "unset" entry plus one paintable
+        // value, so the user can paint something immediately instead of
+        // having to build a palette before the tool does anything.
+        palette: vec![
+            TerrainPaletteEntry {
+                value: 0,
+                label: "unset".to_string(),
+                color: Color::srgb(0.5, 0.5, 0.5),
+            },
+            TerrainPaletteEntry {
+                value: 1,
+                label: "value-1".to_string(),
+                color: seed_color(0),
+            },
+        ],
+    });
+    paint.active_channel = index;
+    paint.active_entry = 1;
+    paint.show_channel = true;
+
+    commands.queue(move |world: &mut World| commit_channels(world, entity));
+    OperatorResult::Finished
+}
+
+/// Remove a channel from the selected terrain.
+#[operator(
+    id = "terrain.channel.remove",
+    label = "Remove Channel",
+    description = "Remove a paint channel and everything painted into it.",
+    is_available = has_selected_terrain,
+    params(index(i64, doc = "Channel index to remove."))
+)]
+pub(crate) fn terrain_channel_remove(
+    params: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut terrains: Query<&mut jackdaw_scene_types::Terrain>,
+    mut paint: ResMut<TerrainPaintState>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let entity = selection.primary()?;
+    let index = usize::try_from(params.as_int("index")?).ok()?;
+    let mut terrain = terrains.get_mut(entity)?;
+    if index >= terrain.channels.len() {
+        return OperatorResult::Cancelled;
+    }
+    terrain.channels.remove(index);
+    paint.active_channel = paint
+        .active_channel
+        .min(terrain.channels.len().saturating_sub(1));
+    paint.active_entry = 0;
+
+    commands.queue(move |world: &mut World| commit_channels(world, entity));
+    OperatorResult::Finished
+}
+
+/// Make a channel the one the brush writes and the viewport tints.
+#[operator(
+    id = "terrain.channel.select",
+    label = "Select Channel",
+    description = "Choose which channel the brush paints into.",
+    allows_undo = false,
+    params(index(i64, doc = "Channel index to select."))
+)]
+pub(crate) fn terrain_channel_select(
+    params: In<OperatorParameters>,
+    mut paint: ResMut<TerrainPaintState>,
+) -> OperatorResult {
+    paint.active_channel = usize::try_from(params.as_int("index")?).ok()?;
+    paint.active_entry = 0;
+    OperatorResult::Finished
+}
+
+/// Append a palette entry to the active channel.
+#[operator(
+    id = "terrain.channel.value.add",
+    label = "Add Palette Value",
+    description = "Add a named value to the active channel's palette.",
+    is_available = has_selected_terrain
+)]
+pub(crate) fn terrain_channel_value_add(
+    _: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut terrains: Query<&mut jackdaw_scene_types::Terrain>,
+    mut paint: ResMut<TerrainPaintState>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let entity = selection.primary()?;
+    let active = paint.active_channel;
+    let mut terrain = terrains.get_mut(entity)?;
+    let ceiling = terrain.channels.get(active)?.element.max_value();
+    let channel = terrain.channels.get_mut(active)?;
+
+    // One past the highest value in use, clamped to what the channel's
+    // width can hold, so values stay stable as entries are added.
+    let next = channel
+        .palette
+        .iter()
+        .map(|entry| entry.value)
+        .max()
+        .map(|highest| highest.saturating_add(1))
+        .unwrap_or(0)
+        .min(ceiling);
+    if channel.palette.iter().any(|entry| entry.value == next) {
+        // The width is exhausted; adding another entry would alias one
+        // that already exists.
+        return OperatorResult::Cancelled;
+    }
+    let index = channel.palette.len();
+    channel.palette.push(TerrainPaletteEntry {
+        value: next,
+        label: format!("value-{next}"),
+        color: seed_color(index.saturating_sub(1)),
+    });
+    paint.active_entry = index;
+
+    commands.queue(move |world: &mut World| commit_channels(world, entity));
+    OperatorResult::Finished
+}
+
+/// Choose which palette value the brush writes.
+#[operator(
+    id = "terrain.channel.value.select",
+    label = "Select Palette Value",
+    description = "Choose which value the brush paints.",
+    allows_undo = false,
+    params(index(i64, doc = "Palette entry index to select."))
+)]
+pub(crate) fn terrain_channel_value_select(
+    params: In<OperatorParameters>,
+    mut paint: ResMut<TerrainPaintState>,
+) -> OperatorResult {
+    paint.active_entry = usize::try_from(params.as_int("index")?).ok()?;
+    OperatorResult::Finished
+}
+
+/// Toggle the viewport tint that shows what is painted.
+#[operator(
+    id = "terrain.channel.toggle_view",
+    label = "Show Painted Channel",
+    description = "Tint the terrain by the active channel so painted values are visible.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_channel_toggle_view(
+    _: In<OperatorParameters>,
+    mut paint: ResMut<TerrainPaintState>,
+) -> OperatorResult {
+    paint.show_channel = !paint.show_channel;
+    OperatorResult::Finished
+}

--- a/src/terrain/channel_ops.rs
+++ b/src/terrain/channel_ops.rs
@@ -11,6 +11,7 @@ use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement, TerrainPaletteE
 
 use super::ops::has_selected_terrain;
 use super::{TerrainDataStore, TerrainDirtyChunks, TerrainPaintState};
+use crate::commands::{CommandHistory, EditorCommand};
 use crate::selection::Selection;
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
@@ -153,34 +154,213 @@ pub(crate) fn terrain_channel_add(
 }
 
 /// Remove a channel from the selected terrain.
+///
+/// `allows_undo = false` because it pushes its own [`RemoveTerrainChannel`]
+/// entry; the generic diff only ever sees the descriptor half of a
+/// remove (bulk channel values live outside the AST), so letting it also
+/// capture a snapshot would both double-record the change and lose the
+/// painted data on undo.
 #[operator(
     id = "terrain.channel.remove",
     label = "Remove Channel",
     description = "Remove a paint channel and everything painted into it.",
     is_available = has_selected_terrain,
+    allows_undo = false,
     params(index(i64, doc = "Channel index to remove."))
 )]
 pub(crate) fn terrain_channel_remove(
     params: In<OperatorParameters>,
     selection: Res<Selection>,
-    mut terrains: Query<&mut jackdaw_scene_types::Terrain>,
+    terrains: Query<&jackdaw_scene_types::Terrain>,
+    store: Res<TerrainDataStore>,
     mut paint: ResMut<TerrainPaintState>,
     mut commands: Commands,
 ) -> OperatorResult {
     let entity = selection.primary()?;
     let index = usize::try_from(params.as_int("index")?).ok()?;
-    let mut terrain = terrains.get_mut(entity)?;
+    let terrain = terrains.get(entity)?;
     if index >= terrain.channels.len() {
         return OperatorResult::Cancelled;
     }
-    terrain.channels.remove(index);
-    paint.active_channel = paint
-        .active_channel
-        .min(terrain.channels.len().saturating_sub(1));
+    let descriptor = terrain.channels[index].clone();
+    let data = store
+        .get(&terrain.data_path)
+        .and_then(|data| data.channels.get(index))
+        .cloned();
+
+    let remaining = terrain.channels.len() - 1;
+    paint.active_channel = paint.active_channel.min(remaining.saturating_sub(1));
     paint.active_entry = 0;
 
-    commands.queue(move |world: &mut World| commit_channels(world, entity));
+    commands.queue(move |world: &mut World| {
+        let command = RemoveTerrainChannel {
+            entity,
+            index,
+            descriptor,
+            data,
+            label: "Remove Channel".to_string(),
+        };
+        world.resource_scope(|world, mut history: Mut<CommandHistory>| {
+            history.execute(Box::new(command), world);
+        });
+    });
     OperatorResult::Finished
+}
+
+/// Undo command for `terrain.channel.remove`.
+///
+/// A channel removal touches two stores: the descriptor leaves
+/// `Terrain::channels` (reflected, reaches the AST) and its per-cell
+/// values leave [`TerrainDataStore`] (bulk data, dropped by
+/// [`TerrainDataStore::entry_for`]'s reconcile the moment the descriptor
+/// is gone -- see `store.rs`). The generic history diff only ever sees
+/// the AST half, so a remove dispatched through it would restore the
+/// descriptor on undo and mint a zeroed channel in its place. This
+/// command captures both halves up front, at construction time, and
+/// restores both on undo.
+pub struct RemoveTerrainChannel {
+    pub entity: Entity,
+    pub index: usize,
+    pub descriptor: TerrainChannel,
+    pub data: Option<jackdaw_terrain::ChannelData>,
+    pub label: String,
+}
+
+impl RemoveTerrainChannel {
+    fn apply_removed(&self, world: &mut World) {
+        let Some(mut terrain) = world.get_mut::<jackdaw_scene_types::Terrain>(self.entity) else {
+            return;
+        };
+        if self.index >= terrain.channels.len() {
+            return;
+        }
+        terrain.channels.remove(self.index);
+        commit_channels(world, self.entity);
+    }
+
+    fn apply_restored(&self, world: &mut World) {
+        let Some(mut terrain) = world.get_mut::<jackdaw_scene_types::Terrain>(self.entity) else {
+            return;
+        };
+        let at = self.index.min(terrain.channels.len());
+        terrain.channels.insert(at, self.descriptor.clone());
+        let terrain = terrain.clone();
+
+        if let Some(data) = world.resource_mut::<TerrainDataStore>().entry_for(&terrain)
+            && let Some(restored) = &self.data
+            && let Some(slot) = data
+                .channels
+                .iter_mut()
+                .find(|channel| channel.name == self.descriptor.name)
+        {
+            *slot = restored.clone();
+        }
+        crate::commands::sync_component_to_ast(
+            world,
+            self.entity,
+            "jackdaw_scene_types::types::Terrain",
+            &terrain,
+        );
+        if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
+            dirty.rebuild_all = true;
+        }
+    }
+}
+
+impl EditorCommand for RemoveTerrainChannel {
+    fn execute(&mut self, world: &mut World) {
+        self.apply_removed(world);
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        self.apply_restored(world);
+    }
+
+    fn description(&self) -> &str {
+        &self.label
+    }
+}
+
+#[cfg(test)]
+mod remove_tests {
+    use bevy::ecs::reflect::AppTypeRegistry;
+
+    use super::*;
+
+    fn channel(name: &str) -> TerrainChannel {
+        TerrainChannel {
+            name: name.to_string(),
+            element: TerrainChannelElement::U8,
+            palette: vec![],
+        }
+    }
+
+    /// C4 pinning test: undoing `terrain.channel.remove` must restore the
+    /// channel's painted values, not mint a zeroed replacement.
+    #[test]
+    fn undoing_a_channel_remove_restores_its_painted_values() {
+        let mut world = World::new();
+        world.init_resource::<AppTypeRegistry>();
+        world.init_resource::<TerrainDataStore>();
+
+        let terrain = jackdaw_scene_types::Terrain {
+            resolution: 2,
+            data_path: "zone.terrain-0.jdterrain".to_string(),
+            channels: vec![channel("biome"), channel("walkable")],
+            ..default()
+        };
+        let entity = world.spawn(terrain.clone()).id();
+
+        {
+            let mut store = world.resource_mut::<TerrainDataStore>();
+            let data = store.entry_for(&terrain).expect("keyed");
+            data.channels[1].values = vec![7, 7, 7, 7];
+        }
+
+        let descriptor = terrain.channels[1].clone();
+        let painted = world
+            .resource::<TerrainDataStore>()
+            .get(&terrain.data_path)
+            .and_then(|data| data.channels.get(1))
+            .cloned()
+            .expect("painted data captured");
+
+        let mut command = RemoveTerrainChannel {
+            entity,
+            index: 1,
+            descriptor,
+            data: Some(painted),
+            label: "Remove Channel".to_string(),
+        };
+
+        command.execute(&mut world);
+        assert_eq!(
+            world
+                .get::<jackdaw_scene_types::Terrain>(entity)
+                .expect("terrain")
+                .channels
+                .len(),
+            1,
+            "the descriptor is gone after execute",
+        );
+
+        command.undo(&mut world);
+        let restored = world
+            .get::<jackdaw_scene_types::Terrain>(entity)
+            .expect("terrain");
+        assert_eq!(restored.channels.len(), 2);
+        assert_eq!(restored.channels[1].name, "walkable");
+
+        let data = world
+            .resource::<TerrainDataStore>()
+            .get(&restored.data_path)
+            .expect("store entry still present");
+        assert_eq!(
+            data.channels[1].values,
+            vec![7, 7, 7, 7],
+            "undo must restore the painted values, not mint zeros",
+        );
+    }
 }
 
 /// Make a channel the one the brush writes and the viewport tints.

--- a/src/terrain/channel_ops.rs
+++ b/src/terrain/channel_ops.rs
@@ -40,6 +40,51 @@ fn seed_color(index: usize) -> Color {
     SEED_COLORS[index % SEED_COLORS.len()].into()
 }
 
+/// Mint a channel name unique against `existing`, first free `channel-N`.
+///
+/// Naming by `existing.len()` alone collides once a channel has been
+/// removed from the middle: add, add, remove index 0, add would mint
+/// `channel-1` twice. Exact-duplicate channel names collapse to one
+/// exported file (`export.rs`'s writer is last-wins), so uniqueness has
+/// to be enforced here at creation, not just caught at export time.
+fn mint_channel_name(existing: &[TerrainChannel]) -> String {
+    for n in 0.. {
+        let candidate = format!("channel-{n}");
+        if !existing.iter().any(|channel| channel.name == candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("the candidate space is unbounded")
+}
+
+#[cfg(test)]
+mod mint_channel_name_tests {
+    use super::*;
+
+    fn channel(name: &str) -> TerrainChannel {
+        TerrainChannel {
+            name: name.to_string(),
+            element: TerrainChannelElement::U8,
+            palette: vec![],
+        }
+    }
+
+    /// C3 pinning test, the exact scenario from the review finding: add,
+    /// add, remove index 0, add must not mint the same name twice.
+    #[test]
+    fn does_not_repeat_after_a_remove_from_the_middle() {
+        let mut channels = vec![channel("channel-0"), channel("channel-1")];
+        channels.remove(0);
+        let minted = mint_channel_name(&channels);
+        assert_ne!(minted, "channel-1", "must not mint a name already in use");
+    }
+
+    #[test]
+    fn starts_at_zero_for_an_empty_terrain() {
+        assert_eq!(mint_channel_name(&[]), "channel-0");
+    }
+}
+
 /// Push the terrain's channel table back into the scene document and
 /// force a mesh rebuild, so a table edit is both saved and visible.
 fn commit_channels(world: &mut World, entity: Entity) {
@@ -79,8 +124,9 @@ pub(crate) fn terrain_channel_add(
     let mut terrain = terrains.get_mut(entity)?;
 
     let index = terrain.channels.len();
+    let name = mint_channel_name(&terrain.channels);
     terrain.channels.push(TerrainChannel {
-        name: format!("channel-{index}"),
+        name,
         element: TerrainChannelElement::U8,
         // A channel is born with an "unset" entry plus one paintable
         // value, so the user can paint something immediately instead of

--- a/src/terrain/export.rs
+++ b/src/terrain/export.rs
@@ -187,7 +187,10 @@ pub fn build_export(input: &ExportInput) -> Result<Vec<ExportedFile>, ExportErro
         // step from the actual min..max of the heights being exported
         // instead, so the pixel range always fits by construction.
         None => {
-            let min = snapped_heights.iter().copied().fold(f32::INFINITY, f32::min);
+            let min = snapped_heights
+                .iter()
+                .copied()
+                .fold(f32::INFINITY, f32::min);
             let max = snapped_heights
                 .iter()
                 .copied()

--- a/src/terrain/export.rs
+++ b/src/terrain/export.rs
@@ -180,8 +180,25 @@ pub fn build_export(input: &ExportInput) -> Result<Vec<ExportedFile>, ExportErro
             jackdaw_terrain::quantize_heights(&mut snapped_heights, elevation_step);
             elevation_step
         }
-        None if input.max_height > 0.0 => input.max_height / 65535.0,
-        None => 1.0,
+        // `max_height` is a configured ceiling, not necessarily the
+        // actual authored span: sculpted heights can run below zero or
+        // above it, and a step sized off `max_height` alone then
+        // overflows the u16 pixel range for that real span. Derive the
+        // step from the actual min..max of the heights being exported
+        // instead, so the pixel range always fits by construction.
+        None => {
+            let min = snapped_heights.iter().copied().fold(f32::INFINITY, f32::min);
+            let max = snapped_heights
+                .iter()
+                .copied()
+                .fold(f32::NEG_INFINITY, f32::max);
+            let span = if min.is_finite() && max.is_finite() {
+                max - min
+            } else {
+                0.0
+            };
+            if span > 0.0 { span / 65535.0 } else { 1.0 }
+        }
     };
 
     let min_height = snapped_heights

--- a/src/terrain/export.rs
+++ b/src/terrain/export.rs
@@ -257,7 +257,14 @@ pub fn build_export(input: &ExportInput) -> Result<Vec<ExportedFile>, ExportErro
                 encode_png_u16(input.resolution, input.resolution, &channel.values)?
             }
             ExportChannelElement::U8 => {
-                let values8: Vec<u8> = channel.values.iter().map(|&v| v as u8).collect();
+                // Saturate rather than wrap, matching sidecar.rs's own
+                // U8 encode: a value of 256 truncating to 0 would be a
+                // silently wrong palette index, not just a clipped one.
+                let values8: Vec<u8> = channel
+                    .values
+                    .iter()
+                    .map(|&v| v.min(u16::from(u8::MAX)) as u8)
+                    .collect();
                 encode_png_u8(input.resolution, input.resolution, &values8)?
             }
         };

--- a/src/terrain/export.rs
+++ b/src/terrain/export.rs
@@ -120,6 +120,7 @@ pub enum ExportError {
         derived: f32,
     },
     ChannelNameCollision(String, String),
+    DuplicateChannelName(String),
     Encode(String),
 }
 
@@ -143,6 +144,11 @@ impl std::fmt::Display for ExportError {
             Self::ChannelNameCollision(a, b) => write!(
                 f,
                 "channel names {a:?} and {b:?} both sanitize to the same export filename"
+            ),
+            Self::DuplicateChannelName(name) => write!(
+                f,
+                "channel name {name:?} is used by more than one channel; \
+                 rename one before exporting"
             ),
             Self::Encode(message) => write!(f, "{message}"),
         }
@@ -214,15 +220,19 @@ pub fn build_export(input: &ExportInput) -> Result<Vec<ExportedFile>, ExportErro
     for channel in &ordered_channels {
         let filename = sanitize_channel_filename(&channel.name);
         if let Some((_, owner)) = filename_owners.iter().find(|(f, _)| *f == filename) {
-            if owner != &channel.name {
-                return Err(ExportError::ChannelNameCollision(
-                    owner.clone(),
-                    channel.name.clone(),
-                ));
+            if owner == &channel.name {
+                // Two channels with the exact same name: not a filename
+                // collision between distinct names, but two distinct
+                // channels racing for one output file. Last-wins in the
+                // writer would silently drop one.
+                return Err(ExportError::DuplicateChannelName(channel.name.clone()));
             }
-        } else {
-            filename_owners.push((filename.clone(), channel.name.clone()));
+            return Err(ExportError::ChannelNameCollision(
+                owner.clone(),
+                channel.name.clone(),
+            ));
         }
+        filename_owners.push((filename.clone(), channel.name.clone()));
 
         let relative_path = format!("channels/{filename}.png");
         let bytes = match channel.element {

--- a/src/terrain/export.rs
+++ b/src/terrain/export.rs
@@ -22,7 +22,7 @@ use bevy::app::App;
 use bevy::ecs::query::{With, Without};
 use bevy::ecs::reflect::{AppTypeRegistry, ReflectComponent};
 use bevy::ecs::world::World;
-use bevy::prelude::{MinimalPlugins, Name, Transform};
+use bevy::prelude::{GlobalTransform, MinimalPlugins, Name, Transform};
 use bevy::reflect::TypePath;
 use bevy::reflect::serde::TypedReflectSerializer;
 use image::{ImageBuffer, Luma};
@@ -92,7 +92,7 @@ pub struct ExportInput<'a> {
     /// `(size.x, size.y)` -- world-space XZ extent.
     pub size: (f32, f32),
     /// World-space XZ position of heightmap sample `(0, 0)` -- the terrain
-    /// entity's own `Transform.translation` minus half `size`, since the
+    /// entity's computed world translation minus half `size`, since the
     /// mesh is built terrain-LOCAL (`world_x = gx * cell.x - half_size.x`,
     /// `jackdaw_terrain::mesh`) and jackdaw terrains are entity-centred. An
     /// importer that places sample `(0, 0)` at its own coordinate-system
@@ -476,6 +476,11 @@ struct PlacementEntry {
 
 /// `jd export-terrain <scene.bsn> --out <dir> [--cell-size <m>] \
 /// [--elevation-step <m>] [--raw-heights]`
+#[expect(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "CLI results are written to stdout and errors to stderr"
+)]
 pub fn run_export_terrain_cli(args: &[String]) -> ExitCode {
     match run(args) {
         Ok(summary) => {
@@ -511,17 +516,8 @@ fn run(args: &[String]) -> Result<String, String> {
     let scene_text = std::fs::read_to_string(&scene_path)
         .map_err(|e| format!("{}: {e}", scene_path.display()))?;
 
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.add_plugins(bevy::transform::TransformPlugin);
-    app.add_plugins(bevy::asset::AssetPlugin::default());
-    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
-    app.add_plugins(jackdaw_runtime::JackdawPlugin);
-    app.register_type::<Name>();
-    app.register_type::<Transform>();
-
-    jackdaw_bsn::load_bsn_scene(app.world_mut(), &scene_text)
-        .map_err(|e| format!("{}: {e}", scene_path.display()))?;
+    let mut app = load_export_app(&scene_text)
+        .map_err(|error| format!("{}: {error}", scene_path.display()))?;
 
     let world = app.world_mut();
     let terrain_entity = world
@@ -533,21 +529,7 @@ fn run(args: &[String]) -> Result<String, String> {
         .get::<Terrain>(terrain_entity)
         .expect("queried entity carries Terrain")
         .clone();
-    // Placements and the terrain entity itself both carry local `Transform`
-    // only (no `app.update()` runs here to propagate `GlobalTransform`), so
-    // this reads the same space `collect_placements` below reads -- terrain
-    // origin and placement translations stay comparable. See
-    // `jackdaw_terrain::mesh`: the mesh is built terrain-LOCAL
-    // (`world_x = gx * cell.x - half_size.x`), so sample `(0, 0)` sits at
-    // this entity's translation minus half `size`.
-    let terrain_translation = world
-        .get::<Transform>(terrain_entity)
-        .map(|t| t.translation)
-        .unwrap_or(bevy::prelude::Vec3::ZERO);
-    let terrain_origin_m = [
-        terrain_translation.x - terrain.size.x / 2.0,
-        terrain_translation.z - terrain.size.y / 2.0,
-    ];
+    let terrain_origin_m = terrain_origin_for(world, terrain_entity, &terrain)?;
 
     let (quantization, quantization_source) =
         resolve_quantization(&terrain, cell_size_flag, elevation_step_flag)?;
@@ -635,6 +617,23 @@ fn run(args: &[String]) -> Result<String, String> {
     ))
 }
 
+/// Load a scene into the same headless app the CLI uses and bring derived
+/// transforms up to date before any export query reads them.
+fn load_export_app(scene_text: &str) -> Result<App, String> {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(bevy::asset::AssetPlugin::default());
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.add_plugins(jackdaw_runtime::JackdawPlugin);
+    app.register_type::<Name>();
+    app.register_type::<Transform>();
+
+    jackdaw_bsn::load_bsn_scene(app.world_mut(), scene_text).map_err(|error| error.to_string())?;
+    app.update();
+    Ok(app)
+}
+
 /// Where a completed export's quantization setting came from, for the
 /// CLI's stdout report.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -682,7 +681,8 @@ fn parse_f32_flag(args: &[String], name: &str) -> Result<Option<f32>, String> {
 
 /// Resolve the export's quantization and where it came from.
 ///
-/// Precedence: the terrain's own authored [`TerrainQuantization`] wins when
+/// Precedence: the terrain's own authored
+/// [`TerrainQuantization`](jackdaw_scene_types::TerrainQuantization) wins when
 /// it is actually turned on (`enabled` and both `cell_size` and
 /// `height_step` positive) -- that is the project's durable setting, not a
 /// one-off export choice. `--cell-size`/`--elevation-step` are the fallback
@@ -737,86 +737,13 @@ fn resolve_quantization(
     }
 }
 
-#[cfg(test)]
-mod resolve_quantization_tests {
-    use super::*;
-
-    fn terrain_with_quantization(enabled: bool, cell_size: f32, height_step: f32) -> Terrain {
-        Terrain {
-            quantization: jackdaw_scene_types::TerrainQuantization {
-                enabled,
-                cell_size,
-                height_step,
-            },
-            ..Terrain::default()
-        }
-    }
-
-    #[test]
-    fn terrain_quantization_wins_when_enabled() {
-        let terrain = terrain_with_quantization(true, 1.0, 0.25);
-        let (quantization, source) = resolve_quantization(&terrain, None, None).unwrap();
-        assert_eq!(quantization, Some((1.0, 0.25)));
-        assert_eq!(source, QuantizationSource::Terrain);
-    }
-
-    #[test]
-    fn flags_are_used_when_terrain_quantization_is_off() {
-        let terrain = Terrain::default();
-        let (quantization, source) = resolve_quantization(&terrain, Some(2.0), Some(0.5)).unwrap();
-        assert_eq!(quantization, Some((2.0, 0.5)));
-        assert_eq!(source, QuantizationSource::Flags);
-    }
-
-    #[test]
-    fn neither_terrain_nor_flags_is_unquantized() {
-        let terrain = Terrain::default();
-        let (quantization, source) = resolve_quantization(&terrain, None, None).unwrap();
-        assert_eq!(quantization, None);
-        assert_eq!(source, QuantizationSource::None);
-    }
-
-    #[test]
-    fn agreeing_terrain_and_flags_are_accepted_as_terrain_sourced() {
-        let terrain = terrain_with_quantization(true, 1.0, 0.25);
-        let (quantization, source) = resolve_quantization(&terrain, Some(1.0), Some(0.25)).unwrap();
-        assert_eq!(quantization, Some((1.0, 0.25)));
-        assert_eq!(source, QuantizationSource::Terrain);
-    }
-
-    #[test]
-    fn disagreeing_terrain_and_flags_are_refused_naming_both() {
-        let terrain = terrain_with_quantization(true, 1.0, 0.25);
-        let error = resolve_quantization(&terrain, Some(2.0), Some(0.25)).unwrap_err();
-        assert!(error.contains("1"), "names the terrain value: {error}");
-        assert!(error.contains("2"), "names the flag value: {error}");
-    }
-
-    #[test]
-    fn one_flag_without_the_other_is_rejected() {
-        let terrain = Terrain::default();
-        let error = resolve_quantization(&terrain, Some(1.0), None).unwrap_err();
-        assert!(error.contains("together"));
-    }
-
-    #[test]
-    fn terrain_quantization_disabled_falls_through_to_flags_even_with_stale_values() {
-        // `enabled: false` with nonzero leftover fields must not leak
-        // through -- disabling quantization has to mean "off", not "off
-        // unless someone forgot to zero the numbers".
-        let terrain = terrain_with_quantization(false, 1.0, 0.25);
-        let (quantization, source) = resolve_quantization(&terrain, Some(3.0), Some(0.75)).unwrap();
-        assert_eq!(quantization, Some((3.0, 0.75)));
-        assert_eq!(source, QuantizationSource::Flags);
-    }
-}
-
 fn load_terrain_data(
     terrain: &Terrain,
     scene_dir: &Path,
 ) -> Result<jackdaw_terrain::TerrainData, String> {
     if !terrain.data_path.is_empty() {
-        let sidecar_path = scene_dir.join(&terrain.data_path);
+        let sidecar_path = jackdaw_terrain::sidecar::resolve_path(scene_dir, &terrain.data_path)
+            .map_err(|err| format!("invalid terrain data path {:?}: {err}", terrain.data_path))?;
         match std::fs::read(&sidecar_path) {
             Ok(bytes) => {
                 let mut data = jackdaw_terrain::sidecar::decode(&bytes)
@@ -853,6 +780,61 @@ fn color_to_hex(color: bevy::color::Color) -> String {
     format!("#{r:02x}{g:02x}{b:02x}")
 }
 
+/// The transform an exported entity occupies in scene space.
+///
+/// Runtime scene loading computes `GlobalTransform` parent-first. A local
+/// fallback keeps isolated worlds and older hand-built fixtures usable.
+fn transform_for_export(local: Transform, global: Option<&GlobalTransform>) -> Transform {
+    global
+        .map(GlobalTransform::compute_transform)
+        .unwrap_or(local)
+}
+
+fn resolved_transform(world: &World, entity: bevy::ecs::entity::Entity) -> Transform {
+    transform_for_export(
+        world.get::<Transform>(entity).copied().unwrap_or_default(),
+        world.get::<GlobalTransform>(entity),
+    )
+}
+
+/// World-space XZ origin for heightmap sample `(0, 0)`.
+///
+/// The export contract is an axis-aligned heightfield and carries no terrain
+/// orientation or scale basis. Reject transforms that cannot be represented
+/// instead of emitting coordinates that only appear valid.
+fn terrain_origin_for(
+    world: &World,
+    entity: bevy::ecs::entity::Entity,
+    terrain: &Terrain,
+) -> Result<[f32; 2], String> {
+    const EPSILON: f32 = 1e-5;
+
+    let transform = resolved_transform(world, entity);
+    let identity_alignment = transform.rotation.dot(bevy::math::Quat::IDENTITY).abs();
+    if 1.0 - identity_alignment > EPSILON {
+        return Err(
+            "terrain export cannot represent terrain rotation; apply the rotation before export"
+                .to_string(),
+        );
+    }
+    if transform
+        .scale
+        .to_array()
+        .into_iter()
+        .any(|axis| (axis - 1.0).abs() > EPSILON)
+    {
+        return Err(
+            "terrain export cannot represent terrain scale; apply the scale before export"
+                .to_string(),
+        );
+    }
+
+    Ok([
+        transform.translation.x - terrain.size.x / 2.0,
+        transform.translation.z - terrain.size.y / 2.0,
+    ])
+}
+
 fn collect_placements(
     world: &mut World,
     terrain_entity: bevy::ecs::entity::Entity,
@@ -860,6 +842,7 @@ fn collect_placements(
     let excluded = [
         Terrain::type_path(),
         Transform::type_path(),
+        GlobalTransform::type_path(),
         Name::type_path(),
         GltfSource::type_path(),
     ];
@@ -867,11 +850,14 @@ fn collect_placements(
     let registry = world.resource::<AppTypeRegistry>().clone();
     let reg = registry.read();
 
-    let mut query =
-        world.query_filtered::<(bevy::ecs::entity::Entity, &Transform), Without<Terrain>>();
+    let mut query = world.query_filtered::<(
+        bevy::ecs::entity::Entity,
+        &Transform,
+        Option<&GlobalTransform>,
+    ), Without<Terrain>>();
     let entities: Vec<(bevy::ecs::entity::Entity, Transform)> = query
         .iter(world)
-        .map(|(entity, transform)| (entity, *transform))
+        .map(|(entity, local, global)| (entity, transform_for_export(*local, global)))
         .collect();
 
     let components = world.components();
@@ -926,4 +912,248 @@ fn collect_placements(
         });
     }
     placements
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::prelude::*;
+
+    use super::*;
+
+    fn terrain_with_quantization(enabled: bool, cell_size: f32, height_step: f32) -> Terrain {
+        Terrain {
+            quantization: jackdaw_scene_types::TerrainQuantization {
+                enabled,
+                cell_size,
+                height_step,
+            },
+            ..Terrain::default()
+        }
+    }
+
+    #[test]
+    fn terrain_quantization_wins_when_enabled() {
+        let terrain = terrain_with_quantization(true, 1.0, 0.25);
+        let (quantization, source) = resolve_quantization(&terrain, None, None).unwrap();
+        assert_eq!(quantization, Some((1.0, 0.25)));
+        assert_eq!(source, QuantizationSource::Terrain);
+    }
+
+    #[test]
+    fn flags_are_used_when_terrain_quantization_is_off() {
+        let terrain = Terrain::default();
+        let (quantization, source) = resolve_quantization(&terrain, Some(2.0), Some(0.5)).unwrap();
+        assert_eq!(quantization, Some((2.0, 0.5)));
+        assert_eq!(source, QuantizationSource::Flags);
+    }
+
+    #[test]
+    fn neither_terrain_nor_flags_is_unquantized() {
+        let terrain = Terrain::default();
+        let (quantization, source) = resolve_quantization(&terrain, None, None).unwrap();
+        assert_eq!(quantization, None);
+        assert_eq!(source, QuantizationSource::None);
+    }
+
+    #[test]
+    fn agreeing_terrain_and_flags_are_accepted_as_terrain_sourced() {
+        let terrain = terrain_with_quantization(true, 1.0, 0.25);
+        let (quantization, source) = resolve_quantization(&terrain, Some(1.0), Some(0.25)).unwrap();
+        assert_eq!(quantization, Some((1.0, 0.25)));
+        assert_eq!(source, QuantizationSource::Terrain);
+    }
+
+    #[test]
+    fn disagreeing_terrain_and_flags_are_refused_naming_both() {
+        let terrain = terrain_with_quantization(true, 1.0, 0.25);
+        let error = resolve_quantization(&terrain, Some(2.0), Some(0.25)).unwrap_err();
+        assert!(error.contains('1'), "names the terrain value: {error}");
+        assert!(error.contains('2'), "names the flag value: {error}");
+    }
+
+    #[test]
+    fn one_flag_without_the_other_is_rejected() {
+        let terrain = Terrain::default();
+        let error = resolve_quantization(&terrain, Some(1.0), None).unwrap_err();
+        assert!(error.contains("together"));
+    }
+
+    #[test]
+    fn terrain_quantization_disabled_falls_through_to_flags_even_with_stale_values() {
+        // `enabled: false` with nonzero leftover fields must not leak
+        // through -- disabling quantization has to mean "off", not "off
+        // unless someone forgot to zero the numbers".
+        let terrain = terrain_with_quantization(false, 1.0, 0.25);
+        let (quantization, source) = resolve_quantization(&terrain, Some(3.0), Some(0.75)).unwrap();
+        assert_eq!(quantization, Some((3.0, 0.75)));
+        assert_eq!(source, QuantizationSource::Flags);
+    }
+
+    fn assert_array_close(actual: [f32; 3], expected: [f32; 3]) {
+        for (actual, expected) in actual.into_iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-5, "{actual} != {expected}");
+        }
+    }
+
+    #[test]
+    fn placements_export_the_propagated_world_transform() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, bevy::transform::TransformPlugin));
+        app.init_resource::<AppTypeRegistry>();
+        app.register_type::<Name>();
+        app.register_type::<Transform>();
+        app.register_type::<GlobalTransform>();
+
+        let parent = app
+            .world_mut()
+            .spawn((
+                Transform {
+                    translation: Vec3::new(10.0, 0.0, -2.0),
+                    rotation: Quat::from_rotation_y(std::f32::consts::FRAC_PI_2),
+                    scale: Vec3::splat(2.0),
+                },
+                GlobalTransform::default(),
+            ))
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                Name::new("child"),
+                Transform {
+                    translation: Vec3::new(1.0, 2.0, 3.0),
+                    rotation: Quat::from_rotation_y(0.25),
+                    scale: Vec3::splat(0.5),
+                },
+                GlobalTransform::default(),
+                ChildOf(parent),
+            ))
+            .id();
+        let terrain_entity = app.world_mut().spawn(Terrain::default()).id();
+
+        app.update();
+        let expected = app
+            .world()
+            .get::<GlobalTransform>(child)
+            .expect("transform propagated")
+            .compute_transform();
+        let placements = collect_placements(app.world_mut(), terrain_entity);
+        let placement = placements
+            .iter()
+            .find(|placement| placement.name == "child")
+            .expect("child exported");
+
+        assert_array_close(placement.translation, expected.translation.to_array());
+        assert_array_close(placement.scale, expected.scale.to_array());
+        for (actual, expected) in placement
+            .rotation
+            .into_iter()
+            .zip(expected.rotation.to_array())
+        {
+            assert!((actual - expected).abs() < 1e-5, "{actual} != {expected}");
+        }
+        assert!(
+            placement
+                .components
+                .keys()
+                .all(|name| !name.contains("GlobalTransform")),
+            "runtime world transform must not be exported as metadata",
+        );
+    }
+
+    #[test]
+    fn terrain_origin_uses_world_translation_and_rejects_unrepresentable_transforms() {
+        let mut world = World::new();
+        let entity = world
+            .spawn((
+                Transform::from_xyz(1.0, 0.0, 2.0),
+                GlobalTransform::from(Transform::from_xyz(11.0, 4.0, -7.0)),
+            ))
+            .id();
+        let terrain = Terrain {
+            size: Vec2::new(4.0, 6.0),
+            ..default()
+        };
+
+        assert_eq!(
+            terrain_origin_for(&world, entity, &terrain),
+            Ok([9.0, -10.0])
+        );
+
+        world
+            .entity_mut(entity)
+            .insert(GlobalTransform::from(Transform {
+                translation: Vec3::new(11.0, 4.0, -7.0),
+                rotation: Quat::from_rotation_y(0.25),
+                ..default()
+            }));
+        assert!(
+            terrain_origin_for(&world, entity, &terrain)
+                .unwrap_err()
+                .contains("rotation")
+        );
+
+        world
+            .entity_mut(entity)
+            .insert(GlobalTransform::from(Transform {
+                translation: Vec3::new(11.0, 4.0, -7.0),
+                scale: Vec3::new(2.0, 1.0, 1.0),
+                ..default()
+            }));
+        assert!(
+            terrain_origin_for(&world, entity, &terrain)
+                .unwrap_err()
+                .contains("scale")
+        );
+    }
+
+    #[test]
+    fn loaded_scene_propagates_parent_rotation_before_export_reads_transforms() {
+        let mut source = App::new();
+        source
+            .register_type::<Name>()
+            .register_type::<Transform>()
+            .register_type::<ChildOf>()
+            .register_type::<Children>()
+            .register_type::<Terrain>();
+
+        let parent = source
+            .world_mut()
+            .spawn((
+                Name::new("parent"),
+                Transform::from_rotation(Quat::from_rotation_y(0.25)),
+            ))
+            .id();
+        source.world_mut().spawn((
+            Name::new("terrain"),
+            Transform::from_xyz(3.0, 0.0, 5.0),
+            Terrain::default(),
+            ChildOf(parent),
+        ));
+        let scene = jackdaw_bsn::serialize_to_bsn(source.world());
+
+        let loaded = load_export_app(&scene).expect("scene reloads through the export shell");
+        let world = loaded.world();
+        let terrain_entity = world
+            .iter_entities()
+            .find(bevy::prelude::EntityRef::contains::<Terrain>)
+            .expect("terrain reloads")
+            .id();
+        let terrain = world
+            .get::<Terrain>(terrain_entity)
+            .expect("queried entity carries Terrain");
+
+        assert!(
+            terrain_origin_for(world, terrain_entity, terrain)
+                .unwrap_err()
+                .contains("rotation"),
+            "the inherited rotation must be propagated before export",
+        );
+    }
+
+    #[test]
+    fn a_missing_global_transform_falls_back_to_local_space() {
+        let local = Transform::from_xyz(3.0, 4.0, 5.0);
+
+        assert_eq!(transform_for_export(local, None), local);
+    }
 }

--- a/src/terrain/export.rs
+++ b/src/terrain/export.rs
@@ -1,0 +1,929 @@
+//! Headless CLI export: a `.bsn` scene's `Terrain` component and sidecar
+//! data become a directory of PNG heightmaps/channels plus a JSON manifest
+//! and a placements list, for an importer in another repo to consume.
+//!
+//! Split in two, per the usual shape: [`build_export`] is a pure function
+//! over plain data (no scene, no `World`), so its byte-for-byte output can
+//! be tested without a `.bsn` fixture. [`run_export_terrain_cli`] is the
+//! thin shell that loads a scene headless, reads its terrain sidecar, and
+//! writes what [`build_export`] returns to disk.
+//!
+//! The output layout is a cross-repo CONTRACT (an importer is being built
+//! against it in another repo at the same time): field names, key order,
+//! sort order, and PNG pixel convention here must not drift without
+//! updating that contract.
+
+use std::cmp::Ordering;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use bevy::app::App;
+use bevy::ecs::query::{With, Without};
+use bevy::ecs::reflect::{AppTypeRegistry, ReflectComponent};
+use bevy::ecs::world::World;
+use bevy::prelude::{MinimalPlugins, Name, Transform};
+use bevy::reflect::TypePath;
+use bevy::reflect::serde::TypedReflectSerializer;
+use image::{ImageBuffer, Luma};
+use serde::Serialize;
+
+use jackdaw_scene_types::{GltfSource, Terrain, TerrainChannelElement};
+
+// --- Pure core: plain data in, file bytes out ---
+
+/// Storage width of one exported channel's pixels.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportChannelElement {
+    U8,
+    U16,
+}
+
+impl ExportChannelElement {
+    fn bit_depth(self) -> u8 {
+        match self {
+            Self::U8 => 8,
+            Self::U16 => 16,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExportPaletteEntry {
+    pub value: u16,
+    pub label: String,
+    /// Lowercase `#rrggbb`.
+    pub color_hex: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExportChannel {
+    pub name: String,
+    pub element: ExportChannelElement,
+    /// Row-major (z-major), `resolution^2` long, raw stored values.
+    pub values: Vec<u16>,
+    pub palette: Vec<ExportPaletteEntry>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExportPlacement {
+    pub name: String,
+    pub asset: Option<String>,
+    pub translation: [f32; 3],
+    /// `[x, y, z, w]`.
+    pub rotation: [f32; 4],
+    pub scale: [f32; 3],
+    /// Keyed by short type path. Values are already reflect-serialized JSON.
+    pub components: serde_json::Map<String, serde_json::Value>,
+}
+
+pub struct ExportInput<'a> {
+    pub resolution: u32,
+    /// Row-major (z-major), `resolution^2` long.
+    pub heights: &'a [f32],
+    pub channels: &'a [ExportChannel],
+    /// `(size.x, size.y)` -- world-space XZ extent.
+    pub size: (f32, f32),
+    /// World-space XZ position of heightmap sample `(0, 0)` -- the terrain
+    /// entity's own `Transform.translation` minus half `size`, since the
+    /// mesh is built terrain-LOCAL (`world_x = gx * cell.x - half_size.x`,
+    /// `jackdaw_terrain::mesh`) and jackdaw terrains are entity-centred. An
+    /// importer that places sample `(0, 0)` at its own coordinate-system
+    /// origin needs this offset to land placements on the cells they were
+    /// actually authored over, rather than wherever "translation minus
+    /// nothing" happens to fall.
+    pub terrain_origin_m: [f32; 2],
+    pub max_height: f32,
+    /// `Some((cell_size_m, elevation_step_m))` for a quantized export.
+    pub quantization: Option<(f32, f32)>,
+    pub source_scene: &'a str,
+    pub placements: &'a [ExportPlacement],
+    pub raw_heights: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExportError {
+    HeightOutOfRange {
+        height: f32,
+        value: f64,
+    },
+    CellSizeMismatch {
+        axis: &'static str,
+        declared: f32,
+        derived: f32,
+    },
+    ChannelNameCollision(String, String),
+    Encode(String),
+}
+
+impl std::fmt::Display for ExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HeightOutOfRange { height, value } => write!(
+                f,
+                "height {height} quantizes to {value}, outside the representable 0..=65535 \
+                 pixel range"
+            ),
+            Self::CellSizeMismatch {
+                axis,
+                declared,
+                derived,
+            } => write!(
+                f,
+                "declared cell size {declared} does not match {axis} / (resolution - 1) = \
+                 {derived}"
+            ),
+            Self::ChannelNameCollision(a, b) => write!(
+                f,
+                "channel names {a:?} and {b:?} both sanitize to the same export filename"
+            ),
+            Self::Encode(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for ExportError {}
+
+/// One exported file, path relative to the export's `--out` directory.
+#[derive(Debug)]
+pub struct ExportedFile {
+    pub relative_path: PathBuf,
+    pub bytes: Vec<u8>,
+}
+
+/// Build every file a terrain export produces, from plain in-memory data.
+///
+/// Pure: no filesystem, no `World`. Deterministic: the same input always
+/// produces byte-identical output (every collection that feeds an output
+/// file is sorted before it is written).
+pub fn build_export(input: &ExportInput) -> Result<Vec<ExportedFile>, ExportError> {
+    if let Some((cell_size, _)) = input.quantization {
+        validate_cell_size(input.size, input.resolution, cell_size)?;
+    }
+
+    let mut snapped_heights = input.heights.to_vec();
+    let step_m = match input.quantization {
+        Some((_, elevation_step)) => {
+            jackdaw_terrain::quantize_heights(&mut snapped_heights, elevation_step);
+            elevation_step
+        }
+        None if input.max_height > 0.0 => input.max_height / 65535.0,
+        None => 1.0,
+    };
+
+    let min_height = snapped_heights
+        .iter()
+        .copied()
+        .fold(f32::INFINITY, f32::min);
+    let min_height = if min_height.is_finite() {
+        min_height
+    } else {
+        0.0
+    };
+    let base_m = (min_height / step_m).floor() * step_m;
+
+    let mut height_pixels = Vec::with_capacity(snapped_heights.len());
+    for &h in &snapped_heights {
+        let raw = (f64::from(h) - f64::from(base_m)) / f64::from(step_m);
+        let value = raw.round();
+        if !(0.0..=65535.0).contains(&value) {
+            return Err(ExportError::HeightOutOfRange { height: h, value });
+        }
+        height_pixels.push(value as u16);
+    }
+    let heightmap_bytes = encode_png_u16(input.resolution, input.resolution, &height_pixels)?;
+
+    let mut files = Vec::new();
+    files.push(ExportedFile {
+        relative_path: PathBuf::from("heightmap.png"),
+        bytes: heightmap_bytes,
+    });
+
+    let mut ordered_channels: Vec<&ExportChannel> = input.channels.iter().collect();
+    ordered_channels.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut filename_owners: Vec<(String, String)> = Vec::new();
+    let mut manifest_channels = Vec::with_capacity(ordered_channels.len());
+    for channel in &ordered_channels {
+        let filename = sanitize_channel_filename(&channel.name);
+        if let Some((_, owner)) = filename_owners.iter().find(|(f, _)| *f == filename) {
+            if owner != &channel.name {
+                return Err(ExportError::ChannelNameCollision(
+                    owner.clone(),
+                    channel.name.clone(),
+                ));
+            }
+        } else {
+            filename_owners.push((filename.clone(), channel.name.clone()));
+        }
+
+        let relative_path = format!("channels/{filename}.png");
+        let bytes = match channel.element {
+            ExportChannelElement::U16 => {
+                encode_png_u16(input.resolution, input.resolution, &channel.values)?
+            }
+            ExportChannelElement::U8 => {
+                let values8: Vec<u8> = channel.values.iter().map(|&v| v as u8).collect();
+                encode_png_u8(input.resolution, input.resolution, &values8)?
+            }
+        };
+        files.push(ExportedFile {
+            relative_path: PathBuf::from(&relative_path),
+            bytes,
+        });
+
+        let mut palette = channel.palette.clone();
+        palette.sort_by_key(|entry| entry.value);
+        manifest_channels.push(ManifestChannel {
+            name: channel.name.clone(),
+            file: relative_path,
+            bit_depth: channel.element.bit_depth(),
+            element: channel.element.label(),
+            palette: palette
+                .into_iter()
+                .map(|entry| ManifestPaletteEntry {
+                    value: entry.value,
+                    label: entry.label,
+                    color: entry.color_hex,
+                })
+                .collect(),
+        });
+    }
+
+    let manifest = Manifest {
+        format: "jackdaw-terrain-export",
+        format_version: 2,
+        source_scene: input.source_scene.to_string(),
+        terrain: ManifestTerrain {
+            resolution: input.resolution,
+            world_size_m: [input.size.0, input.size.1],
+            max_height_m: input.max_height,
+            terrain_origin_m: input.terrain_origin_m,
+        },
+        quantization: input.quantization.map(|(cell_size_m, elevation_step_m)| {
+            ManifestQuantization {
+                cell_size_m,
+                elevation_step_m,
+            }
+        }),
+        heightmap: ManifestHeightmap {
+            file: "heightmap.png",
+            bit_depth: 16,
+            encoding: "unsigned-steps-from-base",
+            base_m,
+            step_m,
+        },
+        channels: manifest_channels,
+        placements_file: "placements.json",
+    };
+    files.push(ExportedFile {
+        relative_path: PathBuf::from("manifest.json"),
+        bytes: to_json_bytes(&manifest).map_err(|e| ExportError::Encode(e.to_string()))?,
+    });
+
+    let mut ordered_placements: Vec<&ExportPlacement> = input.placements.iter().collect();
+    ordered_placements.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.asset.cmp(&b.asset))
+            .then_with(|| cmp_f32_array(&a.translation, &b.translation))
+    });
+    let placements_doc = PlacementsFile {
+        format_version: 1,
+        placements: ordered_placements
+            .into_iter()
+            .map(|p| PlacementEntry {
+                name: p.name.clone(),
+                asset: p.asset.clone(),
+                translation_m: p.translation,
+                rotation_quat: p.rotation,
+                scale: p.scale,
+                components: p.components.clone(),
+            })
+            .collect(),
+    };
+    files.push(ExportedFile {
+        relative_path: PathBuf::from("placements.json"),
+        bytes: to_json_bytes(&placements_doc).map_err(|e| ExportError::Encode(e.to_string()))?,
+    });
+
+    if input.raw_heights {
+        let mut buf = Vec::with_capacity(input.heights.len() * 4);
+        for h in input.heights {
+            buf.extend_from_slice(&h.to_le_bytes());
+        }
+        files.push(ExportedFile {
+            relative_path: PathBuf::from("heights.f32"),
+            bytes: buf,
+        });
+    }
+
+    Ok(files)
+}
+
+fn validate_cell_size(size: (f32, f32), resolution: u32, declared: f32) -> Result<(), ExportError> {
+    if resolution < 2 {
+        return Ok(());
+    }
+    let denom = (resolution - 1) as f32;
+    let derived_x = size.0 / denom;
+    let derived_y = size.1 / denom;
+    if (derived_x - declared).abs() > 1e-6 {
+        return Err(ExportError::CellSizeMismatch {
+            axis: "size.x",
+            declared,
+            derived: derived_x,
+        });
+    }
+    if (derived_y - declared).abs() > 1e-6 {
+        return Err(ExportError::CellSizeMismatch {
+            axis: "size.y",
+            declared,
+            derived: derived_y,
+        });
+    }
+    Ok(())
+}
+
+/// Any character outside `[A-Za-z0-9_-]` becomes `_`.
+fn sanitize_channel_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn cmp_f32_array(a: &[f32; 3], b: &[f32; 3]) -> Ordering {
+    for i in 0..3 {
+        let ord = a[i].total_cmp(&b[i]);
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    Ordering::Equal
+}
+
+fn encode_png_u16(width: u32, height: u32, pixels: &[u16]) -> Result<Vec<u8>, ExportError> {
+    let buffer: ImageBuffer<Luma<u16>, Vec<u16>> =
+        ImageBuffer::from_raw(width, height, pixels.to_vec())
+            .ok_or_else(|| ExportError::Encode("pixel buffer size mismatch".to_string()))?;
+    let mut out = Cursor::new(Vec::new());
+    buffer
+        .write_to(&mut out, image::ImageFormat::Png)
+        .map_err(|e| ExportError::Encode(e.to_string()))?;
+    Ok(out.into_inner())
+}
+
+fn encode_png_u8(width: u32, height: u32, pixels: &[u8]) -> Result<Vec<u8>, ExportError> {
+    let buffer: ImageBuffer<Luma<u8>, Vec<u8>> =
+        ImageBuffer::from_raw(width, height, pixels.to_vec())
+            .ok_or_else(|| ExportError::Encode("pixel buffer size mismatch".to_string()))?;
+    let mut out = Cursor::new(Vec::new());
+    buffer
+        .write_to(&mut out, image::ImageFormat::Png)
+        .map_err(|e| ExportError::Encode(e.to_string()))?;
+    Ok(out.into_inner())
+}
+
+fn to_json_bytes<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+// --- Manifest / placements document shapes (exact key order matters) ---
+
+#[derive(Serialize)]
+struct Manifest {
+    format: &'static str,
+    format_version: u32,
+    source_scene: String,
+    terrain: ManifestTerrain,
+    quantization: Option<ManifestQuantization>,
+    heightmap: ManifestHeightmap,
+    channels: Vec<ManifestChannel>,
+    placements_file: &'static str,
+}
+
+#[derive(Serialize)]
+struct ManifestTerrain {
+    resolution: u32,
+    world_size_m: [f32; 2],
+    max_height_m: f32,
+    terrain_origin_m: [f32; 2],
+}
+
+#[derive(Serialize)]
+struct ManifestQuantization {
+    cell_size_m: f32,
+    elevation_step_m: f32,
+}
+
+#[derive(Serialize)]
+struct ManifestHeightmap {
+    file: &'static str,
+    bit_depth: u8,
+    encoding: &'static str,
+    base_m: f32,
+    step_m: f32,
+}
+
+#[derive(Serialize)]
+struct ManifestChannel {
+    name: String,
+    file: String,
+    bit_depth: u8,
+    element: &'static str,
+    palette: Vec<ManifestPaletteEntry>,
+}
+
+#[derive(Serialize)]
+struct ManifestPaletteEntry {
+    value: u16,
+    label: String,
+    color: String,
+}
+
+#[derive(Serialize)]
+struct PlacementsFile {
+    format_version: u32,
+    placements: Vec<PlacementEntry>,
+}
+
+#[derive(Serialize)]
+struct PlacementEntry {
+    name: String,
+    asset: Option<String>,
+    translation_m: [f32; 3],
+    rotation_quat: [f32; 4],
+    scale: [f32; 3],
+    components: serde_json::Map<String, serde_json::Value>,
+}
+
+// --- Shell: load a scene, read its sidecar, write the export to disk ---
+
+/// `jd export-terrain <scene.bsn> --out <dir> [--cell-size <m>] \
+/// [--elevation-step <m>] [--raw-heights]`
+pub fn run_export_terrain_cli(args: &[String]) -> ExitCode {
+    match run(args) {
+        Ok(summary) => {
+            println!("{summary}");
+            ExitCode::SUCCESS
+        }
+        Err(message) => {
+            eprintln!("jd export-terrain: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(args: &[String]) -> Result<String, String> {
+    let scene_arg = first_positional(args)
+        .ok_or("usage: jd export-terrain <scene.bsn> --out <dir>")?
+        .clone();
+    let scene_path = PathBuf::from(&scene_arg);
+    if !scene_path.exists() {
+        return Err(format!(
+            "{}: scene file does not exist",
+            scene_path.display()
+        ));
+    }
+
+    let out_dir = flag_value(args, "--out")
+        .map(PathBuf::from)
+        .ok_or("--out <dir> is required")?;
+    let cell_size_flag = parse_f32_flag(args, "--cell-size")?;
+    let elevation_step_flag = parse_f32_flag(args, "--elevation-step")?;
+    let raw_heights = args.iter().any(|a| a == "--raw-heights");
+
+    let scene_text = std::fs::read_to_string(&scene_path)
+        .map_err(|e| format!("{}: {e}", scene_path.display()))?;
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(bevy::asset::AssetPlugin::default());
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.add_plugins(jackdaw_runtime::JackdawPlugin);
+    app.register_type::<Name>();
+    app.register_type::<Transform>();
+
+    jackdaw_bsn::load_bsn_scene(app.world_mut(), &scene_text)
+        .map_err(|e| format!("{}: {e}", scene_path.display()))?;
+
+    let world = app.world_mut();
+    let terrain_entity = world
+        .query_filtered::<bevy::ecs::entity::Entity, With<Terrain>>()
+        .iter(world)
+        .next()
+        .ok_or_else(|| format!("{}: scene has no Terrain component", scene_path.display()))?;
+    let terrain = world
+        .get::<Terrain>(terrain_entity)
+        .expect("queried entity carries Terrain")
+        .clone();
+    // Placements and the terrain entity itself both carry local `Transform`
+    // only (no `app.update()` runs here to propagate `GlobalTransform`), so
+    // this reads the same space `collect_placements` below reads -- terrain
+    // origin and placement translations stay comparable. See
+    // `jackdaw_terrain::mesh`: the mesh is built terrain-LOCAL
+    // (`world_x = gx * cell.x - half_size.x`), so sample `(0, 0)` sits at
+    // this entity's translation minus half `size`.
+    let terrain_translation = world
+        .get::<Transform>(terrain_entity)
+        .map(|t| t.translation)
+        .unwrap_or(bevy::prelude::Vec3::ZERO);
+    let terrain_origin_m = [
+        terrain_translation.x - terrain.size.x / 2.0,
+        terrain_translation.z - terrain.size.y / 2.0,
+    ];
+
+    let (quantization, quantization_source) =
+        resolve_quantization(&terrain, cell_size_flag, elevation_step_flag)?;
+    let quantization_report = match (quantization_source, quantization) {
+        (QuantizationSource::Terrain, Some((cell_size, step))) => {
+            format!("quantization: from terrain (cell_size {cell_size} m, step {step} m)")
+        }
+        (QuantizationSource::Flags, Some((cell_size, step))) => {
+            format!("quantization: from flags (cell_size {cell_size} m, step {step} m)")
+        }
+        _ => "quantization: none".to_string(),
+    };
+
+    let scene_dir = scene_path.parent().unwrap_or_else(|| Path::new("."));
+    let terrain_data = load_terrain_data(&terrain, scene_dir)?;
+    if terrain_data.heights.len() != terrain.cell_count() {
+        return Err(format!(
+            "{}: terrain data has {} height values, expected {} for resolution {}",
+            scene_path.display(),
+            terrain_data.heights.len(),
+            terrain.cell_count(),
+            terrain.resolution
+        ));
+    }
+
+    let channels: Vec<ExportChannel> = terrain
+        .channels
+        .iter()
+        .map(|descriptor| {
+            let values = terrain_data
+                .channels
+                .iter()
+                .find(|c| c.name == descriptor.name)
+                .map(|c| c.values.clone())
+                .unwrap_or_else(|| vec![0u16; terrain.cell_count()]);
+            ExportChannel {
+                name: descriptor.name.clone(),
+                element: match descriptor.element {
+                    TerrainChannelElement::U8 => ExportChannelElement::U8,
+                    TerrainChannelElement::U16 => ExportChannelElement::U16,
+                },
+                values,
+                palette: descriptor
+                    .palette
+                    .iter()
+                    .map(|entry| ExportPaletteEntry {
+                        value: entry.value,
+                        label: entry.label.clone(),
+                        color_hex: color_to_hex(entry.color),
+                    })
+                    .collect(),
+            }
+        })
+        .collect();
+
+    let placements = collect_placements(app.world_mut(), terrain_entity);
+
+    let input = ExportInput {
+        resolution: terrain.resolution,
+        heights: &terrain_data.heights,
+        channels: &channels,
+        size: (terrain.size.x, terrain.size.y),
+        terrain_origin_m,
+        max_height: terrain.max_height,
+        quantization,
+        source_scene: &scene_arg,
+        placements: &placements,
+        raw_heights,
+    };
+    let files = build_export(&input).map_err(|e| e.to_string())?;
+
+    std::fs::create_dir_all(&out_dir).map_err(|e| format!("{}: {e}", out_dir.display()))?;
+    for file in &files {
+        let dest = out_dir.join(&file.relative_path);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+        }
+        std::fs::write(&dest, &file.bytes).map_err(|e| format!("{}: {e}", dest.display()))?;
+    }
+
+    Ok(format!(
+        "{quantization_report}\nexported {} file(s) to {}",
+        files.len(),
+        out_dir.display()
+    ))
+}
+
+/// Where a completed export's quantization setting came from, for the
+/// CLI's stdout report.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QuantizationSource {
+    Terrain,
+    Flags,
+    None,
+}
+
+fn first_positional(args: &[String]) -> Option<&String> {
+    const VALUE_FLAGS: [&str; 3] = ["--out", "--cell-size", "--elevation-step"];
+    let mut skip_next = false;
+    for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if VALUE_FLAGS.contains(&arg.as_str()) {
+            skip_next = true;
+            continue;
+        }
+        if !arg.starts_with('-') {
+            return Some(arg);
+        }
+    }
+    None
+}
+
+fn flag_value(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn parse_f32_flag(args: &[String], name: &str) -> Result<Option<f32>, String> {
+    match flag_value(args, name) {
+        Some(raw) => raw
+            .parse::<f32>()
+            .map(Some)
+            .map_err(|_| format!("{name} expects a number, got {raw:?}")),
+        None => Ok(None),
+    }
+}
+
+/// Resolve the export's quantization and where it came from.
+///
+/// Precedence: the terrain's own authored [`TerrainQuantization`] wins when
+/// it is actually turned on (`enabled` and both `cell_size` and
+/// `height_step` positive) -- that is the project's durable setting, not a
+/// one-off export choice. `--cell-size`/`--elevation-step` are the fallback
+/// for terrains that never opted in. Giving exactly one flag is ambiguous
+/// and rejected; giving both while the terrain also declares quantization
+/// is accepted only when they agree (within the same 1e-6 tolerance the
+/// cell-size/resolution check uses) -- silently preferring one would hide
+/// a real authoring mismatch.
+fn resolve_quantization(
+    terrain: &Terrain,
+    cell_size_flag: Option<f32>,
+    elevation_step_flag: Option<f32>,
+) -> Result<(Option<(f32, f32)>, QuantizationSource), String> {
+    let terrain_quant = {
+        let q = &terrain.quantization;
+        if q.enabled
+            && q.cell_size.is_finite()
+            && q.cell_size > 0.0
+            && q.height_step.is_finite()
+            && q.height_step > 0.0
+        {
+            Some((q.cell_size, q.height_step))
+        } else {
+            None
+        }
+    };
+
+    let flags = match (cell_size_flag, elevation_step_flag) {
+        (Some(cell_size), Some(elevation_step)) => Some((cell_size, elevation_step)),
+        (None, None) => None,
+        _ => {
+            return Err(
+                "--cell-size and --elevation-step must be given together, or neither".to_string(),
+            );
+        }
+    };
+
+    match (terrain_quant, flags) {
+        (Some(t), Some(f)) => {
+            if (t.0 - f.0).abs() > 1e-6 || (t.1 - f.1).abs() > 1e-6 {
+                return Err(format!(
+                    "terrain declares quantization (cell_size {} m, elevation_step {} m) but \
+                     --cell-size/--elevation-step declare ({} m, {} m); these disagree",
+                    t.0, t.1, f.0, f.1
+                ));
+            }
+            Ok((Some(t), QuantizationSource::Terrain))
+        }
+        (Some(t), None) => Ok((Some(t), QuantizationSource::Terrain)),
+        (None, Some(f)) => Ok((Some(f), QuantizationSource::Flags)),
+        (None, None) => Ok((None, QuantizationSource::None)),
+    }
+}
+
+#[cfg(test)]
+mod resolve_quantization_tests {
+    use super::*;
+
+    fn terrain_with_quantization(enabled: bool, cell_size: f32, height_step: f32) -> Terrain {
+        Terrain {
+            quantization: jackdaw_scene_types::TerrainQuantization {
+                enabled,
+                cell_size,
+                height_step,
+            },
+            ..Terrain::default()
+        }
+    }
+
+    #[test]
+    fn terrain_quantization_wins_when_enabled() {
+        let terrain = terrain_with_quantization(true, 1.0, 0.25);
+        let (quantization, source) = resolve_quantization(&terrain, None, None).unwrap();
+        assert_eq!(quantization, Some((1.0, 0.25)));
+        assert_eq!(source, QuantizationSource::Terrain);
+    }
+
+    #[test]
+    fn flags_are_used_when_terrain_quantization_is_off() {
+        let terrain = Terrain::default();
+        let (quantization, source) = resolve_quantization(&terrain, Some(2.0), Some(0.5)).unwrap();
+        assert_eq!(quantization, Some((2.0, 0.5)));
+        assert_eq!(source, QuantizationSource::Flags);
+    }
+
+    #[test]
+    fn neither_terrain_nor_flags_is_unquantized() {
+        let terrain = Terrain::default();
+        let (quantization, source) = resolve_quantization(&terrain, None, None).unwrap();
+        assert_eq!(quantization, None);
+        assert_eq!(source, QuantizationSource::None);
+    }
+
+    #[test]
+    fn agreeing_terrain_and_flags_are_accepted_as_terrain_sourced() {
+        let terrain = terrain_with_quantization(true, 1.0, 0.25);
+        let (quantization, source) = resolve_quantization(&terrain, Some(1.0), Some(0.25)).unwrap();
+        assert_eq!(quantization, Some((1.0, 0.25)));
+        assert_eq!(source, QuantizationSource::Terrain);
+    }
+
+    #[test]
+    fn disagreeing_terrain_and_flags_are_refused_naming_both() {
+        let terrain = terrain_with_quantization(true, 1.0, 0.25);
+        let error = resolve_quantization(&terrain, Some(2.0), Some(0.25)).unwrap_err();
+        assert!(error.contains("1"), "names the terrain value: {error}");
+        assert!(error.contains("2"), "names the flag value: {error}");
+    }
+
+    #[test]
+    fn one_flag_without_the_other_is_rejected() {
+        let terrain = Terrain::default();
+        let error = resolve_quantization(&terrain, Some(1.0), None).unwrap_err();
+        assert!(error.contains("together"));
+    }
+
+    #[test]
+    fn terrain_quantization_disabled_falls_through_to_flags_even_with_stale_values() {
+        // `enabled: false` with nonzero leftover fields must not leak
+        // through -- disabling quantization has to mean "off", not "off
+        // unless someone forgot to zero the numbers".
+        let terrain = terrain_with_quantization(false, 1.0, 0.25);
+        let (quantization, source) = resolve_quantization(&terrain, Some(3.0), Some(0.75)).unwrap();
+        assert_eq!(quantization, Some((3.0, 0.75)));
+        assert_eq!(source, QuantizationSource::Flags);
+    }
+}
+
+fn load_terrain_data(
+    terrain: &Terrain,
+    scene_dir: &Path,
+) -> Result<jackdaw_terrain::TerrainData, String> {
+    if !terrain.data_path.is_empty() {
+        let sidecar_path = scene_dir.join(&terrain.data_path);
+        match std::fs::read(&sidecar_path) {
+            Ok(bytes) => {
+                let mut data = jackdaw_terrain::sidecar::decode(&bytes)
+                    .map_err(|e| format!("{}: {e}", sidecar_path.display()))?;
+                data.normalize();
+                return Ok(data);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !terrain.heights.is_empty() => {
+                // Legacy scene: no sidecar was ever written, fall through to
+                // the inline heights below.
+            }
+            Err(e) => {
+                return Err(format!(
+                    "{}: terrain sidecar unreadable: {e}",
+                    sidecar_path.display()
+                ));
+            }
+        }
+    }
+
+    if terrain.heights.is_empty() {
+        return Err("terrain has no data_path sidecar and no legacy inline heights".to_string());
+    }
+    Ok(jackdaw_terrain::TerrainData {
+        resolution: terrain.resolution,
+        heights: terrain.heights.clone(),
+        channels: Vec::new(),
+    })
+}
+
+fn color_to_hex(color: bevy::color::Color) -> String {
+    use bevy::color::ColorToPacked;
+    let [r, g, b] = color.to_srgba().to_u8_array_no_alpha();
+    format!("#{r:02x}{g:02x}{b:02x}")
+}
+
+fn collect_placements(
+    world: &mut World,
+    terrain_entity: bevy::ecs::entity::Entity,
+) -> Vec<ExportPlacement> {
+    let excluded = [
+        Terrain::type_path(),
+        Transform::type_path(),
+        Name::type_path(),
+        GltfSource::type_path(),
+    ];
+
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let reg = registry.read();
+
+    let mut query =
+        world.query_filtered::<(bevy::ecs::entity::Entity, &Transform), Without<Terrain>>();
+    let entities: Vec<(bevy::ecs::entity::Entity, Transform)> = query
+        .iter(world)
+        .map(|(entity, transform)| (entity, *transform))
+        .collect();
+
+    let components = world.components();
+    let mut placements = Vec::new();
+    for (entity, transform) in entities {
+        if entity == terrain_entity {
+            continue;
+        }
+        let name = world
+            .get::<Name>(entity)
+            .map(|n| n.as_str().to_string())
+            .unwrap_or_default();
+        let asset = world.get::<GltfSource>(entity).map(|g| g.path.clone());
+
+        let mut other_components = serde_json::Map::new();
+        if let Ok(entity_ref) = world.get_entity(entity) {
+            for component_id in entity_ref.archetype().iter_components() {
+                let Some(info) = components.get_info(component_id) else {
+                    continue;
+                };
+                let Some(type_id) = info.type_id() else {
+                    continue;
+                };
+                let Some(registration) = reg.get(type_id) else {
+                    continue;
+                };
+                let full_path = registration.type_info().type_path_table().path();
+                if excluded.contains(&full_path) {
+                    continue;
+                }
+                let Some(reflect_component) = registration.data::<ReflectComponent>() else {
+                    continue;
+                };
+                let Some(component_ref) = reflect_component.reflect(entity_ref) else {
+                    continue;
+                };
+                let serializer = TypedReflectSerializer::new(component_ref, &reg);
+                if let Ok(value) = serde_json::to_value(&serializer) {
+                    let short = registration.type_info().type_path_table().short_path();
+                    other_components.insert(short.to_string(), value);
+                }
+            }
+        }
+
+        placements.push(ExportPlacement {
+            name,
+            asset,
+            translation: transform.translation.to_array(),
+            rotation: transform.rotation.to_array(),
+            scale: transform.scale.to_array(),
+            components: other_components,
+        });
+    }
+    placements
+}

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -420,7 +420,10 @@ fn update_terrain_inspector(
         ));
         commands
             .spawn((
-                combobox::combobox_with_selected(noise_options, gen_state.settings.noise_type.index()),
+                combobox::combobox_with_selected(
+                    noise_options,
+                    gen_state.settings.noise_type.index(),
+                ),
                 ChildOf(noise_row),
             ))
             .observe(
@@ -843,9 +846,7 @@ pub(super) fn spawn_tile(
     commands
         .entity(tile)
         .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-            let mut call = commands
-                .operator(op_id)
-                .settings(tile_dispatch_settings());
+            let mut call = commands.operator(op_id).settings(tile_dispatch_settings());
             if let Some(index) = index {
                 call = call.param("index", index as i64);
             }
@@ -1172,7 +1173,9 @@ mod update_terrain_inspector_tests {
         world.flush();
 
         // Frame 2: the container shows up.
-        let container = world.spawn((TerrainInspectorContainer, Node::default())).id();
+        let container = world
+            .spawn((TerrainInspectorContainer, Node::default()))
+            .id();
         world
             .run_system_cached(update_terrain_inspector)
             .expect("system runs");
@@ -1194,8 +1197,12 @@ mod update_terrain_inspector_tests {
         let mut world = base_world();
         select_a_terrain(&mut world);
 
-        let a = world.spawn((TerrainInspectorContainer, Node::default())).id();
-        let b = world.spawn((TerrainInspectorContainer, Node::default())).id();
+        let a = world
+            .spawn((TerrainInspectorContainer, Node::default()))
+            .id();
+        let b = world
+            .spawn((TerrainInspectorContainer, Node::default()))
+            .id();
 
         world
             .run_system_cached(update_terrain_inspector)

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -591,20 +591,16 @@ fn sync_brush_fields(
 
 /// Edge of one channel / palette tile.
 const TILE_PX: f32 = 52.0;
-/// Height of the accent bar marking the selected tile. Unity underlines
-/// the selected layer, Unreal bars it above the name, `Terrain3D` outlines
-/// it; a bar is the same idea in jackdaw's own colour language.
+/// Height of the accent bar marking the selected tile.
 const ACCENT_PX: f32 = 3.0;
 
 /// The channel tile grid, the active channel's palette swatches, and the
 /// painted-state toggle.
 ///
-/// Shaped after the layer grids in Unity's Paint Texture tab, Unreal's
-/// Target Layers, and `Terrain3D`'s asset dock: a grid of tiles rather than
-/// a text list, each tile click-to-select with an accent bar when active,
-/// and a `+` tile at the end to add one. The tiles show a palette swatch
-/// instead of a texture thumbnail because a channel is an integer layer,
-/// not a material.
+/// A grid of tiles rather than a text list: each tile is click-to-select
+/// with an accent bar when active, and a `+` tile at the end adds one. The
+/// tiles show a palette swatch rather than a texture thumbnail because a
+/// channel is an integer layer, not a material.
 fn spawn_channel_ui(
     commands: &mut Commands,
     parent: Entity,
@@ -674,9 +670,8 @@ fn spawn_channel_ui(
         crate::terrain::channel_ops::TerrainChannelValueAddOp::ID,
     );
 
-    // The painted-state view. Terrain3D's control-texture debug view is
-    // the closest equivalent, and without something like it the user is
-    // painting data with no feedback at all.
+    // The painted-state view. Without it the user is painting data with
+    // no feedback at all.
     commands.spawn((
         button::button(
             ButtonProps::new(if paint.show_channel {
@@ -795,8 +790,8 @@ pub(super) fn spawn_tile(
         });
 }
 
-/// `Terrain3D`'s `+` tile, carried over directly: the way to add a layer
-/// sits at the end of the grid, not in a separate menu.
+/// The `+` tile: the way to add a layer sits at the end of the grid, not
+/// in a separate menu.
 pub(super) fn spawn_add_tile(commands: &mut Commands, parent: Entity, op_id: &'static str) {
     let tile = commands
         .spawn((
@@ -828,8 +823,8 @@ pub(super) fn spawn_add_tile(commands: &mut Commands, parent: Entity, op_id: &'s
         });
 }
 
-/// `Terrain3D` puts a remove affordance on the tile itself; jackdaw puts a
-/// small one beside it, so the swatch stays a clean colour sample.
+/// A small remove affordance beside the tile rather than on it, so the
+/// swatch stays a clean colour sample.
 ///
 /// `op_id` is dispatched with the tile's index, so the same affordance
 /// serves the channel grid and the scatter palette.

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -1144,6 +1144,7 @@ mod update_terrain_inspector_tests {
         world.init_resource::<TerrainBrushSettings>();
         world.init_resource::<TerrainGenerateState>();
         world.insert_resource(IconFont(Handle::default()));
+        world.insert_resource(EditorFont(Handle::default()));
         world.init_resource::<TerrainPaintState>();
         world.init_resource::<crate::terrain::scatter::TerrainScatterState>();
         world.init_resource::<crate::terrain::scatter::TerrainScatterReport>();

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -173,6 +173,18 @@ fn update_terrain_inspector(
         return;
     }
 
+    // Ensure at least one container exists before committing local
+    // state: a container is spawned by the component display system the
+    // frame after selection, so skip silently and retry next frame
+    // rather than marking this render "done" for a container that was
+    // never actually populated. Committing local_state here (rather than
+    // as soon as `changed` is known) is what makes the retry possible --
+    // committing unconditionally left the inspector permanently blank
+    // whenever this frame's render did not actually happen.
+    if container_query.is_empty() {
+        return;
+    }
+
     local_state.terrain_entity = terrain_entity;
     local_state.edit_mode_is_sculpt = is_sculpt;
     local_state.edit_mode_is_paint = is_paint;
@@ -180,342 +192,341 @@ fn update_terrain_inspector(
     local_state.quantization_enabled = quantization.enabled;
     local_state.scatter_signature = scatter_signature;
 
-    // Ensure container exists
-    let container = if let Ok((entity, children)) = container_query.single() {
+    // Multi-instance dock layouts can host more than one inspector tab,
+    // each with its own TerrainInspectorContainer (see
+    // component_display.rs's `for inspector in &inspectors`); every
+    // container gets its own subtree mirroring the same data.
+    for (container, children) in &container_query {
         // Clear existing content
         if let Some(children) = children {
             for child in children.iter() {
                 commands.entity(child).despawn();
             }
         }
-        entity
-    } else {
-        // Will be created by the component display system -- skip this frame
-        return;
-    };
 
-    let Some(terrain_entity_id) = terrain_entity else {
-        return;
-    };
+        let Some(terrain_entity_id) = terrain_entity else {
+            continue;
+        };
 
-    // --- Paint channels (when paint mode active) ---
-    // Above the brush, matching every reference tool: you pick what you
-    // are painting first, then how wide the brush is.
-    if is_paint {
+        // --- Paint channels (when paint mode active) ---
+        // Above the brush, matching every reference tool: you pick what you
+        // are painting first, then how wide the brush is.
+        if is_paint {
+            let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+                &mut commands,
+                "Paint Channels",
+                &icon_font.0,
+                container,
+            );
+            let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
+            spawn_channel_ui(&mut commands, body, terrain.as_ref(), &paint_state);
+        }
+
+        // --- Brush settings section (sculpt and paint share one brush) ---
+        if is_sculpt || is_paint {
+            let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+                &mut commands,
+                "Brush",
+                &icon_font.0,
+                container,
+            );
+
+            spawn_labeled_field(
+                &mut commands,
+                body,
+                "Radius",
+                "Area of effect for the brush",
+                brush_settings.radius as f64,
+                BrushField::Radius,
+            );
+            spawn_labeled_field(
+                &mut commands,
+                body,
+                "Strength",
+                "How quickly the brush modifies terrain",
+                brush_settings.strength as f64,
+                BrushField::Strength,
+            );
+            spawn_labeled_field(
+                &mut commands,
+                body,
+                "Falloff",
+                "Brush edge softness (1=linear, 2=smooth)",
+                brush_settings.falloff as f64,
+                BrushField::Falloff,
+            );
+        }
+
+        // --- Scatter section (always shown when terrain selected) ---
+        // Declarative rather than brush-driven, so unlike Paint Channels it
+        // is not gated on an edit mode: there is no scatter tool to pick up.
+        {
+            let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+                &mut commands,
+                "Scatter",
+                &icon_font.0,
+                container,
+            );
+            let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
+            crate::terrain::scatter::spawn_scatter_ui(
+                &mut commands,
+                body,
+                terrain.as_ref(),
+                &scatter_state,
+                &scatter_report,
+            );
+        }
+
+        // --- Quantization section (always shown when terrain selected) ---
+        // It describes the terrain itself, not a tool, so it is not gated on
+        // an edit mode the way the brush is.
+        {
+            let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+                &mut commands,
+                "Quantization",
+                &icon_font.0,
+                container,
+            );
+
+            commands.spawn((
+                button::button(
+                    ButtonProps::new(if quantization.enabled {
+                        "Quantization: On"
+                    } else {
+                        "Quantization: Off"
+                    })
+                    .with_variant(if quantization.enabled {
+                        ButtonVariant::Primary
+                    } else {
+                        ButtonVariant::Default
+                    })
+                    .call_operator(crate::terrain::quantize_ops::TerrainQuantizeToggleOp::ID),
+                ),
+                ChildOf(body),
+            ));
+
+            spawn_quant_field(
+                &mut commands,
+                body,
+                "Cell Size",
+                "World units per cell edge. 0 leaves the terrain's size alone",
+                quantization.cell_size as f64,
+                QuantField::CellSize,
+            );
+            spawn_quant_field(
+                &mut commands,
+                body,
+                "Height Step",
+                "World units per elevation step. 0 leaves heights unsnapped",
+                quantization.height_step as f64,
+                QuantField::HeightStep,
+            );
+
+            // Sculpt, generate and erode snap as they go; this is for the
+            // heights that were already there when the setting was turned on.
+            commands.spawn((
+                button::button(
+                    ButtonProps::new("Apply")
+                        .with_variant(ButtonVariant::Primary)
+                        .call_operator(crate::terrain::quantize_ops::TerrainQuantizeApplyOp::ID),
+                ),
+                ChildOf(body),
+            ));
+        }
+
+        // --- Generation section (always shown when terrain selected) ---
         let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
             &mut commands,
-            "Paint Channels",
+            "Terrain Generation",
             &icon_font.0,
             container,
         );
-        let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
-        spawn_channel_ui(&mut commands, body, terrain.as_ref(), &paint_state);
-    }
 
-    // --- Brush settings section (sculpt and paint share one brush) ---
-    if is_sculpt || is_paint {
-        let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
-            &mut commands,
-            "Brush",
-            &icon_font.0,
-            container,
-        );
-
-        spawn_labeled_field(
-            &mut commands,
-            body,
-            "Radius",
-            "Area of effect for the brush",
-            brush_settings.radius as f64,
-            BrushField::Radius,
-        );
-        spawn_labeled_field(
-            &mut commands,
-            body,
-            "Strength",
-            "How quickly the brush modifies terrain",
-            brush_settings.strength as f64,
-            BrushField::Strength,
-        );
-        spawn_labeled_field(
-            &mut commands,
-            body,
-            "Falloff",
-            "Brush edge softness (1=linear, 2=smooth)",
-            brush_settings.falloff as f64,
-            BrushField::Falloff,
-        );
-    }
-
-    // --- Scatter section (always shown when terrain selected) ---
-    // Declarative rather than brush-driven, so unlike Paint Channels it
-    // is not gated on an edit mode: there is no scatter tool to pick up.
-    {
-        let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
-            &mut commands,
-            "Scatter",
-            &icon_font.0,
-            container,
-        );
-        let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
-        crate::terrain::scatter::spawn_scatter_ui(
-            &mut commands,
-            body,
-            terrain.as_ref(),
-            &scatter_state,
-            &scatter_report,
-        );
-    }
-
-    // --- Quantization section (always shown when terrain selected) ---
-    // It describes the terrain itself, not a tool, so it is not gated on
-    // an edit mode the way the brush is.
-    {
-        let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
-            &mut commands,
-            "Quantization",
-            &icon_font.0,
-            container,
-        );
-
+        // Noise type combobox
+        let noise_options: Vec<String> = jackdaw_terrain::NoiseType::ALL
+            .iter()
+            .map(|n| n.label().to_string())
+            .collect();
+        let noise_row = commands
+            .spawn((
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    column_gap: px(tokens::SPACING_XS),
+                    width: Val::Percent(100.0),
+                    ..Default::default()
+                },
+                ChildOf(body),
+            ))
+            .id();
         commands.spawn((
-            button::button(
-                ButtonProps::new(if quantization.enabled {
-                    "Quantization: On"
-                } else {
-                    "Quantization: Off"
-                })
-                .with_variant(if quantization.enabled {
-                    ButtonVariant::Primary
-                } else {
-                    ButtonVariant::Default
-                })
-                .call_operator(crate::terrain::quantize_ops::TerrainQuantizeToggleOp::ID),
-            ),
-            ChildOf(body),
-        ));
-
-        spawn_quant_field(
-            &mut commands,
-            body,
-            "Cell Size",
-            "World units per cell edge. 0 leaves the terrain's size alone",
-            quantization.cell_size as f64,
-            QuantField::CellSize,
-        );
-        spawn_quant_field(
-            &mut commands,
-            body,
-            "Height Step",
-            "World units per elevation step. 0 leaves heights unsnapped",
-            quantization.height_step as f64,
-            QuantField::HeightStep,
-        );
-
-        // Sculpt, generate and erode snap as they go; this is for the
-        // heights that were already there when the setting was turned on.
-        commands.spawn((
-            button::button(
-                ButtonProps::new("Apply")
-                    .with_variant(ButtonVariant::Primary)
-                    .call_operator(crate::terrain::quantize_ops::TerrainQuantizeApplyOp::ID),
-            ),
-            ChildOf(body),
-        ));
-    }
-
-    // --- Generation section (always shown when terrain selected) ---
-    let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
-        &mut commands,
-        "Terrain Generation",
-        &icon_font.0,
-        container,
-    );
-
-    // Noise type combobox
-    let noise_options: Vec<String> = jackdaw_terrain::NoiseType::ALL
-        .iter()
-        .map(|n| n.label().to_string())
-        .collect();
-    let noise_row = commands
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Row,
-                align_items: AlignItems::Center,
-                column_gap: px(tokens::SPACING_XS),
-                width: Val::Percent(100.0),
+            Text::new("Noise Type"),
+            TextFont {
+                font_size: tokens::TEXT_SIZE_SM,
                 ..Default::default()
             },
-            ChildOf(body),
-        ))
-        .id();
-    commands.spawn((
-        Text::new("Noise Type"),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_SM,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        Node {
-            min_width: px(80.0),
-            flex_shrink: 0.0,
-            ..Default::default()
-        },
-        ChildOf(noise_row),
-    ));
-    commands
-        .spawn((
-            combobox::combobox_with_selected(noise_options, gen_state.settings.noise_type.index()),
-            ChildOf(noise_row),
-        ))
-        .observe(
-            |event: On<ComboBoxChangeEvent>, mut gen_state: ResMut<TerrainGenerateState>| {
-                gen_state.settings.noise_type =
-                    jackdaw_terrain::NoiseType::from_index(event.selected);
+            TextColor(tokens::TEXT_SECONDARY),
+            Node {
+                min_width: px(80.0),
+                flex_shrink: 0.0,
+                ..Default::default()
             },
+            ChildOf(noise_row),
+        ));
+        commands
+            .spawn((
+                combobox::combobox_with_selected(noise_options, gen_state.settings.noise_type.index()),
+                ChildOf(noise_row),
+            ))
+            .observe(
+                |event: On<ComboBoxChangeEvent>, mut gen_state: ResMut<TerrainGenerateState>| {
+                    gen_state.settings.noise_type =
+                        jackdaw_terrain::NoiseType::from_index(event.selected);
+                },
+            );
+
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Seed",
+            "Same seed always produces the same terrain",
+            gen_state.settings.seed as f64,
+            GenField::Seed,
+        );
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Frequency",
+            "Lower = broader features, higher = finer detail",
+            gen_state.settings.frequency,
+            GenField::Frequency,
+        );
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Octaves",
+            "Layers of noise stacked together. More = finer detail",
+            gen_state.settings.octaves as f64,
+            GenField::Octaves,
+        );
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Lacunarity",
+            "How much each octave's frequency increases",
+            gen_state.settings.lacunarity,
+            GenField::Lacunarity,
+        );
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Persistence",
+            "How much each octave contributes. Lower = subtler",
+            gen_state.settings.persistence,
+            GenField::Persistence,
+        );
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Amplitude",
+            "Overall height scale of the generated terrain",
+            gen_state.settings.amplitude as f64,
+            GenField::Amplitude,
+        );
+        spawn_gen_field(
+            &mut commands,
+            body,
+            "Offset",
+            "Vertical offset added after generation",
+            gen_state.settings.offset as f64,
+            GenField::Offset,
         );
 
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Seed",
-        "Same seed always produces the same terrain",
-        gen_state.settings.seed as f64,
-        GenField::Seed,
-    );
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Frequency",
-        "Lower = broader features, higher = finer detail",
-        gen_state.settings.frequency,
-        GenField::Frequency,
-    );
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Octaves",
-        "Layers of noise stacked together. More = finer detail",
-        gen_state.settings.octaves as f64,
-        GenField::Octaves,
-    );
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Lacunarity",
-        "How much each octave's frequency increases",
-        gen_state.settings.lacunarity,
-        GenField::Lacunarity,
-    );
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Persistence",
-        "How much each octave contributes. Lower = subtler",
-        gen_state.settings.persistence,
-        GenField::Persistence,
-    );
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Amplitude",
-        "Overall height scale of the generated terrain",
-        gen_state.settings.amplitude as f64,
-        GenField::Amplitude,
-    );
-    spawn_gen_field(
-        &mut commands,
-        body,
-        "Offset",
-        "Vertical offset added after generation",
-        gen_state.settings.offset as f64,
-        GenField::Offset,
-    );
+        // Generate button
+        commands.spawn((
+            button::button(
+                ButtonProps::new("Generate")
+                    .with_variant(ButtonVariant::Primary)
+                    .call_operator(crate::terrain::ops::TerrainGenerateOp::ID),
+            ),
+            ChildOf(body),
+        ));
 
-    // Generate button
-    commands.spawn((
-        button::button(
-            ButtonProps::new("Generate")
-                .with_variant(ButtonVariant::Primary)
-                .call_operator(crate::terrain::ops::TerrainGenerateOp::ID),
-        ),
-        ChildOf(body),
-    ));
+        // --- Erosion section ---
+        let (_section, ebody) = jackdaw_feathers::collapsible::collapsible_section(
+            &mut commands,
+            "Hydraulic Erosion",
+            &icon_font.0,
+            container,
+        );
 
-    // --- Erosion section ---
-    let (_section, ebody) = jackdaw_feathers::collapsible::collapsible_section(
-        &mut commands,
-        "Hydraulic Erosion",
-        &icon_font.0,
-        container,
-    );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Iterations",
+            "Number of water droplets simulated",
+            gen_state.erosion.iterations as f64,
+            ErosionField::Iterations,
+        );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Erosion Radius",
+            "Area of effect for each erosion step",
+            gen_state.erosion.erosion_radius as f64,
+            ErosionField::ErosionRadius,
+        );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Inertia",
+            "How much a droplet keeps its previous direction",
+            gen_state.erosion.inertia as f64,
+            ErosionField::Inertia,
+        );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Capacity",
+            "How much sediment water can carry",
+            gen_state.erosion.capacity as f64,
+            ErosionField::Capacity,
+        );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Deposition",
+            "Rate sediment is dropped when water slows",
+            gen_state.erosion.deposition as f64,
+            ErosionField::Deposition,
+        );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Erosion Rate",
+            "Rate terrain is dissolved by flowing water",
+            gen_state.erosion.erosion as f64,
+            ErosionField::Erosion,
+        );
+        spawn_erosion_field(
+            &mut commands,
+            ebody,
+            "Evaporation",
+            "How quickly water droplets shrink",
+            gen_state.erosion.evaporation as f64,
+            ErosionField::Evaporation,
+        );
 
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Iterations",
-        "Number of water droplets simulated",
-        gen_state.erosion.iterations as f64,
-        ErosionField::Iterations,
-    );
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Erosion Radius",
-        "Area of effect for each erosion step",
-        gen_state.erosion.erosion_radius as f64,
-        ErosionField::ErosionRadius,
-    );
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Inertia",
-        "How much a droplet keeps its previous direction",
-        gen_state.erosion.inertia as f64,
-        ErosionField::Inertia,
-    );
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Capacity",
-        "How much sediment water can carry",
-        gen_state.erosion.capacity as f64,
-        ErosionField::Capacity,
-    );
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Deposition",
-        "Rate sediment is dropped when water slows",
-        gen_state.erosion.deposition as f64,
-        ErosionField::Deposition,
-    );
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Erosion Rate",
-        "Rate terrain is dissolved by flowing water",
-        gen_state.erosion.erosion as f64,
-        ErosionField::Erosion,
-    );
-    spawn_erosion_field(
-        &mut commands,
-        ebody,
-        "Evaporation",
-        "How quickly water droplets shrink",
-        gen_state.erosion.evaporation as f64,
-        ErosionField::Evaporation,
-    );
-
-    // Erode button
-    commands.spawn((
-        button::button(
-            ButtonProps::new("Erode")
-                .with_variant(ButtonVariant::Primary)
-                .call_operator(crate::terrain::ops::TerrainErodeOp::ID),
-        ),
-        ChildOf(ebody),
-    ));
+        // Erode button
+        commands.spawn((
+            button::button(
+                ButtonProps::new("Erode")
+                    .with_variant(ButtonVariant::Primary)
+                    .call_operator(crate::terrain::ops::TerrainErodeOp::ID),
+            ),
+            ChildOf(ebody),
+        ));
+    }
 }
 
 /// Sync brush resource values into existing `text_edit` widgets without rebuilding the UI.
@@ -1100,6 +1111,20 @@ fn spawn_erosion_field(
     ));
 }
 
+/// Parse a committed numeric field, falling back to `0.0` for anything
+/// that is not a usable number.
+///
+/// `str::parse::<f64>` accepts "nan" / "inf" / "-inf" as valid input, so a
+/// parse success alone does not mean a usable number: a non-finite value
+/// is rejected the same as a parse failure, rather than being allowed to
+/// reach the brush, the store, undo, and eventually the sidecar.
+fn parse_finite_or_zero(text: &str) -> f64 {
+    text.parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite())
+        .unwrap_or(0.0)
+}
+
 /// Handle `TextEditCommitEvent` for terrain inspector fields (brush, gen, erosion).
 fn on_terrain_text_commit(
     event: On<TextEditCommitEvent>,
@@ -1113,7 +1138,7 @@ fn on_terrain_text_commit(
     selection: Res<Selection>,
     mut commands: Commands,
 ) {
-    let value: f64 = event.text.parse().unwrap_or(0.0);
+    let value: f64 = parse_finite_or_zero(&event.text);
 
     // Walk up from committed entity to find a field binding
     let mut current = event.entity;
@@ -1173,5 +1198,117 @@ fn on_terrain_text_commit(
             return;
         }
         current = parent;
+    }
+}
+
+#[cfg(test)]
+mod parse_finite_or_zero_tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_numbers_parse_through() {
+        assert_eq!(parse_finite_or_zero("3.5"), 3.5);
+        assert_eq!(parse_finite_or_zero("-12"), -12.0);
+    }
+
+    /// I2 pinning test, the exact scenario from the review finding: `nan`
+    /// and `inf` parse successfully as `f64` but must not reach a brush
+    /// setting as usable numbers.
+    #[test]
+    fn non_finite_text_falls_back_to_zero() {
+        assert_eq!(parse_finite_or_zero("nan"), 0.0);
+        assert_eq!(parse_finite_or_zero("NaN"), 0.0);
+        assert_eq!(parse_finite_or_zero("inf"), 0.0);
+        assert_eq!(parse_finite_or_zero("-inf"), 0.0);
+        assert_eq!(parse_finite_or_zero("infinity"), 0.0);
+    }
+
+    #[test]
+    fn unparsable_text_falls_back_to_zero() {
+        assert_eq!(parse_finite_or_zero("not a number"), 0.0);
+        assert_eq!(parse_finite_or_zero(""), 0.0);
+    }
+}
+
+#[cfg(test)]
+mod update_terrain_inspector_tests {
+    use jackdaw_feathers::icons::IconFont;
+
+    use super::*;
+    use crate::selection::Selection;
+
+    fn base_world() -> World {
+        let mut world = World::new();
+        world.init_resource::<Selection>();
+        world.init_resource::<TerrainEditMode>();
+        world.init_resource::<TerrainBrushSettings>();
+        world.init_resource::<TerrainGenerateState>();
+        world.insert_resource(IconFont(Handle::default()));
+        world.init_resource::<TerrainPaintState>();
+        world.init_resource::<crate::terrain::scatter::TerrainScatterState>();
+        world.init_resource::<crate::terrain::scatter::TerrainScatterReport>();
+        world
+    }
+
+    fn select_a_terrain(world: &mut World) {
+        let terrain = world.spawn(jackdaw_scene_types::Terrain::default()).id();
+        world.resource_mut::<Selection>().entities = vec![terrain];
+    }
+
+    /// I3 pinning test, the exact scenario from the review finding: the
+    /// signature was committed to `local_state` before the container
+    /// lookup, so a frame where the container did not exist yet (it is
+    /// spawned a frame later, by the component display system) still
+    /// marked the render "done" -- `changed` went false and the
+    /// inspector never tried again.
+    #[test]
+    fn a_container_that_appears_a_frame_late_still_gets_rendered() {
+        let mut world = base_world();
+        select_a_terrain(&mut world);
+
+        // Frame 1: selection changed, but no container exists yet.
+        world
+            .run_system_cached(update_terrain_inspector)
+            .expect("system runs");
+        world.flush();
+
+        // Frame 2: the container shows up.
+        let container = world.spawn((TerrainInspectorContainer, Node::default())).id();
+        world
+            .run_system_cached(update_terrain_inspector)
+            .expect("system runs");
+        world.flush();
+
+        let children = world.get::<Children>(container);
+        assert!(
+            children.is_some_and(|c| !c.is_empty()),
+            "the container must be populated once it exists, even a frame late",
+        );
+    }
+
+    /// I3 pinning test: a multi-instance dock layout spawns one
+    /// TerrainInspectorContainer per docked inspector panel.
+    /// `Query::single()` errors when more than one entity matches an
+    /// archetype, which used to leave every docked panel blank.
+    #[test]
+    fn every_docked_container_gets_rendered() {
+        let mut world = base_world();
+        select_a_terrain(&mut world);
+
+        let a = world.spawn((TerrainInspectorContainer, Node::default())).id();
+        let b = world.spawn((TerrainInspectorContainer, Node::default())).id();
+
+        world
+            .run_system_cached(update_terrain_inspector)
+            .expect("system runs");
+        world.flush();
+
+        for container in [a, b] {
+            let children = world.get::<Children>(container);
+            assert!(
+                children.is_some_and(|c| !c.is_empty()),
+                "container {container:?} must be populated",
+            );
+        }
     }
 }

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -591,16 +591,20 @@ fn sync_brush_fields(
 
 /// Edge of one channel / palette tile.
 const TILE_PX: f32 = 52.0;
-/// Height of the accent bar marking the selected tile.
+/// Height of the accent bar marking the selected tile. Unity underlines
+/// the selected layer, Unreal bars it above the name, `Terrain3D` outlines
+/// it; a bar is the same idea in jackdaw's own colour language.
 const ACCENT_PX: f32 = 3.0;
 
 /// The channel tile grid, the active channel's palette swatches, and the
 /// painted-state toggle.
 ///
-/// A grid of tiles rather than a text list: each tile is click-to-select
-/// with an accent bar when active, and a `+` tile at the end adds one. The
-/// tiles show a palette swatch rather than a texture thumbnail because a
-/// channel is an integer layer, not a material.
+/// Shaped after the layer grids in Unity's Paint Texture tab, Unreal's
+/// Target Layers, and `Terrain3D`'s asset dock: a grid of tiles rather than
+/// a text list, each tile click-to-select with an accent bar when active,
+/// and a `+` tile at the end to add one. The tiles show a palette swatch
+/// instead of a texture thumbnail because a channel is an integer layer,
+/// not a material.
 fn spawn_channel_ui(
     commands: &mut Commands,
     parent: Entity,
@@ -670,8 +674,9 @@ fn spawn_channel_ui(
         crate::terrain::channel_ops::TerrainChannelValueAddOp::ID,
     );
 
-    // The painted-state view. Without it the user is painting data with
-    // no feedback at all.
+    // The painted-state view. Terrain3D's control-texture debug view is
+    // the closest equivalent, and without something like it the user is
+    // painting data with no feedback at all.
     commands.spawn((
         button::button(
             ButtonProps::new(if paint.show_channel {
@@ -790,8 +795,8 @@ pub(super) fn spawn_tile(
         });
 }
 
-/// The `+` tile: the way to add a layer sits at the end of the grid, not
-/// in a separate menu.
+/// `Terrain3D`'s `+` tile, carried over directly: the way to add a layer
+/// sits at the end of the grid, not in a separate menu.
 pub(super) fn spawn_add_tile(commands: &mut Commands, parent: Entity, op_id: &'static str) {
     let tile = commands
         .spawn((
@@ -823,8 +828,8 @@ pub(super) fn spawn_add_tile(commands: &mut Commands, parent: Entity, op_id: &'s
         });
 }
 
-/// A small remove affordance beside the tile rather than on it, so the
-/// swatch stays a clean colour sample.
+/// `Terrain3D` puts a remove affordance on the tile itself; jackdaw puts a
+/// small one beside it, so the swatch stays a clean colour sample.
 ///
 /// `op_id` is dispatched with the tile's index, so the same affordance
 /// serves the channel grid and the scatter palette.

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -350,7 +350,7 @@ fn update_terrain_inspector(
                 ChildOf(body),
             ));
 
-            spawn_quant_field(
+            spawn_labeled_field(
                 &mut commands,
                 body,
                 "Cell Size",
@@ -358,7 +358,7 @@ fn update_terrain_inspector(
                 quantization.cell_size as f64,
                 QuantField::CellSize,
             );
-            spawn_quant_field(
+            spawn_labeled_field(
                 &mut commands,
                 body,
                 "Height Step",
@@ -430,7 +430,7 @@ fn update_terrain_inspector(
                 },
             );
 
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Seed",
@@ -438,7 +438,7 @@ fn update_terrain_inspector(
             gen_state.settings.seed as f64,
             GenField::Seed,
         );
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Frequency",
@@ -446,7 +446,7 @@ fn update_terrain_inspector(
             gen_state.settings.frequency,
             GenField::Frequency,
         );
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Octaves",
@@ -454,7 +454,7 @@ fn update_terrain_inspector(
             gen_state.settings.octaves as f64,
             GenField::Octaves,
         );
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Lacunarity",
@@ -462,7 +462,7 @@ fn update_terrain_inspector(
             gen_state.settings.lacunarity,
             GenField::Lacunarity,
         );
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Persistence",
@@ -470,7 +470,7 @@ fn update_terrain_inspector(
             gen_state.settings.persistence,
             GenField::Persistence,
         );
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Amplitude",
@@ -478,7 +478,7 @@ fn update_terrain_inspector(
             gen_state.settings.amplitude as f64,
             GenField::Amplitude,
         );
-        spawn_gen_field(
+        spawn_labeled_field(
             &mut commands,
             body,
             "Offset",
@@ -505,7 +505,7 @@ fn update_terrain_inspector(
             container,
         );
 
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Iterations",
@@ -513,7 +513,7 @@ fn update_terrain_inspector(
             gen_state.erosion.iterations as f64,
             ErosionField::Iterations,
         );
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Erosion Radius",
@@ -521,7 +521,7 @@ fn update_terrain_inspector(
             gen_state.erosion.erosion_radius as f64,
             ErosionField::ErosionRadius,
         );
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Inertia",
@@ -529,7 +529,7 @@ fn update_terrain_inspector(
             gen_state.erosion.inertia as f64,
             ErosionField::Inertia,
         );
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Capacity",
@@ -537,7 +537,7 @@ fn update_terrain_inspector(
             gen_state.erosion.capacity as f64,
             ErosionField::Capacity,
         );
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Deposition",
@@ -545,7 +545,7 @@ fn update_terrain_inspector(
             gen_state.erosion.deposition as f64,
             ErosionField::Deposition,
         );
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Erosion Rate",
@@ -553,7 +553,7 @@ fn update_terrain_inspector(
             gen_state.erosion.erosion as f64,
             ErosionField::Erosion,
         );
-        spawn_erosion_field(
+        spawn_labeled_field(
             &mut commands,
             ebody,
             "Evaporation",
@@ -959,159 +959,6 @@ pub(super) fn spawn_labeled_field<C: Component>(
     tooltip: &str,
     value: f64,
     field: C,
-) {
-    let row = commands
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Column,
-                row_gap: px(tokens::SPACING_XS),
-                width: Val::Percent(100.0),
-                ..Default::default()
-            },
-            ChildOf(parent),
-        ))
-        .id();
-
-    commands.spawn((
-        Text::new(label),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_SM,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        ChildOf(row),
-    ));
-
-    commands.spawn((
-        Text::new(tooltip),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_XS,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        ChildOf(row),
-    ));
-
-    commands.spawn((
-        text_edit::text_edit(
-            TextEditProps::default()
-                .numeric_f32()
-                .with_default_value(value.to_string()),
-        ),
-        field,
-        ChildOf(row),
-    ));
-}
-
-fn spawn_quant_field(
-    commands: &mut Commands,
-    parent: Entity,
-    label: &str,
-    tooltip: &str,
-    value: f64,
-    field: QuantField,
-) {
-    let row = commands
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Column,
-                row_gap: px(tokens::SPACING_XS),
-                width: Val::Percent(100.0),
-                ..Default::default()
-            },
-            ChildOf(parent),
-        ))
-        .id();
-
-    commands.spawn((
-        Text::new(label),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_SM,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        ChildOf(row),
-    ));
-
-    commands.spawn((
-        Text::new(tooltip),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_XS,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        ChildOf(row),
-    ));
-
-    commands.spawn((
-        text_edit::text_edit(
-            TextEditProps::default()
-                .numeric_f32()
-                .with_default_value(value.to_string()),
-        ),
-        field,
-        ChildOf(row),
-    ));
-}
-
-fn spawn_gen_field(
-    commands: &mut Commands,
-    parent: Entity,
-    label: &str,
-    tooltip: &str,
-    value: f64,
-    field: GenField,
-) {
-    let row = commands
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Column,
-                row_gap: px(tokens::SPACING_XS),
-                width: Val::Percent(100.0),
-                ..Default::default()
-            },
-            ChildOf(parent),
-        ))
-        .id();
-
-    commands.spawn((
-        Text::new(label),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_SM,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        ChildOf(row),
-    ));
-
-    commands.spawn((
-        Text::new(tooltip),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_XS,
-            ..Default::default()
-        },
-        TextColor(tokens::TEXT_SECONDARY),
-        ChildOf(row),
-    ));
-
-    commands.spawn((
-        text_edit::text_edit(
-            TextEditProps::default()
-                .numeric_f32()
-                .with_default_value(value.to_string()),
-        ),
-        field,
-        ChildOf(row),
-    ));
-}
-
-fn spawn_erosion_field(
-    commands: &mut Commands,
-    parent: Entity,
-    label: &str,
-    tooltip: &str,
-    value: f64,
-    field: ErosionField,
 ) {
     let row = commands
         .spawn((

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -1086,7 +1086,7 @@ fn on_terrain_text_commit(
                 // do what it says.
                 ErosionField::Iterations => {
                     gen_state.erosion.iterations =
-                        (value as u32).min(jackdaw_terrain::erosion::MAX_ITERATIONS)
+                        (value as u32).min(jackdaw_terrain::erosion::MAX_ITERATIONS);
                 }
                 ErosionField::ErosionRadius => gen_state.erosion.erosion_radius = value as u32,
                 ErosionField::Inertia => gen_state.erosion.inertia = value as f32,
@@ -1189,7 +1189,7 @@ mod update_terrain_inspector_tests {
     }
 
     /// I3 pinning test: a multi-instance dock layout spawns one
-    /// TerrainInspectorContainer per docked inspector panel.
+    /// `TerrainInspectorContainer` per docked inspector panel.
     /// `Query::single()` errors when more than one entity matches an
     /// archetype, which used to leave every docked panel blank.
     #[test]

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -787,12 +787,26 @@ pub(super) fn spawn_tile(
     commands
         .entity(tile)
         .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-            let mut call = commands.operator(op_id);
+            let mut call = commands
+                .operator(op_id)
+                .settings(tile_dispatch_settings());
             if let Some(index) = index {
                 call = call.param("index", index as i64);
             }
             call.call();
         });
+}
+
+/// Dispatch settings shared by every tile-grid affordance (select, add,
+/// remove). Matches the house dispatcher in `core_extension.rs`: history
+/// entries and tab dirtiness must follow a tile click exactly as they do
+/// a toolbar button click. Operators that opt out (`allows_undo = false`,
+/// e.g. the select tiles) are unaffected either way.
+fn tile_dispatch_settings() -> CallOperatorSettings {
+    CallOperatorSettings {
+        creates_history_entry: true,
+        execution_context: ExecutionContext::Invoke,
+    }
 }
 
 /// `Terrain3D`'s `+` tile, carried over directly: the way to add a layer
@@ -824,7 +838,10 @@ pub(super) fn spawn_add_tile(commands: &mut Commands, parent: Entity, op_id: &'s
     commands
         .entity(tile)
         .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-            commands.operator(op_id).call();
+            commands
+                .operator(op_id)
+                .settings(tile_dispatch_settings())
+                .call();
         });
 }
 
@@ -863,7 +880,11 @@ pub(super) fn spawn_tile_remove(
     commands
         .entity(button)
         .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-            commands.operator(op_id).param("index", index as i64).call();
+            commands
+                .operator(op_id)
+                .param("index", index as i64)
+                .settings(tile_dispatch_settings())
+                .call();
         });
 }
 

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -11,7 +11,7 @@ use jackdaw_feathers::{
     tokens,
 };
 
-use super::{TerrainBrushSettings, TerrainEditMode};
+use super::{TerrainBrushSettings, TerrainEditMode, TerrainPaintState};
 use crate::selection::Selection;
 
 pub(super) fn plugin(app: &mut App) {
@@ -55,6 +55,31 @@ pub fn spawn_terrain_inspector_container(commands: &mut Commands, parent: Entity
 struct InspectorState {
     terrain_entity: Option<Entity>,
     edit_mode_is_sculpt: bool,
+    edit_mode_is_paint: bool,
+    /// Channel table shape and selection, so the tile grid redraws when a
+    /// channel is added, removed, renamed or picked. Compared rather than
+    /// change-detected because `TerrainPaintState` also carries the brush
+    /// position, which moves nearly every frame.
+    channel_signature: Option<ChannelSignature>,
+    /// Whether quantization was on last time the panel was drawn. Only
+    /// the flag is tracked: the two numeric fields are typed into, and
+    /// rebuilding the section on every committed keystroke would take
+    /// the focus away mid-edit.
+    quantization_enabled: bool,
+    /// Scatter palette, mask selection, toggles and last-run report.
+    /// Same reasoning as `channel_signature`: the numeric fields are
+    /// typed into and must not redraw under the caret.
+    scatter_signature: Option<crate::terrain::scatter::ScatterSignature>,
+}
+
+/// What the channel UI depends on. Anything else changing on the terrain
+/// or the paint state leaves the panel alone.
+#[derive(PartialEq, Clone)]
+struct ChannelSignature {
+    channels: Vec<(String, usize)>,
+    active_channel: usize,
+    active_entry: usize,
+    show_channel: bool,
 }
 
 // --- Field binding tags ---
@@ -64,6 +89,12 @@ enum BrushField {
     Radius,
     Strength,
     Falloff,
+}
+
+#[derive(Component, Clone, Copy)]
+enum QuantField {
+    CellSize,
+    HeightStep,
 }
 
 #[derive(Component, Clone, Copy)]
@@ -98,14 +129,44 @@ fn update_terrain_inspector(
     brush_settings: Res<TerrainBrushSettings>,
     gen_state: Res<TerrainGenerateState>,
     icon_font: Res<jackdaw_feathers::icons::IconFont>,
+    paint_state: Res<TerrainPaintState>,
+    terrain_data: Query<&jackdaw_scene_types::Terrain>,
+    scatter_state: Res<crate::terrain::scatter::TerrainScatterState>,
+    scatter_report: Res<crate::terrain::scatter::TerrainScatterReport>,
 ) {
     // Determine if we should show terrain inspector
     let terrain_entity = selection.primary().filter(|&e| terrains.contains(e));
 
     let is_sculpt = matches!(*edit_mode, TerrainEditMode::Sculpt(_));
+    let is_paint = *edit_mode == TerrainEditMode::Paint;
+
+    let signature = terrain_entity
+        .and_then(|e| terrain_data.get(e).ok())
+        .map(|terrain| ChannelSignature {
+            channels: terrain
+                .channels
+                .iter()
+                .map(|channel| (channel.name.clone(), channel.palette.len()))
+                .collect(),
+            active_channel: paint_state.active_channel,
+            active_entry: paint_state.active_entry,
+            show_channel: paint_state.show_channel,
+        });
+
+    let quantization = terrain_entity
+        .and_then(|e| terrain_data.get(e).ok())
+        .map(|terrain| terrain.quantization.clone())
+        .unwrap_or_default();
+
+    let scatter_signature =
+        terrain_entity.map(|_| crate::terrain::scatter::signature(&scatter_state, &scatter_report));
 
     let changed = local_state.terrain_entity != terrain_entity
         || local_state.edit_mode_is_sculpt != is_sculpt
+        || local_state.edit_mode_is_paint != is_paint
+        || local_state.channel_signature != signature
+        || local_state.quantization_enabled != quantization.enabled
+        || local_state.scatter_signature != scatter_signature
         || (terrain_entity.is_some() && edit_mode.is_changed());
 
     if !changed {
@@ -114,6 +175,10 @@ fn update_terrain_inspector(
 
     local_state.terrain_entity = terrain_entity;
     local_state.edit_mode_is_sculpt = is_sculpt;
+    local_state.edit_mode_is_paint = is_paint;
+    local_state.channel_signature = signature;
+    local_state.quantization_enabled = quantization.enabled;
+    local_state.scatter_signature = scatter_signature;
 
     // Ensure container exists
     let container = if let Ok((entity, children)) = container_query.single() {
@@ -129,15 +194,29 @@ fn update_terrain_inspector(
         return;
     };
 
-    let Some(_terrain_entity) = terrain_entity else {
+    let Some(terrain_entity_id) = terrain_entity else {
         return;
     };
 
-    // --- Brush settings section (when sculpt mode active) ---
-    if is_sculpt {
+    // --- Paint channels (when paint mode active) ---
+    // Above the brush, matching every reference tool: you pick what you
+    // are painting first, then how wide the brush is.
+    if is_paint {
         let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
             &mut commands,
-            "Sculpt Brush",
+            "Paint Channels",
+            &icon_font.0,
+            container,
+        );
+        let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
+        spawn_channel_ui(&mut commands, body, terrain.as_ref(), &paint_state);
+    }
+
+    // --- Brush settings section (sculpt and paint share one brush) ---
+    if is_sculpt || is_paint {
+        let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+            &mut commands,
+            "Brush",
             &icon_font.0,
             container,
         );
@@ -166,6 +245,83 @@ fn update_terrain_inspector(
             brush_settings.falloff as f64,
             BrushField::Falloff,
         );
+    }
+
+    // --- Scatter section (always shown when terrain selected) ---
+    // Declarative rather than brush-driven, so unlike Paint Channels it
+    // is not gated on an edit mode: there is no scatter tool to pick up.
+    {
+        let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+            &mut commands,
+            "Scatter",
+            &icon_font.0,
+            container,
+        );
+        let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
+        crate::terrain::scatter::spawn_scatter_ui(
+            &mut commands,
+            body,
+            terrain.as_ref(),
+            &scatter_state,
+            &scatter_report,
+        );
+    }
+
+    // --- Quantization section (always shown when terrain selected) ---
+    // It describes the terrain itself, not a tool, so it is not gated on
+    // an edit mode the way the brush is.
+    {
+        let (_section, body) = jackdaw_feathers::collapsible::collapsible_section(
+            &mut commands,
+            "Quantization",
+            &icon_font.0,
+            container,
+        );
+
+        commands.spawn((
+            button::button(
+                ButtonProps::new(if quantization.enabled {
+                    "Quantization: On"
+                } else {
+                    "Quantization: Off"
+                })
+                .with_variant(if quantization.enabled {
+                    ButtonVariant::Primary
+                } else {
+                    ButtonVariant::Default
+                })
+                .call_operator(crate::terrain::quantize_ops::TerrainQuantizeToggleOp::ID),
+            ),
+            ChildOf(body),
+        ));
+
+        spawn_quant_field(
+            &mut commands,
+            body,
+            "Cell Size",
+            "World units per cell edge. 0 leaves the terrain's size alone",
+            quantization.cell_size as f64,
+            QuantField::CellSize,
+        );
+        spawn_quant_field(
+            &mut commands,
+            body,
+            "Height Step",
+            "World units per elevation step. 0 leaves heights unsnapped",
+            quantization.height_step as f64,
+            QuantField::HeightStep,
+        );
+
+        // Sculpt, generate and erode snap as they go; this is for the
+        // heights that were already there when the setting was turned on.
+        commands.spawn((
+            button::button(
+                ButtonProps::new("Apply")
+                    .with_variant(ButtonVariant::Primary)
+                    .call_operator(crate::terrain::quantize_ops::TerrainQuantizeApplyOp::ID),
+            ),
+            ChildOf(body),
+        ));
     }
 
     // --- Generation section (always shown when terrain selected) ---
@@ -431,15 +587,352 @@ fn sync_brush_fields(
     }
 }
 
+// --- Channel UI ---
+
+/// Edge of one channel / palette tile.
+const TILE_PX: f32 = 52.0;
+/// Height of the accent bar marking the selected tile. Unity underlines
+/// the selected layer, Unreal bars it above the name, `Terrain3D` outlines
+/// it; a bar is the same idea in jackdaw's own colour language.
+const ACCENT_PX: f32 = 3.0;
+
+/// The channel tile grid, the active channel's palette swatches, and the
+/// painted-state toggle.
+///
+/// Shaped after the layer grids in Unity's Paint Texture tab, Unreal's
+/// Target Layers, and `Terrain3D`'s asset dock: a grid of tiles rather than
+/// a text list, each tile click-to-select with an accent bar when active,
+/// and a `+` tile at the end to add one. The tiles show a palette swatch
+/// instead of a texture thumbnail because a channel is an integer layer,
+/// not a material.
+fn spawn_channel_ui(
+    commands: &mut Commands,
+    parent: Entity,
+    terrain: Option<&jackdaw_scene_types::Terrain>,
+    paint: &TerrainPaintState,
+) {
+    let empty: &[jackdaw_scene_types::TerrainChannel] = &[];
+    let channels = terrain.map(|t| t.channels.as_slice()).unwrap_or(empty);
+
+    spawn_hint(
+        commands,
+        parent,
+        "Channels are yours to name. Paint what a cell is, not what it looks like.",
+    );
+
+    let grid = spawn_tile_grid(commands, parent);
+    for (index, channel) in channels.iter().enumerate() {
+        let swatch = channel
+            .palette
+            .iter()
+            .find(|entry| entry.value != 0)
+            .or_else(|| channel.palette.first())
+            .map(|entry| entry.color)
+            .unwrap_or(Color::srgb(0.5, 0.5, 0.5));
+        spawn_tile(
+            commands,
+            grid,
+            swatch,
+            &channel.name,
+            index == paint.active_channel,
+            crate::terrain::channel_ops::TerrainChannelSelectOp::ID,
+            Some(index),
+        );
+        spawn_tile_remove(
+            commands,
+            grid,
+            crate::terrain::channel_ops::TerrainChannelRemoveOp::ID,
+            index,
+        );
+    }
+    spawn_add_tile(
+        commands,
+        grid,
+        crate::terrain::channel_ops::TerrainChannelAddOp::ID,
+    );
+
+    let Some(channel) = channels.get(paint.active_channel) else {
+        return;
+    };
+
+    spawn_hint(commands, parent, "Value");
+    let values = spawn_tile_grid(commands, parent);
+    for (index, entry) in channel.palette.iter().enumerate() {
+        spawn_tile(
+            commands,
+            values,
+            entry.color,
+            &entry.label,
+            index == paint.active_entry,
+            crate::terrain::channel_ops::TerrainChannelValueSelectOp::ID,
+            Some(index),
+        );
+    }
+    spawn_add_tile(
+        commands,
+        values,
+        crate::terrain::channel_ops::TerrainChannelValueAddOp::ID,
+    );
+
+    // The painted-state view. Terrain3D's control-texture debug view is
+    // the closest equivalent, and without something like it the user is
+    // painting data with no feedback at all.
+    commands.spawn((
+        button::button(
+            ButtonProps::new(if paint.show_channel {
+                "Hide Painted Values"
+            } else {
+                "Show Painted Values"
+            })
+            .with_variant(if paint.show_channel {
+                ButtonVariant::Primary
+            } else {
+                ButtonVariant::Default
+            })
+            .call_operator(crate::terrain::channel_ops::TerrainChannelToggleViewOp::ID),
+        ),
+        ChildOf(parent),
+    ));
+}
+
+pub(super) fn spawn_hint(commands: &mut Commands, parent: Entity, text: &str) {
+    commands.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_XS,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(parent),
+    ));
+}
+
+pub(super) fn spawn_tile_grid(commands: &mut Commands, parent: Entity) -> Entity {
+    commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                flex_wrap: FlexWrap::Wrap,
+                column_gap: px(tokens::SPACING_XS),
+                row_gap: px(tokens::SPACING_XS),
+                width: Val::Percent(100.0),
+                ..Default::default()
+            },
+            ChildOf(parent),
+        ))
+        .id()
+}
+
+/// One selectable tile: colour swatch, accent bar, name under it.
+/// Clicking dispatches `op_id` with the tile's index.
+pub(super) fn spawn_tile(
+    commands: &mut Commands,
+    parent: Entity,
+    swatch: Color,
+    label: &str,
+    selected: bool,
+    op_id: &'static str,
+    index: Option<usize>,
+) {
+    let tile = commands
+        .spawn((
+            Node {
+                width: px(TILE_PX),
+                flex_direction: FlexDirection::Column,
+                row_gap: px(2.0),
+                ..Default::default()
+            },
+            ChildOf(parent),
+        ))
+        .id();
+
+    commands.spawn((
+        Node {
+            width: Val::Percent(100.0),
+            height: px(TILE_PX * 0.62),
+            ..Default::default()
+        },
+        BackgroundColor(swatch),
+        ChildOf(tile),
+    ));
+
+    commands.spawn((
+        Node {
+            width: Val::Percent(100.0),
+            height: px(ACCENT_PX),
+            ..Default::default()
+        },
+        BackgroundColor(if selected {
+            tokens::ACCENT_BLUE
+        } else {
+            Color::NONE
+        }),
+        ChildOf(tile),
+    ));
+
+    commands.spawn((
+        Text::new(label),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_XS,
+            ..Default::default()
+        },
+        TextColor(if selected {
+            tokens::TEXT_BODY_COLOR.into()
+        } else {
+            tokens::TEXT_SECONDARY
+        }),
+        ChildOf(tile),
+    ));
+
+    commands
+        .entity(tile)
+        .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            let mut call = commands.operator(op_id);
+            if let Some(index) = index {
+                call = call.param("index", index as i64);
+            }
+            call.call();
+        });
+}
+
+/// `Terrain3D`'s `+` tile, carried over directly: the way to add a layer
+/// sits at the end of the grid, not in a separate menu.
+pub(super) fn spawn_add_tile(commands: &mut Commands, parent: Entity, op_id: &'static str) {
+    let tile = commands
+        .spawn((
+            Node {
+                width: px(TILE_PX),
+                height: px(TILE_PX * 0.62),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                border: UiRect::all(px(1.0)),
+                ..Default::default()
+            },
+            BorderColor::all(tokens::TEXT_SECONDARY.with_alpha(0.4)),
+            ChildOf(parent),
+        ))
+        .id();
+    commands.spawn((
+        Text::new("+"),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_SM,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(tile),
+    ));
+    commands
+        .entity(tile)
+        .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            commands.operator(op_id).call();
+        });
+}
+
+/// `Terrain3D` puts a remove affordance on the tile itself; jackdaw puts a
+/// small one beside it, so the swatch stays a clean colour sample.
+///
+/// `op_id` is dispatched with the tile's index, so the same affordance
+/// serves the channel grid and the scatter palette.
+pub(super) fn spawn_tile_remove(
+    commands: &mut Commands,
+    parent: Entity,
+    op_id: &'static str,
+    index: usize,
+) {
+    let button = commands
+        .spawn((
+            Node {
+                width: px(14.0),
+                height: px(TILE_PX * 0.62),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..Default::default()
+            },
+            ChildOf(parent),
+        ))
+        .id();
+    commands.spawn((
+        Text::new("x"),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_XS,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(button),
+    ));
+    commands
+        .entity(button)
+        .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            commands.operator(op_id).param("index", index as i64).call();
+        });
+}
+
 // --- Spawn helpers ---
 
-fn spawn_labeled_field(
+/// A label, a one-line explanation, and a numeric `text_edit` tagged with
+/// `field`.
+///
+/// Generic over the tag so a panel section can bring its own binding enum
+/// and read commits back in its own observer, rather than every terrain
+/// field having to be understood by one handler.
+pub(super) fn spawn_labeled_field<C: Component>(
     commands: &mut Commands,
     parent: Entity,
     label: &str,
     tooltip: &str,
     value: f64,
-    field: BrushField,
+    field: C,
+) {
+    let row = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Column,
+                row_gap: px(tokens::SPACING_XS),
+                width: Val::Percent(100.0),
+                ..Default::default()
+            },
+            ChildOf(parent),
+        ))
+        .id();
+
+    commands.spawn((
+        Text::new(label),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_SM,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(row),
+    ));
+
+    commands.spawn((
+        Text::new(tooltip),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_XS,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(row),
+    ));
+
+    commands.spawn((
+        text_edit::text_edit(
+            TextEditProps::default()
+                .numeric_f32()
+                .with_default_value(value.to_string()),
+        ),
+        field,
+        ChildOf(row),
+    ));
+}
+
+fn spawn_quant_field(
+    commands: &mut Commands,
+    parent: Entity,
+    label: &str,
+    tooltip: &str,
+    value: f64,
+    field: QuantField,
 ) {
     let row = commands
         .spawn((
@@ -590,11 +1083,14 @@ fn spawn_erosion_field(
 fn on_terrain_text_commit(
     event: On<TextEditCommitEvent>,
     brush_bindings: Query<&BrushField>,
+    quant_bindings: Query<&QuantField>,
     gen_bindings: Query<&GenField>,
     erosion_bindings: Query<&ErosionField>,
     child_of_query: Query<&ChildOf>,
     mut brush_settings: ResMut<TerrainBrushSettings>,
     mut gen_state: ResMut<TerrainGenerateState>,
+    selection: Res<Selection>,
+    mut commands: Commands,
 ) {
     let value: f64 = event.text.parse().unwrap_or(0.0);
 
@@ -612,6 +1108,23 @@ fn on_terrain_text_commit(
                 BrushField::Strength => brush_settings.strength = value as f32,
                 BrushField::Falloff => brush_settings.falloff = value as f32,
             }
+            return;
+        }
+        // Unlike the brush and generation fields, these live on the
+        // component rather than a resource, so the edit has to reach the
+        // scene document. `commit_quantization` is the one place that
+        // knows how.
+        if let Ok(&field) = quant_bindings.get(parent) {
+            let Some(entity) = selection.primary() else {
+                return;
+            };
+            let value = value as f32;
+            commands.queue(move |world: &mut World| {
+                crate::terrain::quantize_ops::commit_quantization(world, entity, |q| match field {
+                    QuantField::CellSize => q.cell_size = value,
+                    QuantField::HeightStep => q.height_step = value,
+                });
+            });
             return;
         }
         if let Ok(&field) = gen_bindings.get(parent) {

--- a/src/terrain/inspector.rs
+++ b/src/terrain/inspector.rs
@@ -3,7 +3,9 @@ use bevy::prelude::*;
 use jackdaw_api::prelude::*;
 use jackdaw_feathers::{
     button::{self, ButtonProps, ButtonVariant},
+    checkbox::{self, CheckboxCommitEvent, CheckboxProps},
     combobox::{self, ComboBoxChangeEvent},
+    icons::EditorFont,
     text_edit::{
         self, TextEditCommitEvent, TextEditDragging, TextEditProps, TextEditVariant,
         TextEditWrapper, format_numeric_value, set_text_input_value,
@@ -20,7 +22,56 @@ pub(super) fn plugin(app: &mut App) {
             Update,
             (update_terrain_inspector, sync_brush_fields).run_if(in_state(crate::AppState::Editor)),
         )
-        .add_observer(on_terrain_text_commit);
+        .add_observer(on_terrain_text_commit)
+        .add_observer(on_quantization_checkbox_commit);
+}
+
+/// Tags the Quantization section's on/off checkbox so its commit handler
+/// can tell "this checkbox" from any other in the editor -- `CheckboxCommitEvent`
+/// is a plain, untargeted `Event`, delivered to every observer regardless
+/// of which checkbox fired it.
+#[derive(Component)]
+struct QuantizationToggleCheckbox;
+
+/// Dispatches `terrain.quantize.toggle` through the same history-creating
+/// settings as a toolbar button (see `tile_dispatch_settings`), so
+/// toggling quantization from the checkbox still produces an undo entry
+/// and marks the tab dirty like the button it replaced did.
+fn on_quantization_checkbox_commit(
+    event: On<CheckboxCommitEvent>,
+    marked: Query<(), With<QuantizationToggleCheckbox>>,
+    mut commands: Commands,
+) {
+    if !marked.contains(event.entity) {
+        return;
+    }
+    commands
+        .operator(crate::terrain::quantize_ops::TerrainQuantizeToggleOp::ID)
+        .settings(tile_dispatch_settings())
+        .call();
+}
+
+#[cfg(test)]
+mod quantization_checkbox_tests {
+    use super::*;
+
+    /// I11 pinning test: `CheckboxCommitEvent` is a plain, untargeted
+    /// event delivered to every observer, so `on_quantization_checkbox_commit`
+    /// depends entirely on `QuantizationToggleCheckbox` to tell its one
+    /// checkbox apart from any other in the editor. Only the entity
+    /// spawned with the marker may match.
+    #[test]
+    fn only_the_marked_entity_matches_the_checkbox_query() {
+        let mut world = World::new();
+        let marked = world.spawn(QuantizationToggleCheckbox).id();
+        let unmarked = world.spawn_empty().id();
+
+        let mut query = world.query_filtered::<Entity, With<QuantizationToggleCheckbox>>();
+        let matched: Vec<Entity> = query.iter(&world).collect();
+
+        assert_eq!(matched, vec![marked]);
+        assert!(!matched.contains(&unmarked));
+    }
 }
 
 // --- State ---
@@ -129,6 +180,7 @@ fn update_terrain_inspector(
     brush_settings: Res<TerrainBrushSettings>,
     gen_state: Res<TerrainGenerateState>,
     icon_font: Res<jackdaw_feathers::icons::IconFont>,
+    editor_font: Res<EditorFont>,
     paint_state: Res<TerrainPaintState>,
     terrain_data: Query<&jackdaw_scene_types::Terrain>,
     scatter_state: Res<crate::terrain::scatter::TerrainScatterState>,
@@ -289,19 +341,12 @@ fn update_terrain_inspector(
             );
 
             commands.spawn((
-                button::button(
-                    ButtonProps::new(if quantization.enabled {
-                        "Quantization: On"
-                    } else {
-                        "Quantization: Off"
-                    })
-                    .with_variant(if quantization.enabled {
-                        ButtonVariant::Primary
-                    } else {
-                        ButtonVariant::Default
-                    })
-                    .call_operator(crate::terrain::quantize_ops::TerrainQuantizeToggleOp::ID),
+                checkbox::checkbox(
+                    CheckboxProps::new("Quantization").checked(quantization.enabled),
+                    &editor_font.0,
+                    &icon_font.0,
                 ),
+                QuantizationToggleCheckbox,
                 ChildOf(body),
             ));
 
@@ -1187,7 +1232,14 @@ fn on_terrain_text_commit(
         }
         if let Ok(&field) = erosion_bindings.get(parent) {
             match field {
-                ErosionField::Iterations => gen_state.erosion.iterations = value as u32,
+                // Clamped at entry too, not just at run time in
+                // hydraulic_erosion: an absurd typed value should not
+                // even sit displayed in the field looking like it will
+                // do what it says.
+                ErosionField::Iterations => {
+                    gen_state.erosion.iterations =
+                        (value as u32).min(jackdaw_terrain::erosion::MAX_ITERATIONS)
+                }
                 ErosionField::ErosionRadius => gen_state.erosion.erosion_radius = value as u32,
                 ErosionField::Inertia => gen_state.erosion.inertia = value as f32,
                 ErosionField::Capacity => gen_state.erosion.capacity = value as f32,

--- a/src/terrain/mesh.rs
+++ b/src/terrain/mesh.rs
@@ -1,20 +1,61 @@
 use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 
-use super::{CHUNK_SIZE, TerrainChunk, TerrainDirtyChunks};
+use super::{CHUNK_SIZE, TerrainChunk, TerrainDataStore, TerrainDirtyChunks, TerrainPaintState};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         Update,
-        (initialize_terrain_chunks, rebuild_dirty_chunks)
+        (
+            rebuild_on_channel_view_change,
+            initialize_terrain_chunks,
+            rebuild_dirty_chunks,
+        )
             .chain()
             .run_if(in_state(crate::AppState::Editor)),
     );
 }
 
-/// Default gray material for terrain chunks.
+/// Shared material for terrain chunks.
+///
+/// `base_color` is white and every chunk carries a vertex-colour
+/// attribute, so the tint lives entirely in the mesh: unpainted ground
+/// writes [`UNPAINTED`] and reads exactly as the flat grey it always did,
+/// while the channel debug view writes palette colours into the same
+/// attribute. One material, no per-terrain variants, and toggling the
+/// view is a mesh rebuild rather than a material swap.
 #[derive(Resource)]
 struct TerrainMaterialHandle(Handle<StandardMaterial>);
+
+/// Vertex colour for ground with nothing painted on it, and for every
+/// vertex when the channel view is off. Matches the material's previous
+/// hardcoded `base_color`, so the default look is unchanged.
+const UNPAINTED: [f32; 4] = [0.5, 0.5, 0.5, 1.0];
+
+/// Rebuild every terrain when the channel being visualised changes.
+///
+/// [`TerrainPaintState`] also carries the brush position, which changes
+/// on almost every frame, so a bare `is_changed()` here would rebuild the
+/// world continuously. Only the two fields the mesh actually depends on
+/// are compared.
+fn rebuild_on_channel_view_change(
+    paint: Res<TerrainPaintState>,
+    mut last: Local<Option<(usize, bool)>>,
+    mut terrains: Query<&mut TerrainDirtyChunks, With<jackdaw_scene_types::Terrain>>,
+) {
+    let current = (paint.active_channel, paint.show_channel);
+    if *last == Some(current) {
+        return;
+    }
+    let first_run = last.is_none();
+    *last = Some(current);
+    if first_run {
+        return;
+    }
+    for mut dirty in &mut terrains {
+        dirty.rebuild_all = true;
+    }
+}
 
 /// When a Terrain component is added or `rebuild_all` is set, despawn old chunks and create new ones.
 fn initialize_terrain_chunks(
@@ -34,6 +75,8 @@ fn initialize_terrain_chunks(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     material_res: Option<Res<TerrainMaterialHandle>>,
+    store: Res<TerrainDataStore>,
+    paint: Res<TerrainPaintState>,
 ) {
     for (terrain_entity, terrain, mut dirty) in &mut terrains {
         if !dirty.rebuild_all {
@@ -54,7 +97,7 @@ fn initialize_terrain_chunks(
             res.0.clone()
         } else {
             let handle = materials.add(StandardMaterial {
-                base_color: Color::srgb(0.5, 0.5, 0.5),
+                base_color: Color::WHITE,
                 perceptual_roughness: 0.9,
                 metallic: 0.0,
                 ..default()
@@ -63,15 +106,14 @@ fn initialize_terrain_chunks(
             handle
         };
 
-        let heightmap = heightmap_from_terrain(terrain);
+        let heightmap = heightmap_from_terrain(terrain, &store);
         let (cx_count, cz_count) = heightmap.chunk_count(CHUNK_SIZE);
 
         for cz in 0..cz_count {
             for cx in 0..cx_count {
-                let mesh_data =
-                    jackdaw_terrain::build_chunk_mesh_data(&heightmap, cx, cz, CHUNK_SIZE);
-
-                let mesh = build_bevy_mesh(mesh_data);
+                let mesh_data = chunk_mesh_data(&heightmap, terrain, cx, cz);
+                let colors = chunk_vertex_colors(terrain, &store, &paint, &mesh_data.grid);
+                let mesh = build_bevy_mesh(mesh_data, colors);
                 let mesh_handle = meshes.add(mesh);
 
                 // `TerrainChunk` requires `EditorHidden +
@@ -98,45 +140,122 @@ fn rebuild_dirty_chunks(
     mut terrains: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
     mut chunks: Query<(&TerrainChunk, &mut Mesh3d)>,
     mut meshes: ResMut<Assets<Mesh>>,
+    store: Res<TerrainDataStore>,
+    paint: Res<TerrainPaintState>,
 ) {
     for (terrain, mut dirty) in &mut terrains {
         if dirty.dirty.is_empty() {
             continue;
         }
 
-        let heightmap = heightmap_from_terrain(terrain);
+        let heightmap = heightmap_from_terrain(terrain, &store);
         let dirty_set: Vec<(u32, u32)> = dirty.dirty.drain().collect();
 
         for (chunk, mut mesh3d) in &mut chunks {
             if dirty_set.contains(&(chunk.chunk_x, chunk.chunk_z)) {
-                let mesh_data = jackdaw_terrain::build_chunk_mesh_data(
-                    &heightmap,
-                    chunk.chunk_x,
-                    chunk.chunk_z,
-                    CHUNK_SIZE,
-                );
-
-                let mesh = build_bevy_mesh(mesh_data);
+                let mesh_data = chunk_mesh_data(&heightmap, terrain, chunk.chunk_x, chunk.chunk_z);
+                let colors = chunk_vertex_colors(terrain, &store, &paint, &mesh_data.grid);
+                let mesh = build_bevy_mesh(mesh_data, colors);
                 mesh3d.0 = meshes.add(mesh);
             }
         }
     }
 }
 
-fn heightmap_from_terrain(terrain: &jackdaw_scene_types::Terrain) -> jackdaw_terrain::Heightmap {
+/// Build the heightmap a chunk mesh is generated from.
+///
+/// Heights come from the store, never from the component: the component's
+/// `heights` field is a legacy inlet that is empty on every terrain this
+/// build created. A terrain the store has never heard of (a missing
+/// sidecar) reads as flat, which is the documented fallback.
+pub(super) fn heightmap_from_terrain(
+    terrain: &jackdaw_scene_types::Terrain,
+    store: &TerrainDataStore,
+) -> jackdaw_terrain::Heightmap {
+    let mut heights = store.heights(&terrain.data_path).to_vec();
+    heights.resize(terrain.cell_count(), 0.0);
     jackdaw_terrain::Heightmap {
         resolution: terrain.resolution,
         size: terrain.size,
         max_height: terrain.max_height,
-        heights: terrain.heights.clone(),
+        heights,
     }
 }
 
-fn build_bevy_mesh(data: jackdaw_terrain::ChunkMeshData) -> Mesh {
+/// Pick the mesher this terrain is drawn with.
+///
+/// A quantized terrain is meshed flat: its heights sit on an elevation
+/// lattice, and the smooth mesher's central-difference normals blend
+/// straight across the risers, so the terracing that is in the data
+/// never reaches the screen. Everything else is meshed exactly as
+/// before.
+fn chunk_mesh_data(
+    heightmap: &jackdaw_terrain::Heightmap,
+    terrain: &jackdaw_scene_types::Terrain,
+    chunk_x: u32,
+    chunk_z: u32,
+) -> jackdaw_terrain::ChunkMeshData {
+    if terrain.quantization.enabled {
+        jackdaw_terrain::build_chunk_mesh_data_flat(heightmap, chunk_x, chunk_z, CHUNK_SIZE)
+    } else {
+        jackdaw_terrain::build_chunk_mesh_data(heightmap, chunk_x, chunk_z, CHUNK_SIZE)
+    }
+}
+
+/// Colour every vertex of a chunk by what is painted under it.
+///
+/// This is jackdaw's answer to `Terrain3D`'s control-texture debug view:
+/// without it the user is painting data they cannot see. Off, or with no
+/// channel selected, every vertex is [`UNPAINTED`] and the terrain looks
+/// exactly as it did before channels existed.
+///
+/// The colours are derived from `grid` -- the grid coordinate the mesher
+/// recorded for each vertex it emitted -- rather than by re-walking the
+/// chunk window here. The smooth and flat meshers emit different vertex
+/// counts in different orders, and a second walk would have to guess
+/// which one ran; reading their own record cannot fall out of step.
+/// Values the palette does not name draw as unpainted rather than as an
+/// error colour: an unnamed value is data the project has not described
+/// yet, not a fault.
+fn chunk_vertex_colors(
+    terrain: &jackdaw_scene_types::Terrain,
+    store: &TerrainDataStore,
+    paint: &TerrainPaintState,
+    grid: &[[u32; 2]],
+) -> Vec<[f32; 4]> {
+    let res = terrain.resolution;
+    let descriptor = terrain.channels.get(paint.active_channel);
+    let values = store
+        .get(&terrain.data_path)
+        .and_then(|data| data.channels.get(paint.active_channel));
+    let (Some(descriptor), Some(values)) = (descriptor, values) else {
+        return vec![UNPAINTED; grid.len()];
+    };
+    if !paint.show_channel {
+        return vec![UNPAINTED; grid.len()];
+    }
+
+    grid.iter()
+        .map(|[gx, gz]| {
+            descriptor
+                .color_of(values.get(res, *gx, *gz))
+                .map(|color| color.to_linear().to_f32_array())
+                .unwrap_or(UNPAINTED)
+        })
+        .collect()
+}
+
+fn build_bevy_mesh(data: jackdaw_terrain::ChunkMeshData, colors: Vec<[f32; 4]>) -> Mesh {
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, default());
+    debug_assert_eq!(
+        colors.len(),
+        data.positions.len(),
+        "vertex colours must be emitted in the same order and count as positions",
+    );
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, data.positions);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, data.normals);
     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, data.uvs);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
     mesh.insert_indices(Indices::U32(data.indices));
     mesh
 }

--- a/src/terrain/mesh.rs
+++ b/src/terrain/mesh.rs
@@ -204,8 +204,7 @@ fn chunk_mesh_data(
 
 /// Colour every vertex of a chunk by what is painted under it.
 ///
-/// This is jackdaw's answer to `Terrain3D`'s control-texture debug view:
-/// without it the user is painting data they cannot see. Off, or with no
+/// Without it the user is painting data they cannot see. Off, or with no
 /// channel selected, every vertex is [`UNPAINTED`] and the terrain looks
 /// exactly as it did before channels existed.
 ///

--- a/src/terrain/mesh.rs
+++ b/src/terrain/mesh.rs
@@ -137,13 +137,17 @@ fn initialize_terrain_chunks(
 
 /// Rebuild meshes for chunks in the dirty set.
 fn rebuild_dirty_chunks(
-    mut terrains: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrains: Query<(
+        Entity,
+        &jackdaw_scene_types::Terrain,
+        &mut TerrainDirtyChunks,
+    )>,
     mut chunks: Query<(&TerrainChunk, &mut Mesh3d)>,
     mut meshes: ResMut<Assets<Mesh>>,
     store: Res<TerrainDataStore>,
     paint: Res<TerrainPaintState>,
 ) {
-    for (terrain, mut dirty) in &mut terrains {
+    for (terrain_entity, terrain, mut dirty) in &mut terrains {
         if dirty.dirty.is_empty() {
             continue;
         }
@@ -151,8 +155,15 @@ fn rebuild_dirty_chunks(
         let heightmap = heightmap_from_terrain(terrain, &store);
         let dirty_set: Vec<(u32, u32)> = dirty.dirty.drain().collect();
 
+        // Chunk coordinates are small integers starting at (0, 0) for
+        // every terrain, so two terrains routinely share a (chunk_x,
+        // chunk_z) pair. Without the owner filter, a coordinate match
+        // alone would rebuild another terrain's chunk with this
+        // terrain's heightmap.
         for (chunk, mut mesh3d) in &mut chunks {
-            if dirty_set.contains(&(chunk.chunk_x, chunk.chunk_z)) {
+            if chunk.terrain_entity == terrain_entity
+                && dirty_set.contains(&(chunk.chunk_x, chunk.chunk_z))
+            {
                 let mesh_data = chunk_mesh_data(&heightmap, terrain, chunk.chunk_x, chunk.chunk_z);
                 let colors = chunk_vertex_colors(terrain, &store, &paint, &mesh_data.grid);
                 let mesh = build_bevy_mesh(mesh_data, colors);
@@ -258,4 +269,110 @@ fn build_bevy_mesh(data: jackdaw_terrain::ChunkMeshData, colors: Vec<[f32; 4]>) 
     mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
     mesh.insert_indices(Indices::U32(data.indices));
     mesh
+}
+
+#[cfg(test)]
+mod rebuild_dirty_chunks_tests {
+    use jackdaw_terrain::TerrainData;
+
+    use super::*;
+
+    fn terrain(data_path: &str) -> jackdaw_scene_types::Terrain {
+        jackdaw_scene_types::Terrain {
+            resolution: 2,
+            size: Vec2::splat(2.0),
+            data_path: data_path.to_string(),
+            ..default()
+        }
+    }
+
+    fn placeholder_mesh() -> Mesh {
+        Mesh::new(PrimitiveTopology::TriangleList, default())
+    }
+
+    /// I6 pinning test, the exact scenario from the review finding: two
+    /// terrains whose chunk grids both start at (0, 0) share that
+    /// coordinate. Only one of them is dirty; before the owner filter,
+    /// the coordinate-only match rebuilt the other terrain's chunk too,
+    /// with the wrong terrain's heightmap.
+    #[test]
+    fn a_coordinate_match_on_another_terrains_chunk_is_left_alone() {
+        let mut world = World::new();
+        world.insert_resource(Assets::<Mesh>::default());
+        world.insert_resource(TerrainPaintState::default());
+
+        let mut store = TerrainDataStore::default();
+        store.insert(
+            "a.jdterrain",
+            TerrainData {
+                resolution: 2,
+                heights: vec![1.0; 4],
+                channels: vec![],
+            },
+        );
+        store.insert(
+            "b.jdterrain",
+            TerrainData {
+                resolution: 2,
+                heights: vec![9.0; 4],
+                channels: vec![],
+            },
+        );
+        world.insert_resource(store);
+
+        let terrain_a = world.spawn(terrain("a.jdterrain")).id();
+        let terrain_b = world.spawn(terrain("b.jdterrain")).id();
+
+        let mut dirty_a = TerrainDirtyChunks::default();
+        dirty_a.dirty.insert((0, 0));
+        world.entity_mut(terrain_a).insert(dirty_a);
+        world
+            .entity_mut(terrain_b)
+            .insert(TerrainDirtyChunks::default());
+
+        let b_original_handle = {
+            let mut meshes = world.resource_mut::<Assets<Mesh>>();
+            meshes.add(placeholder_mesh())
+        };
+        let chunk_b = world
+            .spawn((
+                TerrainChunk {
+                    terrain_entity: terrain_b,
+                    chunk_x: 0,
+                    chunk_z: 0,
+                },
+                Mesh3d(b_original_handle.clone()),
+            ))
+            .id();
+
+        let a_original_handle = {
+            let mut meshes = world.resource_mut::<Assets<Mesh>>();
+            meshes.add(placeholder_mesh())
+        };
+        let chunk_a = world
+            .spawn((
+                TerrainChunk {
+                    terrain_entity: terrain_a,
+                    chunk_x: 0,
+                    chunk_z: 0,
+                },
+                Mesh3d(a_original_handle.clone()),
+            ))
+            .id();
+
+        world
+            .run_system_cached(rebuild_dirty_chunks)
+            .expect("system runs");
+
+        assert_eq!(
+            world.get::<Mesh3d>(chunk_b).unwrap().0,
+            b_original_handle,
+            "terrain B's chunk was not dirty and must keep its original mesh",
+        );
+        assert_ne!(
+            world.get::<Mesh3d>(chunk_a).unwrap().0,
+            a_original_handle,
+            "terrain A's chunk was dirty and must have been rebuilt",
+        );
+    }
 }

--- a/src/terrain/mesh.rs
+++ b/src/terrain/mesh.rs
@@ -204,7 +204,8 @@ fn chunk_mesh_data(
 
 /// Colour every vertex of a chunk by what is painted under it.
 ///
-/// Without it the user is painting data they cannot see. Off, or with no
+/// This is jackdaw's answer to `Terrain3D`'s control-texture debug view:
+/// without it the user is painting data they cannot see. Off, or with no
 /// channel selected, every vertex is [`UNPAINTED`] and the terrain looks
 /// exactly as it did before channels existed.
 ///

--- a/src/terrain/mod.rs
+++ b/src/terrain/mod.rs
@@ -1,13 +1,21 @@
+pub mod channel_ops;
+pub mod export;
 pub mod inspector;
 pub mod mesh;
 pub mod ops;
+pub mod paint;
+pub mod quantize_ops;
+pub mod scatter;
 pub mod sculpt;
+pub mod store;
 pub mod toolbar;
 
 use std::collections::HashSet;
 
 use bevy::prelude::*;
 
+pub use paint::TerrainPaintState;
+pub use store::TerrainDataStore;
 pub use toolbar::TerrainToolbar;
 
 pub struct TerrainPlugin;
@@ -19,13 +27,18 @@ impl Plugin for TerrainPlugin {
         app.init_resource::<TerrainEditMode>()
             .init_resource::<TerrainBrushSettings>()
             .init_resource::<TerrainSculptState>()
+            .init_resource::<TerrainDataStore>()
             .add_systems(
                 Update,
-                ensure_terrain_dirty_chunks.run_if(in_state(crate::AppState::Editor)),
+                (ensure_terrain_dirty_chunks, ensure_terrain_data_path)
+                    .chain()
+                    .run_if(in_state(crate::AppState::Editor)),
             )
             .add_plugins((
                 mesh::plugin,
                 sculpt::plugin,
+                paint::plugin,
+                scatter::plugin,
                 toolbar::plugin,
                 inspector::plugin,
             ));
@@ -51,6 +64,84 @@ fn ensure_terrain_dirty_chunks(
             rebuild_all: true,
             ..default()
         });
+    }
+}
+
+/// Give every terrain a sidecar path and a store entry.
+///
+/// One system covers every way a terrain can appear -- the add-entity
+/// operator, a paste, a duplicate, a legacy scene with no `data_path` --
+/// so no spawn site has to remember to do it. Terrains that already carry
+/// a path are left alone, which is what makes this cheap enough to run
+/// every frame.
+///
+/// A duplicated terrain arrives carrying the original's `data_path`. That
+/// would silently alias two terrains onto one heightmap, so the copy is
+/// re-keyed here and the original's data is cloned into the new key.
+fn ensure_terrain_data_path(world: &mut World) {
+    let mut query = world.query::<(Entity, &jackdaw_scene_types::Terrain)>();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut needs_path: Vec<(Entity, Option<String>)> = Vec::new();
+    for (entity, terrain) in query.iter(world) {
+        if terrain.data_path.is_empty() {
+            needs_path.push((entity, None));
+        } else if !seen.insert(terrain.data_path.clone()) {
+            needs_path.push((entity, Some(terrain.data_path.clone())));
+        }
+    }
+    if needs_path.is_empty() {
+        return;
+    }
+
+    let stem = store::active_scene_stem(world);
+    for (entity, aliased) in needs_path {
+        let minted = {
+            let store = world.resource::<TerrainDataStore>();
+            store::mint_data_path(store, &stem)
+        };
+        // A duplicate starts from the original's data rather than flat
+        // ground: the user copied a shape, not an empty terrain.
+        let cloned =
+            aliased.and_then(|from| world.resource::<TerrainDataStore>().get(&from).cloned());
+        {
+            let mut store = world.resource_mut::<TerrainDataStore>();
+            match cloned {
+                Some(data) => store.insert(minted.clone(), data),
+                None => {
+                    if !store.contains(&minted) {
+                        store.insert(minted.clone(), jackdaw_terrain::TerrainData::default());
+                    }
+                }
+            }
+        }
+        let Some(mut terrain) = world.get_mut::<jackdaw_scene_types::Terrain>(entity) else {
+            continue;
+        };
+        terrain.data_path = minted;
+        // Drain any legacy inline heights the same pass, so a scene
+        // authored before the sidecar existed keeps its shape.
+        let legacy = std::mem::take(&mut terrain.heights);
+        let terrain = terrain.clone();
+        {
+            let mut store = world.resource_mut::<TerrainDataStore>();
+            if let Some(data) = store.entry_for(&terrain)
+                && !legacy.is_empty()
+            {
+                data.heights = legacy;
+                data.normalize();
+            }
+        }
+        // The document is the save-time source of truth, so the emptied
+        // heights and the new path have to reach it explicitly.
+        crate::commands::sync_component_to_ast(
+            world,
+            entity,
+            "jackdaw_scene_types::types::Terrain",
+            &terrain,
+        );
+        if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(entity) {
+            dirty.rebuild_all = true;
+        }
     }
 }
 
@@ -82,6 +173,8 @@ pub enum TerrainEditMode {
     #[default]
     None,
     Sculpt(jackdaw_terrain::SculptTool),
+    /// Stamping palette values into the active paint channel.
+    Paint,
     Generate,
 }
 

--- a/src/terrain/mod.rs
+++ b/src/terrain/mod.rs
@@ -178,6 +178,91 @@ pub enum TerrainEditMode {
     Generate,
 }
 
+impl TerrainEditMode {
+    /// Whether the brush (sculpt or paint) is the active tool and should
+    /// own viewport input: entity click-select, gizmo drag, and
+    /// Shift+Scroll grid resize all defer to it. `Generate` and `None`
+    /// do not claim the viewport this way.
+    ///
+    /// One predicate for every mode guard that used to check `Sculpt(_)`
+    /// alone: each left `Paint` unguarded, so painting could select
+    /// entities out from under the brush, drag the gizmo, or resize the
+    /// snap grid mid-stroke.
+    pub fn brush_active(&self) -> bool {
+        matches!(self, Self::Sculpt(_) | Self::Paint)
+    }
+}
+
+#[cfg(test)]
+mod terrain_edit_mode_tests {
+    use super::*;
+
+    /// I4 pinning test, the exact scenario from the review finding: every
+    /// mode guard that special-cased `Sculpt(_)` alone left `Paint`
+    /// unguarded.
+    #[test]
+    fn brush_active_covers_both_sculpt_and_paint() {
+        assert!(TerrainEditMode::Sculpt(jackdaw_terrain::SculptTool::Raise).brush_active());
+        assert!(TerrainEditMode::Paint.brush_active());
+    }
+
+    #[test]
+    fn brush_active_excludes_generate_and_none() {
+        assert!(!TerrainEditMode::None.brush_active());
+        assert!(!TerrainEditMode::Generate.brush_active());
+    }
+}
+
+/// Whether a brush-modal stroke (`terrain.sculpt`, `terrain.paint`)
+/// should end this frame.
+///
+/// Level state (`pressed`), not a `just_released` edge -- and meant to
+/// be checked unconditionally every frame the modal runs, including its
+/// first, when `ActiveModalOperator` has not been attached yet. A press
+/// and release that land within the same input frame set `just_released`
+/// on that very first frame; a modal that only checks the edge once
+/// `ActiveModalOperator` exists (i.e. on later frames, gated behind an
+/// `else` on the initialization branch) never observes it, and the
+/// brush keeps applying every frame with no way to stop.
+pub(crate) fn stroke_should_end(mouse: &bevy::input::ButtonInput<MouseButton>) -> bool {
+    !mouse.pressed(MouseButton::Left)
+}
+
+#[cfg(test)]
+mod stroke_should_end_tests {
+    use bevy::input::ButtonInput;
+
+    use super::*;
+
+    /// I5 pinning test, the exact scenario from the review finding: a
+    /// press and release that both land within one input frame (before
+    /// `ButtonInput::clear` runs) must still read as "should end" --
+    /// `pressed()` is already false, unlike `just_released()`, which
+    /// depends on which frame happens to check it.
+    #[test]
+    fn a_press_and_release_within_one_frame_still_ends_the_stroke() {
+        let mut mouse = ButtonInput::<MouseButton>::default();
+        mouse.press(MouseButton::Left);
+        mouse.release(MouseButton::Left);
+
+        assert!(mouse.just_released(MouseButton::Left));
+        assert!(stroke_should_end(&mouse));
+    }
+
+    #[test]
+    fn a_held_button_does_not_end_the_stroke() {
+        let mut mouse = ButtonInput::<MouseButton>::default();
+        mouse.press(MouseButton::Left);
+        assert!(!stroke_should_end(&mouse));
+    }
+
+    #[test]
+    fn a_button_that_was_never_pressed_ends_the_stroke() {
+        let mouse = ButtonInput::<MouseButton>::default();
+        assert!(stroke_should_end(&mouse));
+    }
+}
+
 /// Brush settings for terrain sculpting.
 #[derive(Resource)]
 pub struct TerrainBrushSettings {

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -5,7 +5,7 @@ use jackdaw_api::prelude::*;
 
 use super::inspector::TerrainGenerateState;
 use super::sculpt::SetTerrainHeights;
-use super::{TerrainDirtyChunks, TerrainEditMode};
+use super::{TerrainDataStore, TerrainDirtyChunks, TerrainEditMode};
 use crate::commands::CommandHistory;
 use crate::selection::Selection;
 
@@ -30,7 +30,7 @@ fn toggle_to(mode: &mut TerrainEditMode, target: TerrainEditMode) {
 
 /// Tool-toggle ops require a terrain to be selected; otherwise the
 /// toolbar that hosts these buttons is hidden anyway.
-fn has_selected_terrain(
+pub(super) fn has_selected_terrain(
     selection: Res<Selection>,
     terrains: Query<(), With<jackdaw_scene_types::Terrain>>,
 ) -> bool {
@@ -159,23 +159,31 @@ pub(crate) fn terrain_tool_generate(
 pub(crate) fn terrain_generate(
     _: In<OperatorParameters>,
     selection: Res<Selection>,
-    mut terrains: Query<(&mut jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrains: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut store: ResMut<TerrainDataStore>,
     gen_state: Res<TerrainGenerateState>,
     mut history: ResMut<CommandHistory>,
 ) -> OperatorResult {
     let entity = selection.primary()?;
-    let (mut terrain, mut dirty) = terrains.get_mut(entity)?;
+    let (terrain, mut dirty) = terrains.get_mut(entity)?;
 
-    let old_heights = terrain.heights.clone();
-    let new_heights = jackdaw_terrain::generate_heightmap(terrain.resolution, &gen_state.settings);
-    terrain.heights = new_heights.clone();
+    let mut new_heights =
+        jackdaw_terrain::generate_heightmap(terrain.resolution, &gen_state.settings);
+    // Snap before the array is stored or recorded, so the terrain is
+    // never briefly off-lattice and undo never restores an unsnapped
+    // intermediate that was not on screen.
+    if let Some(step) = terrain.quantization.active_height_step() {
+        jackdaw_terrain::quantize_heights(&mut new_heights, step);
+    }
+    let data = store.entry_for(terrain)?;
+    let old_heights = std::mem::replace(&mut data.heights, new_heights.clone());
     dirty.rebuild_all = true;
-    history.push_executed(Box::new(SetTerrainHeights {
+    history.push_executed(Box::new(SetTerrainHeights::new(
         entity,
         old_heights,
         new_heights,
-        label: "Generate Terrain".to_string(),
-    }));
+        "Generate Terrain".to_string(),
+    )));
     OperatorResult::Finished
 }
 
@@ -196,23 +204,33 @@ pub(crate) fn terrain_generate(
 pub(crate) fn terrain_erode(
     _: In<OperatorParameters>,
     selection: Res<Selection>,
-    mut terrains: Query<(&mut jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrains: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut store: ResMut<TerrainDataStore>,
     gen_state: Res<TerrainGenerateState>,
     mut history: ResMut<CommandHistory>,
 ) -> OperatorResult {
     let entity = selection.primary()?;
-    let (mut terrain, mut dirty) = terrains.get_mut(entity)?;
+    let (terrain, mut dirty) = terrains.get_mut(entity)?;
+    let resolution = terrain.resolution;
+    let step = terrain.quantization.active_height_step();
+    let data = store.entry_for(terrain)?;
 
-    let old_heights = terrain.heights.clone();
-    let mut new_heights = terrain.heights.clone();
-    jackdaw_terrain::hydraulic_erosion(&mut new_heights, terrain.resolution, &gen_state.erosion);
-    terrain.heights = new_heights.clone();
+    let old_heights = data.heights.clone();
+    let mut new_heights = data.heights.clone();
+    jackdaw_terrain::hydraulic_erosion(&mut new_heights, resolution, &gen_state.erosion);
+    // Erosion moves sediment in continuous amounts, so on a quantized
+    // terrain it is re-snapped whole: without this a single erode pass
+    // silently takes every cell off the lattice.
+    if let Some(step) = step {
+        jackdaw_terrain::quantize_heights(&mut new_heights, step);
+    }
+    data.heights = new_heights.clone();
     dirty.rebuild_all = true;
-    history.push_executed(Box::new(SetTerrainHeights {
+    history.push_executed(Box::new(SetTerrainHeights::new(
         entity,
         old_heights,
         new_heights,
-        label: "Erode Terrain".to_string(),
-    }));
+        "Erode Terrain".to_string(),
+    )));
     OperatorResult::Finished
 }

--- a/src/terrain/ops.rs
+++ b/src/terrain/ops.rs
@@ -147,9 +147,12 @@ pub(crate) fn terrain_tool_generate(
 /// Reads the noise/octaves/etc. settings from the inspector's
 /// generation panel ([`TerrainGenerateState`]).
 ///
-/// `allows_undo = false` because this op pushes its own
-/// [`SetTerrainHeights`] history entry; letting the framework also
-/// capture a diff would double-record the change.
+/// `allows_undo` is left at its default (`true`), not set to `false`:
+/// this op pushes its own [`SetTerrainHeights`] history entry, but that
+/// entry only ever touches heights, which live outside the AST (see
+/// `store.rs`'s module doc). The framework's automatic before/after
+/// snapshot diff sees no change there and skips recording a duplicate,
+/// per CONTRIBUTING's note on `push_executed`.
 #[operator(
     id = "terrain.generate",
     label = "Generate Terrain",
@@ -192,9 +195,12 @@ pub(crate) fn terrain_generate(
 /// Uses the erosion settings from the inspector's generation panel
 /// ([`TerrainGenerateState::erosion`]).
 ///
-/// `allows_undo = false` because this op pushes its own
-/// [`SetTerrainHeights`] history entry; letting the framework also
-/// capture a diff would double-record the change.
+/// `allows_undo` is left at its default (`true`), not set to `false`:
+/// this op pushes its own [`SetTerrainHeights`] history entry, but that
+/// entry only ever touches heights, which live outside the AST (see
+/// `store.rs`'s module doc). The framework's automatic before/after
+/// snapshot diff sees no change there and skips recording a duplicate,
+/// per CONTRIBUTING's note on `push_executed`.
 #[operator(
     id = "terrain.erode",
     label = "Erode Terrain",

--- a/src/terrain/paint.rs
+++ b/src/terrain/paint.rs
@@ -2,12 +2,15 @@
 //!
 //! Mirrors [`super::sculpt`] exactly: a modal operator driven by LMB, one
 //! history entry pushed on release, Escape restoring the pre-stroke
-//! snapshot, and Shift+scroll resizing the same brush. One brush idiom
-//! covers both modes.
+//! snapshot, and Shift+scroll resizing the same brush. Sculpt and paint
+//! share one brush idiom because that is what the tools people arrive
+//! from do -- Unity, Unreal and `Terrain3D` all use one set of brush
+//! controls across their terrain modes.
 //!
 //! The values are integers, so the brush is a threshold stamp rather than
 //! an accumulation: a cell inside the falloff is written, a cell outside
-//! is left alone. Holding Ctrl paints 0, the erase gesture.
+//! is left alone. Holding Ctrl paints 0 -- the erase gesture every one of
+//! those tools has and jackdaw did not.
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
@@ -49,8 +52,13 @@ pub struct TerrainPaintState {
     pub active_entry: usize,
     /// Tint the terrain by the active channel.
     ///
-    /// On by default: without it the user is painting invisible data. A
-    /// terrain with no channels is unaffected.
+    /// `Terrain3D` calls this a control-texture debug view and it is the
+    /// single most borrowable thing in the reference set: without it a
+    /// user is painting invisible data.
+    ///
+    /// On by default. A terrain with no channels is unaffected, and for
+    /// one that has them the alternative is opening a painted scene,
+    /// seeing flat grey, and concluding nothing was ever painted.
     pub show_channel: bool,
     /// The terrain the brush is over.
     pub target: Option<Entity>,
@@ -216,9 +224,7 @@ fn paint_invoke_trigger(
 #[operator(
     id = "terrain.paint",
     label = "Paint Terrain",
-    description = "Stamp the active channel value while LMB is held. Modal: commits \
-                   the change as a single undo entry on release; Escape restores \
-                   the pre-stroke values. Hold Ctrl to erase.",
+    description = "Paint the active channel under the brush, or erase it while holding Ctrl.",
     modal = true,
     allows_undo = false,
     cancel = cancel_terrain_paint,

--- a/src/terrain/paint.rs
+++ b/src/terrain/paint.rs
@@ -1,0 +1,482 @@
+//! Painting per-cell integer values into a terrain's channels.
+//!
+//! Mirrors [`super::sculpt`] exactly: a modal operator driven by LMB, one
+//! history entry pushed on release, Escape restoring the pre-stroke
+//! snapshot, and Shift+scroll resizing the same brush. One brush idiom
+//! covers both modes.
+//!
+//! The values are integers, so the brush is a threshold stamp rather than
+//! an accumulation: a cell inside the falloff is written, a cell outside
+//! is left alone. Holding Ctrl paints 0, the erase gesture.
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::lifecycle::ActiveModalOperator;
+
+use super::{
+    CHUNK_SIZE, TerrainBrushSettings, TerrainDataStore, TerrainDirtyChunks, TerrainEditMode,
+};
+use crate::commands::{CommandHistory, EditorCommand};
+use crate::default_style;
+use crate::selection::Selection;
+
+pub(super) fn plugin(app: &mut App) {
+    app.init_resource::<TerrainPaintState>().add_systems(
+        Update,
+        (
+            update_paint_brush_position,
+            paint_invoke_trigger,
+            handle_paint_resize_scroll,
+            draw_paint_brush_gizmo,
+        )
+            .chain()
+            .run_if(in_state(crate::AppState::Editor)),
+    );
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<TerrainPaintOp>();
+    ctx.register_operator::<TerrainToolPaintOp>();
+}
+
+/// Which channel and value the paint brush writes, and whether the
+/// viewport is showing what has been painted.
+#[derive(Resource)]
+pub struct TerrainPaintState {
+    /// Index into the terrain's channel table.
+    pub active_channel: usize,
+    /// Index into that channel's palette.
+    pub active_entry: usize,
+    /// Tint the terrain by the active channel.
+    ///
+    /// On by default: without it the user is painting invisible data. A
+    /// terrain with no channels is unaffected.
+    pub show_channel: bool,
+    /// The terrain the brush is over.
+    pub target: Option<Entity>,
+    /// Whether a stroke is in progress (LMB held).
+    pub active: bool,
+    /// Values of the painted channel at stroke start, for undo.
+    pub stroke_snapshot: Vec<u16>,
+    /// Which channel the in-progress stroke is writing.
+    pub stroke_channel: usize,
+    /// Brush position in grid space.
+    pub brush_position: Option<Vec2>,
+}
+
+impl Default for TerrainPaintState {
+    fn default() -> Self {
+        Self {
+            active_channel: 0,
+            active_entry: 0,
+            show_channel: true,
+            target: None,
+            active: false,
+            stroke_snapshot: Vec::new(),
+            stroke_channel: 0,
+            brush_position: None,
+        }
+    }
+}
+
+impl TerrainPaintState {
+    /// The value the brush writes for a terrain, honouring the erase
+    /// modifier. `None` when the terrain declares no usable channel.
+    pub fn value_for(&self, terrain: &jackdaw_scene_types::Terrain, erase: bool) -> Option<u16> {
+        let channel = terrain.channels.get(self.active_channel)?;
+        if erase {
+            return Some(0);
+        }
+        Some(
+            channel
+                .palette
+                .get(self.active_entry)
+                .map(|entry| entry.value)
+                .unwrap_or(0),
+        )
+    }
+}
+
+/// Undo command for a paint stroke.
+///
+/// Deliberately does not touch the scene document. Channel values are
+/// bulk per-cell data and live in the sidecar store, the same as heights;
+/// pushing them through the BSN AST is the defect the sidecar fixes.
+pub struct SetTerrainChannel {
+    pub entity: Entity,
+    pub channel: usize,
+    pub old_values: Vec<u16>,
+    pub new_values: Vec<u16>,
+    pub label: String,
+}
+
+impl SetTerrainChannel {
+    fn apply(&self, world: &mut World, values: &[u16]) {
+        let Some(terrain) = world.get::<jackdaw_scene_types::Terrain>(self.entity) else {
+            return;
+        };
+        let terrain = terrain.clone();
+        if let Some(data) = world.resource_mut::<TerrainDataStore>().entry_for(&terrain)
+            && let Some(channel) = data.channels.get_mut(self.channel)
+        {
+            channel.values = values.to_vec();
+            channel.resize_to(terrain.resolution);
+        }
+        if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
+            dirty.rebuild_all = true;
+        }
+    }
+}
+
+impl EditorCommand for SetTerrainChannel {
+    fn execute(&mut self, world: &mut World) {
+        self.apply(world, &self.new_values.clone());
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        self.apply(world, &self.old_values.clone());
+    }
+
+    fn description(&self) -> &str {
+        &self.label
+    }
+}
+
+/// Pick the paint tool. Pressing again puts the brush away.
+#[operator(
+    id = "terrain.tool.paint",
+    label = "Paint",
+    description = "Paint the active channel's selected value onto the terrain.",
+    is_available = super::ops::has_selected_terrain
+)]
+pub(crate) fn terrain_tool_paint(
+    _: In<OperatorParameters>,
+    mut mode: ResMut<TerrainEditMode>,
+) -> OperatorResult {
+    *mode = if *mode == TerrainEditMode::Paint {
+        TerrainEditMode::None
+    } else {
+        TerrainEditMode::Paint
+    };
+    OperatorResult::Finished
+}
+
+/// Track the brush target so the ring gizmo follows the cursor even
+/// between strokes.
+fn update_paint_brush_position(
+    edit_mode: Res<TerrainEditMode>,
+    vp: crate::viewport::ViewportCursor,
+    terrain_query: Query<(Entity, &jackdaw_scene_types::Terrain, &GlobalTransform)>,
+    selection: Res<Selection>,
+    mut paint_state: ResMut<TerrainPaintState>,
+) {
+    if *edit_mode != TerrainEditMode::Paint {
+        if paint_state.brush_position.is_some() || paint_state.target.is_some() {
+            paint_state.brush_position = None;
+            paint_state.target = None;
+        }
+        return;
+    }
+    match super::sculpt::terrain_brush_hit(&vp, &terrain_query, &selection) {
+        Some((entity, grid)) => {
+            paint_state.target = Some(entity);
+            paint_state.brush_position = Some(grid);
+        }
+        None => paint_state.brush_position = None,
+    }
+}
+
+/// LMB in paint mode dispatches `terrain.paint`. Mouse-button gestures
+/// are not expressible as BEI key bindings.
+fn paint_invoke_trigger(
+    mouse: Res<ButtonInput<MouseButton>>,
+    edit_mode: Res<TerrainEditMode>,
+    paint_state: Res<TerrainPaintState>,
+    mut commands: Commands,
+) {
+    if paint_state.active
+        || !mouse.just_pressed(MouseButton::Left)
+        || *edit_mode != TerrainEditMode::Paint
+        || paint_state.brush_position.is_none()
+        || paint_state.target.is_none()
+    {
+        return;
+    }
+    commands.queue(|world: &mut World| {
+        let _ = world
+            .operator(TerrainPaintOp::ID)
+            .settings(CallOperatorSettings {
+                execution_context: ExecutionContext::Invoke,
+                creates_history_entry: false,
+            })
+            .call();
+    });
+}
+
+#[operator(
+    id = "terrain.paint",
+    label = "Paint Terrain",
+    description = "Stamp the active channel value while LMB is held. Modal: commits \
+                   the change as a single undo entry on release; Escape restores \
+                   the pre-stroke values. Hold Ctrl to erase.",
+    modal = true,
+    allows_undo = false,
+    cancel = cancel_terrain_paint,
+)]
+pub fn terrain_paint(
+    _: In<OperatorParameters>,
+    mouse: Res<ButtonInput<MouseButton>>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    edit_mode: Res<TerrainEditMode>,
+    brush_settings: Res<TerrainBrushSettings>,
+    mut paint_state: ResMut<TerrainPaintState>,
+    terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut store: ResMut<TerrainDataStore>,
+    mut history: ResMut<CommandHistory>,
+    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+) -> OperatorResult {
+    if *edit_mode != TerrainEditMode::Paint {
+        return OperatorResult::Cancelled;
+    }
+    let mut terrain_query = terrain_query;
+    let target = paint_state.target?;
+    let (terrain, mut dirty) = terrain_query.get_mut(target)?;
+    let terrain = terrain.clone();
+
+    let erase = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
+    let value = paint_state.value_for(&terrain, erase)?;
+    let channel_index = if modal.is_none() {
+        paint_state.active_channel
+    } else {
+        paint_state.stroke_channel
+    };
+
+    let data = store.entry_for(&terrain)?;
+    let channel = data.channels.get_mut(channel_index)?;
+
+    if modal.is_none() {
+        paint_state.active = true;
+        paint_state.stroke_channel = channel_index;
+        paint_state.stroke_snapshot = channel.values.clone();
+    } else if mouse.just_released(MouseButton::Left) {
+        paint_state.active = false;
+        let old_values = std::mem::take(&mut paint_state.stroke_snapshot);
+        // A stroke that changed nothing (repainting a value onto itself)
+        // must not leave an empty entry cluttering the undo stack.
+        if old_values != channel.values {
+            history.push_executed(Box::new(SetTerrainChannel {
+                entity: target,
+                channel: channel_index,
+                old_values,
+                new_values: channel.values.clone(),
+                label: format!("Paint {}", channel.name),
+            }));
+        }
+        return OperatorResult::Finished;
+    }
+
+    if let Some(grid_pos) = paint_state.brush_position {
+        let changed = jackdaw_terrain::apply_channel_brush(
+            &mut channel.values,
+            terrain.resolution,
+            channel.element,
+            grid_pos,
+            brush_settings.radius,
+            brush_settings.falloff,
+            PAINT_THRESHOLD,
+            value,
+        );
+        if changed > 0 {
+            // Only the chunks the stroke touched, never `rebuild_all`.
+            for chunk in jackdaw_terrain::affected_chunks_at(
+                terrain.resolution,
+                grid_pos,
+                brush_settings.radius,
+                CHUNK_SIZE,
+            ) {
+                dirty.dirty.insert(chunk);
+            }
+        }
+    }
+    OperatorResult::Running
+}
+
+/// Falloff a cell must clear to be written.
+///
+/// Integer channels cannot blend, so a soft brush edge has to become a
+/// hard decision somewhere. Half-strength is the natural place: the
+/// painted disc matches the visible ring's half-intensity contour, which
+/// is what a user reads the ring as meaning.
+const PAINT_THRESHOLD: f32 = 0.5;
+
+fn cancel_terrain_paint(
+    mut paint_state: ResMut<TerrainPaintState>,
+    terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut store: ResMut<TerrainDataStore>,
+) {
+    if !paint_state.active {
+        return;
+    }
+    paint_state.active = false;
+    let snapshot = std::mem::take(&mut paint_state.stroke_snapshot);
+    let channel_index = paint_state.stroke_channel;
+    let mut terrain_query = terrain_query;
+    if let Some(target) = paint_state.target
+        && let Ok((terrain, mut dirty)) = terrain_query.get_mut(target)
+    {
+        let terrain = terrain.clone();
+        if let Some(data) = store.entry_for(&terrain)
+            && let Some(channel) = data.channels.get_mut(channel_index)
+        {
+            channel.values = snapshot;
+            channel.resize_to(terrain.resolution);
+        }
+        dirty.rebuild_all = true;
+    }
+}
+
+/// Shift+scroll resizes the paint brush exactly as it resizes the sculpt
+/// brush, so the gesture does not change meaning between modes.
+fn handle_paint_resize_scroll(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    nav_scroll: crate::modal_inputs::NavScrollInputs,
+    edit_mode: Res<TerrainEditMode>,
+    mut brush_settings: ResMut<TerrainBrushSettings>,
+) {
+    if *edit_mode != TerrainEditMode::Paint
+        || !keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight])
+    {
+        return;
+    }
+    if nav_scroll.resize_up() {
+        brush_settings.radius = f32::min(brush_settings.radius * 1.15, 50.0);
+    } else if nav_scroll.resize_down() {
+        brush_settings.radius = f32::max(brush_settings.radius * 0.87, 1.0);
+    }
+}
+
+/// Ring gizmo following the terrain surface, in the active palette
+/// colour so the user can see what they are about to lay down.
+fn draw_paint_brush_gizmo(
+    paint_state: Res<TerrainPaintState>,
+    brush_settings: Res<TerrainBrushSettings>,
+    edit_mode: Res<TerrainEditMode>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    terrains: Query<(&jackdaw_scene_types::Terrain, &GlobalTransform)>,
+    store: Res<TerrainDataStore>,
+    mut gizmos: Gizmos,
+) {
+    if *edit_mode != TerrainEditMode::Paint {
+        return;
+    }
+    let (Some(target), Some(grid_pos)) = (paint_state.target, paint_state.brush_position) else {
+        return;
+    };
+    let Ok((terrain, terrain_tf)) = terrains.get(target) else {
+        return;
+    };
+
+    let erase = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
+    let color = if erase {
+        default_style::TERRAIN_SCULPT_GIZMO
+    } else {
+        terrain
+            .channels
+            .get(paint_state.active_channel)
+            .and_then(|channel| channel.palette.get(paint_state.active_entry))
+            .map(|entry| entry.color)
+            .unwrap_or(default_style::TERRAIN_SCULPT_GIZMO)
+    };
+
+    let heightmap = super::mesh::heightmap_from_terrain(terrain, &store);
+    let segments = 32;
+    let radius = brush_settings.radius;
+    let origin = terrain_tf.translation();
+    let cell = heightmap.cell_size();
+    let half = terrain.size / 2.0;
+
+    for i in 0..segments {
+        let a0 = (i as f32 / segments as f32) * std::f32::consts::TAU;
+        let a1 = ((i + 1) as f32 / segments as f32) * std::f32::consts::TAU;
+
+        let gx0 = grid_pos.x + a0.cos() * radius;
+        let gz0 = grid_pos.y + a0.sin() * radius;
+        let gx1 = grid_pos.x + a1.cos() * radius;
+        let gz1 = grid_pos.y + a1.sin() * radius;
+
+        let h0 = heightmap.sample_bilinear(gx0, gz0);
+        let h1 = heightmap.sample_bilinear(gx1, gz1);
+
+        let p0 = origin + Vec3::new(gx0 * cell.x - half.x, h0 + 0.1, gz0 * cell.y - half.y);
+        let p1 = origin + Vec3::new(gx1 * cell.x - half.x, h1 + 0.1, gz1 * cell.y - half.y);
+        gizmos.line(p0, p1, color);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement, TerrainPaletteEntry};
+
+    fn two_entry_terrain() -> jackdaw_scene_types::Terrain {
+        jackdaw_scene_types::Terrain {
+            channels: vec![TerrainChannel {
+                name: "biome".to_string(),
+                element: TerrainChannelElement::U8,
+                palette: vec![
+                    TerrainPaletteEntry {
+                        value: 0,
+                        label: "unset".to_string(),
+                        color: Color::BLACK,
+                    },
+                    TerrainPaletteEntry {
+                        value: 7,
+                        label: "marsh".to_string(),
+                        color: Color::WHITE,
+                    },
+                ],
+            }],
+            ..default()
+        }
+    }
+
+    #[test]
+    fn the_brush_writes_the_selected_palette_entrys_value() {
+        let state = TerrainPaintState {
+            active_entry: 1,
+            ..default()
+        };
+        assert_eq!(state.value_for(&two_entry_terrain(), false), Some(7));
+    }
+
+    /// Ctrl-held erases. Every reference tool binds Ctrl to the inverse
+    /// of the current brush; for an integer channel the inverse of
+    /// "write this value" is "write nothing here".
+    #[test]
+    fn ctrl_erases_regardless_of_the_selected_entry() {
+        let state = TerrainPaintState {
+            active_entry: 1,
+            ..default()
+        };
+        assert_eq!(state.value_for(&two_entry_terrain(), true), Some(0));
+    }
+
+    #[test]
+    fn a_terrain_with_no_channels_has_nothing_to_paint() {
+        let state = TerrainPaintState::default();
+        let bare = jackdaw_scene_types::Terrain::default();
+        assert_eq!(state.value_for(&bare, false), None);
+    }
+
+    /// An out-of-range palette index reads as 0 rather than panicking:
+    /// removing the selected entry from the palette must not take the
+    /// editor down on the next brush move.
+    #[test]
+    fn a_stale_palette_selection_falls_back_to_zero() {
+        let state = TerrainPaintState {
+            active_entry: 99,
+            ..default()
+        };
+        assert_eq!(state.value_for(&two_entry_terrain(), false), Some(0));
+    }
+}

--- a/src/terrain/paint.rs
+++ b/src/terrain/paint.rs
@@ -14,7 +14,6 @@
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 
 use super::{
     CHUNK_SIZE, TerrainBrushSettings, TerrainDataStore, TerrainDirtyChunks, TerrainEditMode,
@@ -239,7 +238,7 @@ pub fn terrain_paint(
     terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
     mut store: ResMut<TerrainDataStore>,
     mut history: ResMut<CommandHistory>,
-    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+    active: ActiveModalQuery,
 ) -> OperatorResult {
     if *edit_mode != TerrainEditMode::Paint {
         return OperatorResult::Cancelled;
@@ -251,16 +250,16 @@ pub fn terrain_paint(
 
     let erase = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
     let value = paint_state.value_for(&terrain, erase)?;
-    let channel_index = if modal.is_none() {
-        paint_state.active_channel
-    } else {
+    let channel_index = if active.is_modal_running() {
         paint_state.stroke_channel
+    } else {
+        paint_state.active_channel
     };
 
     let data = store.entry_for(&terrain)?;
     let channel = data.channels.get_mut(channel_index)?;
 
-    if modal.is_none() {
+    if !active.is_modal_running() {
         paint_state.active = true;
         paint_state.stroke_channel = channel_index;
         paint_state.stroke_snapshot = channel.values.clone();

--- a/src/terrain/paint.rs
+++ b/src/terrain/paint.rs
@@ -264,7 +264,11 @@ pub fn terrain_paint(
         paint_state.active = true;
         paint_state.stroke_channel = channel_index;
         paint_state.stroke_snapshot = channel.values.clone();
-    } else if mouse.just_released(MouseButton::Left) {
+    }
+
+    // See `super::stroke_should_end` doc: checked every frame, including
+    // the modal's first, not gated behind `else`/`modal.is_some()`.
+    if super::stroke_should_end(&mouse) {
         paint_state.active = false;
         let old_values = std::mem::take(&mut paint_state.stroke_snapshot);
         // A stroke that changed nothing (repainting a value onto itself)

--- a/src/terrain/quantize_ops.rs
+++ b/src/terrain/quantize_ops.rs
@@ -63,8 +63,7 @@ pub(super) fn commit_quantization(
 #[operator(
     id = "terrain.quantize.toggle",
     label = "Toggle Quantization",
-    description = "Snap this terrain to a metric grid, and mesh it as flat cells. \
-                   Turning it off leaves stored heights exactly as they are.",
+    description = "Snap the terrain to a metric grid and show its surface as flat cells.",
     is_available = has_selected_terrain
 )]
 pub(crate) fn terrain_quantize_toggle(

--- a/src/terrain/quantize_ops.rs
+++ b/src/terrain/quantize_ops.rs
@@ -1,0 +1,159 @@
+//! Operators for a terrain's grid quantization.
+//!
+//! Quantization is a three-field descriptor on the `Terrain` component --
+//! small, human-edited, inline in the scene document -- so every mutation
+//! here syncs the component back to the AST. What it *governs* is bulk
+//! data, and that still travels the sidecar route: the apply operator
+//! hands the snapped array to [`SetTerrainHeights`] and never puts a
+//! height near the document.
+//!
+//! Turning quantization off is deliberately inert. It changes how the
+//! terrain is meshed and stops future strokes snapping; it does not
+//! un-snap anything already stored. A user who terraced a hillside and
+//! then switched the setting off still has the hillside they made.
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_scene_types::TerrainQuantization;
+
+use super::ops::has_selected_terrain;
+use super::sculpt::SetTerrainHeights;
+use super::{TerrainDataStore, TerrainDirtyChunks};
+use crate::commands::CommandHistory;
+use crate::selection::Selection;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<TerrainQuantizeToggleOp>()
+        .register_operator::<TerrainQuantizeApplyOp>();
+}
+
+/// Edit a terrain's quantization descriptor and push it to the document.
+///
+/// The inspector's numeric fields and the on/off toggle both come
+/// through here so there is one place that knows a descriptor edit has
+/// to reach the AST, and that flipping `enabled` changes which mesher
+/// runs and therefore needs a full rebuild.
+pub(super) fn commit_quantization(
+    world: &mut World,
+    entity: Entity,
+    edit: impl FnOnce(&mut TerrainQuantization),
+) {
+    let Some(mut terrain) = world.get_mut::<jackdaw_scene_types::Terrain>(entity) else {
+        return;
+    };
+    let before = terrain.quantization.clone();
+    edit(&mut terrain.quantization);
+    if terrain.quantization == before {
+        return;
+    }
+    let shading_changed = terrain.quantization.enabled != before.enabled;
+    let terrain = terrain.clone();
+    crate::commands::sync_component_to_ast(
+        world,
+        entity,
+        "jackdaw_scene_types::types::Terrain",
+        &terrain,
+    );
+    if shading_changed && let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(entity) {
+        dirty.rebuild_all = true;
+    }
+}
+
+/// Turn quantization on or off for the selected terrain.
+#[operator(
+    id = "terrain.quantize.toggle",
+    label = "Toggle Quantization",
+    description = "Snap this terrain to a metric grid, and mesh it as flat cells. \
+                   Turning it off leaves stored heights exactly as they are.",
+    is_available = has_selected_terrain
+)]
+pub(crate) fn terrain_quantize_toggle(
+    _: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let entity = selection.primary()?;
+    commands.queue(move |world: &mut World| {
+        commit_quantization(world, entity, |q| q.enabled = !q.enabled);
+    });
+    OperatorResult::Finished
+}
+
+/// Snap the selected terrain's existing heights and pin its cell size.
+///
+/// Sculpting, generating and eroding all snap as they go once
+/// quantization is on, so this operator is for the terrain that already
+/// existed when the setting was turned on, or whose step has since
+/// changed.
+///
+/// `allows_undo = false` because it pushes its own [`SetTerrainHeights`]
+/// entry; letting the framework also capture a diff would double-record
+/// the change.
+#[operator(
+    id = "terrain.quantize.apply",
+    label = "Apply Quantization",
+    description = "Snap every stored height to the elevation step and resize the \
+                   terrain so its vertex spacing equals the cell size.",
+    is_available = has_selected_terrain,
+    allows_undo = false
+)]
+pub(crate) fn terrain_quantize_apply(
+    _: In<OperatorParameters>,
+    selection: Res<Selection>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let entity = selection.primary()?;
+    commands.queue(move |world: &mut World| apply_quantization(world, entity));
+    OperatorResult::Finished
+}
+
+/// One history entry covering both halves of the snap.
+///
+/// The heights and the world size move together: pinning vertex spacing
+/// to a metric cell size is a resize, and undoing the snapped heights
+/// without the resize would leave the terrain at a spacing its heights
+/// were never snapped for.
+fn apply_quantization(world: &mut World, entity: Entity) {
+    let Some(terrain) = world.get::<jackdaw_scene_types::Terrain>(entity) else {
+        return;
+    };
+    let terrain = terrain.clone();
+    if !terrain.quantization.enabled {
+        return;
+    }
+
+    let old_size = terrain.size;
+    let new_size = terrain
+        .quantization
+        .world_size_for(terrain.resolution)
+        .unwrap_or(old_size);
+
+    let Some(old_heights) = world
+        .resource_mut::<TerrainDataStore>()
+        .entry_for(&terrain)
+        .map(|data| data.heights.clone())
+    else {
+        return;
+    };
+    let mut new_heights = old_heights.clone();
+    if let Some(step) = terrain.quantization.active_height_step() {
+        jackdaw_terrain::quantize_heights(&mut new_heights, step);
+    }
+
+    // An already-conforming terrain should not leave an undo entry that
+    // does nothing when the user presses Ctrl+Z.
+    if new_heights == old_heights && new_size == old_size {
+        return;
+    }
+
+    let command = SetTerrainHeights {
+        entity,
+        old_heights,
+        new_heights,
+        label: "Quantize Terrain".to_string(),
+        resize: (new_size != old_size).then_some((old_size, new_size)),
+    };
+    world.resource_scope(|world, mut history: Mut<CommandHistory>| {
+        history.execute(Box::new(command), world);
+    });
+}

--- a/src/terrain/scatter.rs
+++ b/src/terrain/scatter.rs
@@ -1,0 +1,1259 @@
+//! The `terrain.scatter` operator: PCG placement over paint channels.
+//!
+//! A run stamps ordinary editable
+//! entities -- the same `GltfSource` + `WorldAssetRoot` + `Transform`
+//! shape a drag from the asset browser produces
+//! ([`crate::entity_ops::spawn_gltf`]) -- parented under one named group
+//! so the outliner shows a single collapsible node. Nothing about an
+//! instance is special-cased afterwards: move it, scale it, delete it,
+//! give it components.
+//!
+//! What makes a re-run safe is [`ScatterInstance`], a small reflected
+//! marker recording the generator, the seed, and the exact transform the
+//! generator produced. On re-run an instance whose live `Transform` still
+//! equals its recorded one is *untouched* and gets replaced; one the user
+//! moved, rotated or scaled no longer matches and is preserved. That is
+//! the whole rule: it needs no bookkeeping beyond what the scene already
+//! saves, and it survives a save/load round trip because both halves are
+//! reflected data.
+//!
+//! The random stream lives in [`jackdaw_terrain::scatter`] and derives
+//! from `(seed, cell index)` only. Nothing in this file adds randomness.
+
+use std::sync::{Arc, Mutex};
+
+use bevy::prelude::*;
+use bevy::world_serialization::WorldAssetRoot;
+use jackdaw_api::prelude::*;
+use jackdaw_feathers::{
+    button::{self, ButtonProps, ButtonVariant},
+    text_edit::{self, TextEditCommitEvent, TextEditProps},
+    tokens,
+};
+use jackdaw_scene_types::GltfSource;
+use jackdaw_terrain::{Heightmap, ScatterMask, ScatterParams};
+
+use super::TerrainDataStore;
+use super::inspector::{
+    spawn_add_tile, spawn_hint, spawn_labeled_field, spawn_tile, spawn_tile_grid, spawn_tile_remove,
+};
+use super::ops::has_selected_terrain;
+use crate::commands::{CommandGroup, CommandHistory, DespawnEntity, EditorCommand, SpawnEntity};
+use crate::selection::Selection;
+
+pub(super) fn plugin(app: &mut App) {
+    app.init_resource::<TerrainScatterState>()
+        .init_resource::<TerrainScatterReport>()
+        .register_type::<ScatterInstance>()
+        .register_type::<ScatterGroup>()
+        .add_observer(on_scatter_text_commit);
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<TerrainScatterOp>()
+        .register_operator::<TerrainScatterClearOp>()
+        .register_operator::<TerrainScatterAssetAddOp>()
+        .register_operator::<TerrainScatterAssetRemoveOp>()
+        .register_operator::<TerrainScatterAssetToggleOp>()
+        .register_operator::<TerrainScatterValueToggleOp>()
+        .register_operator::<TerrainScatterToggleYawOp>()
+        .register_operator::<TerrainScatterToggleAlignOp>();
+}
+
+// --- Provenance ---
+
+/// Marks the group entity a scatter run stamps its instances under.
+///
+/// `key` is what a re-run matches on, so two scatter runs over the same
+/// terrain (undergrowth and trees, say) stay independent stamps rather
+/// than overwriting each other.
+#[derive(Component, Reflect, Clone, Debug, Default)]
+#[reflect(Component, Default)]
+pub struct ScatterGroup {
+    /// Operator id that produced this group.
+    pub generator: String,
+    /// Stamp identity. Matched on re-run.
+    pub key: String,
+}
+
+/// Provenance carried by every generated instance.
+///
+/// `generated` is the transform this instance was born with. An instance
+/// whose live `Transform` still equals it has not been touched by hand
+/// and a re-run may replace it; anything else is the user's work and is
+/// preserved. Exact equality is the right test here because nothing in
+/// the editor perturbs a transform without the user asking -- there is no
+/// physics settle, no re-import, no snapping pass over placed entities.
+#[derive(Component, Reflect, Clone, Debug, Default)]
+#[reflect(Component, Default)]
+pub struct ScatterInstance {
+    pub generator: String,
+    pub key: String,
+    pub seed: u64,
+    pub generated: Transform,
+}
+
+// --- Panel state ---
+
+/// One entry in the scatter palette.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScatterAsset {
+    /// Project-relative or absolute path to a `.gltf` / `.glb`.
+    pub path: String,
+    /// Whether this entry takes part in the next run.
+    pub active: bool,
+}
+
+impl ScatterAsset {
+    /// File stem, used as the tile caption and the instance name.
+    pub fn stem(&self) -> &str {
+        std::path::Path::new(&self.path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("model")
+    }
+}
+
+/// Everything the Scatter panel edits, and the defaults every parameter
+/// of `terrain.scatter` falls back to when the caller omits it.
+///
+/// Keeping the defaults in a resource is what lets the same operator be
+/// clicked with no arguments and scripted with all of them.
+#[derive(Resource, Clone, Debug, PartialEq)]
+pub struct TerrainScatterState {
+    pub seed: u64,
+    pub density: f32,
+    pub min_spacing: f32,
+    pub mask_channel: usize,
+    /// Palette values that accept a cell. Empty means no mask.
+    pub accept: Vec<u16>,
+    /// Channel index scaling density per cell, or `None`.
+    pub weight_channel: Option<usize>,
+    pub scale_min: f32,
+    pub scale_max: f32,
+    pub random_yaw: bool,
+    pub align_to_normal: bool,
+    pub assets: Vec<ScatterAsset>,
+    /// Path typed into the panel's asset field, waiting on `+`.
+    pub asset_draft: String,
+}
+
+impl Default for TerrainScatterState {
+    fn default() -> Self {
+        Self {
+            seed: 1,
+            density: 0.5,
+            min_spacing: 0.35,
+            mask_channel: 0,
+            accept: Vec::new(),
+            weight_channel: None,
+            scale_min: 0.8,
+            scale_max: 1.25,
+            random_yaw: true,
+            align_to_normal: false,
+            assets: Vec::new(),
+            asset_draft: String::new(),
+        }
+    }
+}
+
+impl TerrainScatterState {
+    fn active_assets(&self) -> Vec<String> {
+        self.assets
+            .iter()
+            .filter(|asset| asset.active)
+            .map(|asset| asset.path.clone())
+            .collect()
+    }
+}
+
+/// What the last run did. Shown in the panel and logged, so a headless
+/// caller sees the same numbers a clicking user does.
+#[derive(Resource, Clone, Debug, Default, PartialEq, Eq)]
+pub struct TerrainScatterReport {
+    /// Instances the run spawned.
+    pub placed: usize,
+    /// Hand-edited instances the run left alone.
+    pub kept: usize,
+    /// Untouched instances the run replaced.
+    pub replaced: usize,
+    /// Human-readable summary, including the reason for a run that did
+    /// nothing.
+    pub message: String,
+}
+
+// --- Field bindings ---
+
+/// Which Scatter panel field a `text_edit` writes into.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ScatterField {
+    AssetDraft,
+    Seed,
+    Density,
+    Spacing,
+    MaskChannel,
+    WeightChannel,
+    ScaleMin,
+    ScaleMax,
+}
+
+// --- Operators ---
+
+/// Scatter instances across a terrain from its paint channels.
+///
+/// `allows_undo = false` because the stamp pushes its own
+/// [`CommandGroup`] history entry; letting the framework also capture a
+/// scene diff would record the change twice.
+#[operator(
+    id = "terrain.scatter",
+    label = "Scatter",
+    description = "Place instances across a terrain, masked by a paint channel.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        group(String, doc = "Stamp identity. Re-running the same group replaces it."),
+        seed(
+            i64,
+            doc = "Random seed. The same seed always places the same instances."
+        ),
+        density(f64, doc = "Instances per square world unit."),
+        spacing(f64, doc = "Minimum world-unit distance between instances."),
+        channel(i64, doc = "Index of the mask channel."),
+        accept(String, doc = "Comma-separated palette values that accept a cell."),
+        weight_channel(i64, doc = "Channel index scaling density per cell. -1 for none."),
+        assets(String, doc = "Comma-separated model paths to place."),
+        scale_min(f64, doc = "Smallest uniform scale."),
+        scale_max(f64, doc = "Largest uniform scale."),
+        random_yaw(bool, doc = "Randomise rotation about Y."),
+        align_to_normal(bool, doc = "Tilt instances onto the surface.")
+    )
+)]
+pub(crate) fn terrain_scatter(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let params = params.0;
+    commands.queue(move |world: &mut World| run_scatter(world, &params));
+    OperatorResult::Finished
+}
+
+/// Delete a scatter stamp and everything in it, as one undo entry.
+#[operator(
+    id = "terrain.scatter.clear",
+    label = "Clear Scatter",
+    description = "Delete a scatter group and every instance under it.",
+    allows_undo = false,
+    params(group(String, doc = "Stamp identity to clear. Defaults to the selection's."))
+)]
+pub(crate) fn terrain_scatter_clear(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let key = params.as_str("group").map(str::to_string);
+    commands.queue(move |world: &mut World| clear_scatter(world, key.as_deref()));
+    OperatorResult::Finished
+}
+
+/// Add a model to the scatter palette.
+#[operator(
+    id = "terrain.scatter.asset.add",
+    label = "Add Scatter Asset",
+    description = "Add a model to the scatter palette.",
+    allows_undo = false,
+    params(path(String, doc = "Model path. Defaults to the panel's asset field."))
+)]
+pub(crate) fn terrain_scatter_asset_add(
+    params: In<OperatorParameters>,
+    mut state: ResMut<TerrainScatterState>,
+) -> OperatorResult {
+    let path = match params.as_str("path").filter(|p| !p.trim().is_empty()) {
+        Some(path) => path.trim().to_string(),
+        None => state.asset_draft.trim().to_string(),
+    };
+    if path.is_empty() || state.assets.iter().any(|asset| asset.path == path) {
+        return OperatorResult::Cancelled;
+    }
+    state.assets.push(ScatterAsset { path, active: true });
+    state.asset_draft.clear();
+    OperatorResult::Finished
+}
+
+/// Remove a model from the scatter palette.
+#[operator(
+    id = "terrain.scatter.asset.remove",
+    label = "Remove Scatter Asset",
+    description = "Remove a model from the scatter palette.",
+    allows_undo = false,
+    params(index(i64, doc = "Palette index to remove."))
+)]
+pub(crate) fn terrain_scatter_asset_remove(
+    params: In<OperatorParameters>,
+    mut state: ResMut<TerrainScatterState>,
+) -> OperatorResult {
+    let index = usize::try_from(params.as_int("index")?).ok()?;
+    if index >= state.assets.len() {
+        return OperatorResult::Cancelled;
+    }
+    state.assets.remove(index);
+    OperatorResult::Finished
+}
+
+/// Include or exclude one palette entry from the next run.
+#[operator(
+    id = "terrain.scatter.asset.toggle",
+    label = "Toggle Scatter Asset",
+    description = "Include or exclude a palette entry from the next run.",
+    allows_undo = false,
+    params(index(i64, doc = "Palette index to toggle."))
+)]
+pub(crate) fn terrain_scatter_asset_toggle(
+    params: In<OperatorParameters>,
+    mut state: ResMut<TerrainScatterState>,
+) -> OperatorResult {
+    let index = usize::try_from(params.as_int("index")?).ok()?;
+    let asset = state.assets.get_mut(index)?;
+    asset.active = !asset.active;
+    OperatorResult::Finished
+}
+
+/// Include or exclude one mask palette value.
+///
+/// Takes the palette *row* index, like `terrain.channel.value.select`,
+/// and resolves the value off the terrain -- so the tile grid can pass
+/// its own index and the stored accept set stays in palette values.
+#[operator(
+    id = "terrain.scatter.value.toggle",
+    label = "Toggle Mask Value",
+    description = "Include or exclude a palette value from the scatter mask.",
+    allows_undo = false,
+    is_available = has_selected_terrain,
+    params(index(i64, doc = "Palette row index in the mask channel."))
+)]
+pub(crate) fn terrain_scatter_value_toggle(
+    params: In<OperatorParameters>,
+    selection: Res<Selection>,
+    terrains: Query<&jackdaw_scene_types::Terrain>,
+    mut state: ResMut<TerrainScatterState>,
+) -> OperatorResult {
+    let row = usize::try_from(params.as_int("index")?).ok()?;
+    let terrain = terrains.get(selection.primary()?).ok()?;
+    let value = terrain
+        .channels
+        .get(state.mask_channel)?
+        .palette
+        .get(row)?
+        .value;
+    match state.accept.iter().position(|v| *v == value) {
+        Some(at) => {
+            state.accept.remove(at);
+        }
+        None => {
+            state.accept.push(value);
+            state.accept.sort_unstable();
+        }
+    }
+    OperatorResult::Finished
+}
+
+/// Randomise rotation about Y, or stop doing so.
+#[operator(
+    id = "terrain.scatter.toggle_yaw",
+    label = "Random Yaw",
+    description = "Randomise each instance's rotation about Y.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_scatter_toggle_yaw(
+    _: In<OperatorParameters>,
+    mut state: ResMut<TerrainScatterState>,
+) -> OperatorResult {
+    state.random_yaw = !state.random_yaw;
+    OperatorResult::Finished
+}
+
+/// Tilt instances onto the surface, or stand them upright.
+#[operator(
+    id = "terrain.scatter.toggle_align",
+    label = "Align to Normal",
+    description = "Tilt each instance onto the surface it sits on.",
+    allows_undo = false
+)]
+pub(crate) fn terrain_scatter_toggle_align(
+    _: In<OperatorParameters>,
+    mut state: ResMut<TerrainScatterState>,
+) -> OperatorResult {
+    state.align_to_normal = !state.align_to_normal;
+    OperatorResult::Finished
+}
+
+// --- The stamp ---
+
+/// Resolve the terrain a run targets: an explicit name first, the
+/// selection otherwise.
+///
+/// The name lookup is what makes the operator drivable with no mouse and
+/// no selection, which is the whole point of taking it as a parameter.
+fn resolve_terrain(world: &mut World, name: Option<&str>) -> Option<Entity> {
+    if let Some(name) = name.filter(|n| !n.is_empty()) {
+        let mut query = world.query::<(Entity, Option<&Name>, &jackdaw_scene_types::Terrain)>();
+        return query
+            .iter(world)
+            .find(|(_, have, _)| have.is_some_and(|have| have.as_str() == name))
+            .map(|(entity, _, _)| entity);
+    }
+    if let Some(entity) = world.resource::<Selection>().primary()
+        && world.get::<jackdaw_scene_types::Terrain>(entity).is_some()
+    {
+        return Some(entity);
+    }
+    // A scene with exactly one terrain needs no disambiguation, and a
+    // headless caller has no way to make a selection. Two or more and the
+    // caller has to say which.
+    let mut query = world.query_filtered::<Entity, With<jackdaw_scene_types::Terrain>>();
+    let mut found = query.iter(world);
+    let only = found.next()?;
+    found.next().is_none().then_some(only)
+}
+
+/// Names of every terrain in the scene, for a failure message that says
+/// what the caller could have asked for instead.
+fn terrain_names(world: &mut World) -> Vec<String> {
+    let mut query = world.query::<(Option<&Name>, &jackdaw_scene_types::Terrain)>();
+    query
+        .iter(world)
+        .map(|(name, _)| {
+            name.map(|n| n.as_str().to_string())
+                .unwrap_or_else(|| "<unnamed>".to_string())
+        })
+        .collect()
+}
+
+/// Default stamp identity: one group per terrain unless the caller names
+/// another.
+fn default_group_key(world: &World, terrain: Entity) -> String {
+    let name = world
+        .get::<Name>(terrain)
+        .map(|n| n.as_str().to_string())
+        .unwrap_or_else(|| "Terrain".to_string());
+    format!("{name} Scatter")
+}
+
+fn set_report(world: &mut World, report: TerrainScatterReport) {
+    info!("terrain.scatter: {}", report.message);
+    *world.resource_mut::<TerrainScatterReport>() = report;
+}
+
+fn run_scatter(world: &mut World, params: &OperatorParameters) {
+    let Some(terrain_entity) = resolve_terrain(world, params.as_str("terrain")) else {
+        let available = terrain_names(world);
+        set_report(
+            world,
+            TerrainScatterReport {
+                message: format!(
+                    "no terrain resolved (asked for {:?}); this scene has {available:?}",
+                    params.as_str("terrain").unwrap_or("")
+                ),
+                ..default()
+            },
+        );
+        return;
+    };
+    let Some(terrain) = world
+        .get::<jackdaw_scene_types::Terrain>(terrain_entity)
+        .cloned()
+    else {
+        return;
+    };
+    let state = world.resource::<TerrainScatterState>().clone();
+
+    let assets: Vec<String> = match params.as_str("assets").filter(|s| !s.trim().is_empty()) {
+        Some(list) => list
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
+        None => state.active_assets(),
+    };
+    if assets.is_empty() {
+        set_report(
+            world,
+            TerrainScatterReport {
+                message: "no assets in the scatter palette".to_string(),
+                ..default()
+            },
+        );
+        return;
+    }
+
+    let accept: Vec<u16> = match params.as_str("accept").filter(|s| !s.trim().is_empty()) {
+        Some(list) => list
+            .split(',')
+            .filter_map(|v| v.trim().parse::<u16>().ok())
+            .collect(),
+        None => state.accept.clone(),
+    };
+    let channel = params
+        .as_int("channel")
+        .and_then(|v| usize::try_from(v).ok())
+        .unwrap_or(state.mask_channel);
+    let weight_channel = match params.as_int("weight_channel") {
+        Some(value) => usize::try_from(value).ok(),
+        None => state.weight_channel,
+    };
+    let seed = params.as_int("seed").map_or(state.seed, |v| v as u64);
+
+    let scatter_params = ScatterParams {
+        seed,
+        density: params
+            .as_float("density")
+            .map_or(state.density, |v| v as f32),
+        min_spacing: params
+            .as_float("spacing")
+            .map_or(state.min_spacing, |v| v as f32),
+        // An empty accept set means "no mask" rather than "accept
+        // nothing": a terrain nobody painted should still scatter.
+        mask: (!accept.is_empty()).then_some(ScatterMask { channel, accept }),
+        weight_channel,
+        scale_min: params
+            .as_float("scale_min")
+            .map_or(state.scale_min, |v| v as f32),
+        scale_max: params
+            .as_float("scale_max")
+            .map_or(state.scale_max, |v| v as f32),
+        random_yaw: params.as_bool("random_yaw").unwrap_or(state.random_yaw),
+        align_to_normal: params
+            .as_bool("align_to_normal")
+            .unwrap_or(state.align_to_normal),
+        asset_count: assets.len(),
+    };
+
+    let (heightmap, channels) = {
+        let mut store = world.resource_mut::<TerrainDataStore>();
+        let Some(data) = store.entry_for(&terrain) else {
+            return;
+        };
+        (
+            Heightmap {
+                resolution: terrain.resolution,
+                size: terrain.size,
+                max_height: terrain.max_height,
+                heights: data.heights.clone(),
+            },
+            data.channels.clone(),
+        )
+    };
+
+    let placements = jackdaw_terrain::scatter(&heightmap, &channels, &scatter_params);
+
+    let key = params
+        .as_str("group")
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| default_group_key(world, terrain_entity));
+
+    let terrain_transform = world
+        .get::<Transform>(terrain_entity)
+        .copied()
+        .unwrap_or_default();
+
+    stamp(
+        world,
+        StampRequest {
+            key,
+            seed,
+            terrain: terrain_entity,
+            terrain_transform,
+            assets,
+            placements,
+        },
+    );
+}
+
+struct StampRequest {
+    key: String,
+    seed: u64,
+    terrain: Entity,
+    /// Placements come out of the kernel in the terrain's local space, so
+    /// the terrain's own transform has to be applied before they become
+    /// world-space instances.
+    terrain_transform: Transform,
+    assets: Vec<String>,
+    placements: Vec<jackdaw_terrain::Placement>,
+}
+
+/// Existing group entity for `key`, if a previous run made one.
+fn find_group(world: &mut World, key: &str) -> Option<Entity> {
+    let mut query = world.query::<(Entity, &ScatterGroup)>();
+    query
+        .iter(world)
+        .find(|(_, group)| group.key == key)
+        .map(|(entity, _)| entity)
+}
+
+/// Split a group's existing instances into the ones a re-run may replace
+/// and the count it must preserve.
+///
+/// The test is exact transform equality against the recorded `generated`
+/// transform. See [`ScatterInstance`] for why that is the whole rule.
+fn partition_existing(world: &mut World, group: Entity) -> (Vec<Entity>, usize) {
+    let children: Vec<Entity> = world
+        .get::<Children>(group)
+        .map(|c| c.iter().collect())
+        .unwrap_or_default();
+    let mut untouched = Vec::new();
+    let mut kept = 0;
+    for child in children {
+        let Some(generated) = world.get::<ScatterInstance>(child).map(|i| i.generated) else {
+            // Something the user parented under the group by hand. Not
+            // ours to remove.
+            kept += 1;
+            continue;
+        };
+        let live = world.get::<Transform>(child).copied().unwrap_or_default();
+        if live == generated {
+            untouched.push(child);
+        } else {
+            kept += 1;
+        }
+    }
+    (untouched, kept)
+}
+
+fn stamp(world: &mut World, request: StampRequest) {
+    let StampRequest {
+        key,
+        seed,
+        terrain,
+        terrain_transform,
+        assets,
+        placements,
+    } = request;
+
+    let existing_group = find_group(world, &key);
+    let (stale, kept) = match existing_group {
+        Some(group) => partition_existing(world, group),
+        None => (Vec::new(), 0),
+    };
+
+    let mut cmds: Vec<Box<dyn EditorCommand>> = Vec::new();
+
+    // The group entity's id is not known until its spawn command runs,
+    // and redo re-runs it, so the instance commands read it out of a
+    // shared slot rather than capturing an id that would go stale.
+    let slot: Arc<Mutex<Option<Entity>>> = Arc::new(Mutex::new(existing_group));
+    if existing_group.is_none() {
+        let group_parent = world.get::<ChildOf>(terrain).map(ChildOf::parent);
+        let group_parent = group_parent.filter(|p| world.get_entity(*p).is_ok());
+        let slot = slot.clone();
+        let key = key.clone();
+        cmds.push(Box::new(SpawnEntity {
+            spawned: None,
+            spawn_fn: Box::new(move |world: &mut World| {
+                let entity = spawn_group(world, &key, group_parent);
+                *slot.lock().expect("scatter group slot") = Some(entity);
+                entity
+            }),
+            label: "Scatter".to_string(),
+        }));
+    }
+
+    for entity in &stale {
+        cmds.push(Box::new(DespawnEntity::from_world(world, *entity)));
+    }
+
+    let placed = placements.len();
+    for (index, placement) in placements.into_iter().enumerate() {
+        let path = assets[placement.asset_index.min(assets.len() - 1)].clone();
+        let name = format!(
+            "{}-{index}",
+            std::path::Path::new(&path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("scatter")
+        );
+        let transform = instance_transform(&placement, &terrain_transform);
+        let provenance = ScatterInstance {
+            generator: TerrainScatterOp::ID.to_string(),
+            key: key.clone(),
+            seed,
+            generated: transform,
+        };
+        let slot = slot.clone();
+        cmds.push(Box::new(SpawnEntity {
+            spawned: None,
+            spawn_fn: Box::new(move |world: &mut World| {
+                let Some(parent) = *slot.lock().expect("scatter group slot") else {
+                    return Entity::PLACEHOLDER;
+                };
+                spawn_instance(world, parent, &path, &name, transform, provenance.clone())
+            }),
+            label: "Scatter instance".to_string(),
+        }));
+    }
+
+    let replaced = stale.len();
+    let mut group: Box<dyn EditorCommand> = Box::new(CommandGroup {
+        commands: cmds,
+        label: format!("Scatter {key}"),
+    });
+    group.execute(world);
+    world.resource_mut::<CommandHistory>().push_executed(group);
+
+    set_report(
+        world,
+        TerrainScatterReport {
+            placed,
+            kept,
+            replaced,
+            message: format!(
+                "placed {placed} in '{key}', replaced {replaced} generated, kept {kept} edited"
+            ),
+        },
+    );
+}
+
+/// World transform for one placement, with the terrain's own transform
+/// applied.
+fn instance_transform(
+    placement: &jackdaw_terrain::Placement,
+    terrain_transform: &Transform,
+) -> Transform {
+    let upright = Quat::from_rotation_arc(Vec3::Y, placement.normal);
+    let rotation = upright * Quat::from_rotation_y(placement.yaw);
+    Transform {
+        translation: terrain_transform.transform_point(placement.position),
+        rotation: terrain_transform.rotation * rotation,
+        scale: terrain_transform.scale * Vec3::splat(placement.scale),
+    }
+}
+
+fn spawn_group(world: &mut World, key: &str, parent: Option<Entity>) -> Entity {
+    let mut entity = world.spawn((
+        Name::new(key.to_string()),
+        ScatterGroup {
+            generator: TerrainScatterOp::ID.to_string(),
+            key: key.to_string(),
+        },
+        Transform::default(),
+        Visibility::default(),
+    ));
+    if let Some(parent) = parent {
+        entity.insert(ChildOf(parent));
+    }
+    let entity = entity.id();
+    crate::scene_io::register_entity_in_ast(world, entity);
+    entity
+}
+
+/// Spawn one instance with exactly the component shape a browser drop
+/// produces, plus its provenance marker.
+fn spawn_instance(
+    world: &mut World,
+    parent: Entity,
+    path: &str,
+    name: &str,
+    transform: Transform,
+    provenance: ScatterInstance,
+) -> Entity {
+    let asset_path = crate::entity_ops::to_asset_path(path);
+    let scene = world
+        .resource::<AssetServer>()
+        .load(GltfAssetLabel::Scene(0).from_asset(asset_path));
+    let entity = world
+        .spawn((
+            Name::new(name.to_string()),
+            GltfSource {
+                path: path.to_string(),
+                scene_index: 0,
+            },
+            WorldAssetRoot(scene),
+            transform,
+            provenance,
+            ChildOf(parent),
+        ))
+        .id();
+    crate::scene_io::register_entity_in_ast(world, entity);
+    entity
+}
+
+fn clear_scatter(world: &mut World, key: Option<&str>) {
+    let key = match key.filter(|k| !k.is_empty()) {
+        Some(key) => key.to_string(),
+        None => {
+            let Some(terrain) = resolve_terrain(world, None) else {
+                return;
+            };
+            default_group_key(world, terrain)
+        }
+    };
+    let Some(group) = find_group(world, &key) else {
+        set_report(
+            world,
+            TerrainScatterReport {
+                message: format!("no scatter group named '{key}'"),
+                ..default()
+            },
+        );
+        return;
+    };
+    let children: Vec<Entity> = world
+        .get::<Children>(group)
+        .map(|c| c.iter().collect())
+        .unwrap_or_default();
+
+    let mut cmds: Vec<Box<dyn EditorCommand>> = Vec::new();
+    for child in &children {
+        cmds.push(Box::new(DespawnEntity::from_world(world, *child)));
+    }
+    cmds.push(Box::new(DespawnEntity::from_world(world, group)));
+    let removed = cmds.len();
+
+    let mut command: Box<dyn EditorCommand> = Box::new(CommandGroup {
+        commands: cmds,
+        label: format!("Clear Scatter {key}"),
+    });
+    command.execute(world);
+    world
+        .resource_mut::<CommandHistory>()
+        .push_executed(command);
+
+    set_report(
+        world,
+        TerrainScatterReport {
+            message: format!("cleared '{key}': {removed} entities removed"),
+            ..default()
+        },
+    );
+}
+
+// --- Panel ---
+
+/// What the Scatter panel's appearance depends on.
+///
+/// The inspector compares this rather than change-detecting the resource,
+/// because the numeric fields are typed into and rebuilding the section
+/// on every committed keystroke would take the focus away mid-edit.
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct ScatterSignature {
+    assets: Vec<(String, bool)>,
+    accept: Vec<u16>,
+    mask_channel: usize,
+    random_yaw: bool,
+    align_to_normal: bool,
+    message: String,
+}
+
+pub(super) fn signature(
+    state: &TerrainScatterState,
+    report: &TerrainScatterReport,
+) -> ScatterSignature {
+    ScatterSignature {
+        assets: state
+            .assets
+            .iter()
+            .map(|asset| (asset.path.clone(), asset.active))
+            .collect(),
+        accept: state.accept.clone(),
+        mask_channel: state.mask_channel,
+        random_yaw: state.random_yaw,
+        align_to_normal: state.align_to_normal,
+        message: report.message.clone(),
+    }
+}
+
+/// The Scatter section of the terrain inspector.
+///
+/// Reads top to bottom in workflow order: *what* is being placed (the
+/// asset palette), *where* it may go (the mask), then *how much* and *how
+/// varied*.
+pub(super) fn spawn_scatter_ui(
+    commands: &mut Commands,
+    parent: Entity,
+    terrain: Option<&jackdaw_scene_types::Terrain>,
+    state: &TerrainScatterState,
+    report: &TerrainScatterReport,
+) {
+    // --- Palette ---
+    spawn_hint(
+        commands,
+        parent,
+        "Models to place. Click a tile to include or exclude it.",
+    );
+    let grid = spawn_tile_grid(commands, parent);
+    for (index, asset) in state.assets.iter().enumerate() {
+        spawn_tile(
+            commands,
+            grid,
+            if asset.active {
+                tokens::ACCENT_BLUE
+            } else {
+                Color::srgb(0.28, 0.28, 0.30)
+            },
+            asset.stem(),
+            asset.active,
+            TerrainScatterAssetToggleOp::ID,
+            Some(index),
+        );
+        spawn_tile_remove(commands, grid, TerrainScatterAssetRemoveOp::ID, index);
+    }
+    spawn_add_tile(commands, grid, TerrainScatterAssetAddOp::ID);
+    spawn_path_field(commands, parent, &state.asset_draft);
+
+    // --- Mask ---
+    // Reusing the channel's own palette swatches means the values here
+    // read identically to the ones in the Paint Channels section: the
+    // user picks the same tiles they painted with.
+    let empty: &[jackdaw_scene_types::TerrainChannel] = &[];
+    let channels = terrain.map(|t| t.channels.as_slice()).unwrap_or(empty);
+    if let Some(channel) = channels.get(state.mask_channel) {
+        spawn_hint(
+            commands,
+            parent,
+            &format!("Place only on '{}' values:", channel.name),
+        );
+        let values = spawn_tile_grid(commands, parent);
+        for (row, entry) in channel.palette.iter().enumerate() {
+            spawn_tile(
+                commands,
+                values,
+                entry.color,
+                &entry.label,
+                state.accept.contains(&entry.value),
+                TerrainScatterValueToggleOp::ID,
+                Some(row),
+            );
+        }
+        if state.accept.is_empty() {
+            spawn_hint(
+                commands,
+                parent,
+                "No value picked, so the whole terrain is eligible.",
+            );
+        }
+    } else {
+        spawn_hint(
+            commands,
+            parent,
+            "This terrain has no paint channels, so nothing masks the scatter.",
+        );
+    }
+
+    // --- Numerics ---
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Seed",
+        "Same seed always places the same instances",
+        state.seed as f64,
+        ScatterField::Seed,
+    );
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Density",
+        "Instances per square world unit",
+        state.density as f64,
+        ScatterField::Density,
+    );
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Min Spacing",
+        "Closest two instances may sit, in world units",
+        state.min_spacing as f64,
+        ScatterField::Spacing,
+    );
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Mask Channel",
+        "Which paint channel gates placement",
+        state.mask_channel as f64,
+        ScatterField::MaskChannel,
+    );
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Weight Channel",
+        "Channel scaling density per cell. -1 for none",
+        state.weight_channel.map_or(-1.0, |c| c as f64),
+        ScatterField::WeightChannel,
+    );
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Scale Min",
+        "Smallest uniform scale",
+        state.scale_min as f64,
+        ScatterField::ScaleMin,
+    );
+    spawn_labeled_field(
+        commands,
+        parent,
+        "Scale Max",
+        "Largest uniform scale",
+        state.scale_max as f64,
+        ScatterField::ScaleMax,
+    );
+
+    // --- Toggles ---
+    // Toggle buttons rather than checkboxes, matching the Quantization
+    // section directly above: the label carries the state, so there is no
+    // separate control to read.
+    spawn_flag_toggle(
+        commands,
+        parent,
+        "Random Yaw",
+        state.random_yaw,
+        TerrainScatterToggleYawOp::ID,
+    );
+    spawn_flag_toggle(
+        commands,
+        parent,
+        "Align to Normal",
+        state.align_to_normal,
+        TerrainScatterToggleAlignOp::ID,
+    );
+
+    // --- Run ---
+    commands.spawn((
+        button::button(
+            ButtonProps::new("Scatter")
+                .with_variant(ButtonVariant::Primary)
+                .call_operator(TerrainScatterOp::ID),
+        ),
+        ChildOf(parent),
+    ));
+    commands.spawn((
+        button::button(ButtonProps::new("Clear Scatter").call_operator(TerrainScatterClearOp::ID)),
+        ChildOf(parent),
+    ));
+
+    // Instance-count feedback: without it a user cannot tell a run that
+    // placed nothing from one that never ran.
+    if !report.message.is_empty() {
+        spawn_hint(commands, parent, &report.message);
+    }
+}
+
+/// The asset-path field. Its own helper rather than the numeric one next
+/// to it, because a path is text.
+fn spawn_path_field(commands: &mut Commands, parent: Entity, value: &str) {
+    let row = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Column,
+                row_gap: px(tokens::SPACING_XS),
+                width: Val::Percent(100.0),
+                ..Default::default()
+            },
+            ChildOf(parent),
+        ))
+        .id();
+    commands.spawn((
+        Text::new("Asset Path"),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_SM,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(row),
+    ));
+    commands.spawn((
+        Text::new("Model to add with +, relative to the project's assets/"),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_XS,
+            ..Default::default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(row),
+    ));
+    commands.spawn((
+        text_edit::text_edit(TextEditProps::default().with_default_value(value.to_string())),
+        ScatterField::AssetDraft,
+        ChildOf(row),
+    ));
+}
+
+fn spawn_flag_toggle(
+    commands: &mut Commands,
+    parent: Entity,
+    label: &str,
+    on: bool,
+    op_id: &'static str,
+) {
+    commands.spawn((
+        button::button(
+            ButtonProps::new(format!("{label}: {}", if on { "On" } else { "Off" }))
+                .with_variant(if on {
+                    ButtonVariant::Primary
+                } else {
+                    ButtonVariant::Default
+                })
+                .call_operator(op_id),
+        ),
+        ChildOf(parent),
+    ));
+}
+
+/// Commit handler for the Scatter section's text fields.
+///
+/// A separate observer from the sculpt/generation one so the Scatter
+/// panel owns its own bindings; both fire on every commit and each
+/// ignores fields it does not recognise.
+fn on_scatter_text_commit(
+    event: On<TextEditCommitEvent>,
+    bindings: Query<&ScatterField>,
+    child_of_query: Query<&ChildOf>,
+    mut state: ResMut<TerrainScatterState>,
+) {
+    let mut current = event.entity;
+    for _ in 0..4 {
+        let Ok(child_of) = child_of_query.get(current) else {
+            return;
+        };
+        let parent = child_of.parent();
+        if let Ok(&field) = bindings.get(parent) {
+            apply_scatter_field(&mut state, field, &event.text);
+            return;
+        }
+        current = parent;
+    }
+}
+
+fn apply_scatter_field(state: &mut TerrainScatterState, field: ScatterField, text: &str) {
+    if field == ScatterField::AssetDraft {
+        state.asset_draft = text.trim().to_string();
+        return;
+    }
+    let number: f64 = text.trim().parse().unwrap_or(0.0);
+    match field {
+        ScatterField::AssetDraft => unreachable!("handled above"),
+        ScatterField::Seed => state.seed = number.max(0.0) as u64,
+        ScatterField::Density => state.density = (number as f32).max(0.0),
+        ScatterField::Spacing => state.min_spacing = (number as f32).max(0.0),
+        ScatterField::MaskChannel => state.mask_channel = number.max(0.0) as usize,
+        // -1 is the "no weight channel" spelling, so the field can say
+        // "off" without a separate toggle beside it.
+        ScatterField::WeightChannel => {
+            state.weight_channel = (number >= 0.0).then_some(number as usize);
+        }
+        ScatterField::ScaleMin => state.scale_min = (number as f32).max(0.0),
+        ScatterField::ScaleMax => state.scale_max = (number as f32).max(0.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_active_palette_entries_take_part_in_a_run() {
+        let state = TerrainScatterState {
+            assets: vec![
+                ScatterAsset {
+                    path: "kit/Tree.gltf".to_string(),
+                    active: true,
+                },
+                ScatterAsset {
+                    path: "kit/Bush.gltf".to_string(),
+                    active: false,
+                },
+            ],
+            ..default()
+        };
+        assert_eq!(state.active_assets(), vec!["kit/Tree.gltf".to_string()]);
+    }
+
+    #[test]
+    fn a_palette_entry_captions_with_its_file_stem() {
+        let asset = ScatterAsset {
+            path: "kit/nature/CommonTree_1.gltf".to_string(),
+            active: true,
+        };
+        assert_eq!(asset.stem(), "CommonTree_1");
+    }
+
+    /// `-1` in the weight-channel field means "no weight channel", so the
+    /// panel does not need a separate toggle beside it.
+    #[test]
+    fn a_negative_weight_channel_turns_the_weight_off() {
+        let mut state = TerrainScatterState::default();
+        apply_scatter_field(&mut state, ScatterField::WeightChannel, "0");
+        assert_eq!(state.weight_channel, Some(0));
+        apply_scatter_field(&mut state, ScatterField::WeightChannel, "-1");
+        assert_eq!(state.weight_channel, None);
+    }
+
+    #[test]
+    fn numeric_fields_clamp_rather_than_going_negative() {
+        let mut state = TerrainScatterState::default();
+        apply_scatter_field(&mut state, ScatterField::Density, "-4");
+        assert_eq!(state.density, 0.0);
+        apply_scatter_field(&mut state, ScatterField::Spacing, "-1");
+        assert_eq!(state.min_spacing, 0.0);
+        apply_scatter_field(&mut state, ScatterField::Seed, "42");
+        assert_eq!(state.seed, 42);
+    }
+
+    #[test]
+    fn the_asset_field_takes_text_rather_than_a_number() {
+        let mut state = TerrainScatterState::default();
+        apply_scatter_field(&mut state, ScatterField::AssetDraft, " kit/Tree.gltf ");
+        assert_eq!(state.asset_draft, "kit/Tree.gltf");
+    }
+
+    /// An instance whose transform still matches what the generator made
+    /// is replaceable; anything else is the user's work.
+    #[test]
+    fn untouched_means_the_transform_still_equals_the_generated_one() {
+        let generated = Transform::from_xyz(1.0, 2.0, 3.0);
+        let instance = ScatterInstance {
+            generated,
+            ..default()
+        };
+        assert_eq!(generated, instance.generated);
+        assert_ne!(Transform::from_xyz(1.0, 2.5, 3.0), instance.generated);
+    }
+
+    /// The terrain's own transform has to reach the instances, or a
+    /// scatter over a moved terrain lands under the world origin.
+    #[test]
+    fn the_terrain_transform_carries_into_the_instance_transform() {
+        let placement = jackdaw_terrain::Placement {
+            position: Vec3::new(1.0, 0.5, -2.0),
+            yaw: 0.0,
+            scale: 2.0,
+            normal: Vec3::Y,
+            asset_index: 0,
+            cell: 0,
+        };
+        let placed = instance_transform(&placement, &Transform::from_xyz(10.0, 0.0, 5.0));
+        assert_eq!(placed.translation, Vec3::new(11.0, 0.5, 3.0));
+        assert_eq!(placed.scale, Vec3::splat(2.0));
+    }
+
+    /// Align-to-normal tilts the instance; upright leaves it alone.
+    #[test]
+    fn a_tilted_normal_tilts_the_instance() {
+        let placement = jackdaw_terrain::Placement {
+            position: Vec3::ZERO,
+            yaw: 0.0,
+            scale: 1.0,
+            normal: Vec3::new(0.5, 1.0, 0.0).normalize(),
+            asset_index: 0,
+            cell: 0,
+        };
+        let tilted = instance_transform(&placement, &Transform::default());
+        assert!((tilted.rotation * Vec3::Y).angle_between(Vec3::Y) > 0.1);
+
+        let upright = instance_transform(
+            &jackdaw_terrain::Placement {
+                normal: Vec3::Y,
+                ..placement
+            },
+            &Transform::default(),
+        );
+        assert!((upright.rotation * Vec3::Y).angle_between(Vec3::Y) < 1e-4);
+    }
+}

--- a/src/terrain/scatter.rs
+++ b/src/terrain/scatter.rs
@@ -1,6 +1,6 @@
 //! The `terrain.scatter` operator: PCG placement over paint channels.
 //!
-//! A run stamps ordinary editable
+//! Generator proposes, painter disposes. A run stamps ordinary editable
 //! entities -- the same `GltfSource` + `WorldAssetRoot` + `Transform`
 //! shape a drag from the asset browser produces
 //! ([`crate::entity_ops::spawn_gltf`]) -- parented under one named group
@@ -13,11 +13,11 @@
 //! generator produced. On re-run an instance whose live `Transform` still
 //! equals its recorded one is *untouched* and gets replaced; one the user
 //! moved, rotated or scaled no longer matches and is preserved. That is
-//! the whole rule: it needs no bookkeeping beyond what the scene already
-//! saves, and it survives a save/load round trip because both halves are
-//! reflected data.
+//! the whole definition, and it is deliberately narrow: it needs no
+//! bookkeeping beyond what is already saved in the scene, and it survives
+//! a save/load round trip because both halves are reflected data.
 //!
-//! The random stream lives in [`jackdaw_terrain::scatter`] and derives
+//! The random stream lives in [`jackdaw_terrain::scatter()`] and derives
 //! from `(seed, cell index)` only. Nothing in this file adds randomness.
 
 use std::sync::{Arc, Mutex};
@@ -100,7 +100,8 @@ pub struct ScatterInstance {
 pub struct ScatterAsset {
     /// Project-relative or absolute path to a `.gltf` / `.glb`.
     pub path: String,
-    /// Whether this entry takes part in the next run.
+    /// Whether this entry takes part in the next run. Unreal's per-row
+    /// checkbox and `Terrain3D`'s per-tile eye are the same control.
     pub active: bool,
 }
 
@@ -863,9 +864,10 @@ pub(super) fn signature(
 
 /// The Scatter section of the terrain inspector.
 ///
-/// Reads top to bottom in workflow order: *what* is being placed (the
-/// asset palette), *where* it may go (the mask), then *how much* and *how
-/// varied*.
+/// Laid out in the order the reference tools use, so the workflow reads
+/// top to bottom the way it does in Unreal's Foliage panel and Unity's
+/// Paint Trees: *what* is being placed (the asset palette), *where* it
+/// may go (the mask), then *how much* and *how varied*.
 pub(super) fn spawn_scatter_ui(
     commands: &mut Commands,
     parent: Entity,
@@ -1029,8 +1031,9 @@ pub(super) fn spawn_scatter_ui(
         ChildOf(parent),
     ));
 
-    // Instance-count feedback: without it a user cannot tell a run that
-    // placed nothing from one that never ran.
+    // Instance-count feedback, the way Unreal shows a live count on the
+    // foliage type and ProtonScatter shows Instance Count: without it a
+    // user cannot tell a run that placed nothing from one that never ran.
     if !report.message.is_empty() {
         spawn_hint(commands, parent, &report.message);
     }

--- a/src/terrain/scatter.rs
+++ b/src/terrain/scatter.rs
@@ -38,6 +38,13 @@ use super::inspector::{
     spawn_add_tile, spawn_hint, spawn_labeled_field, spawn_tile, spawn_tile_grid, spawn_tile_remove,
 };
 use super::ops::has_selected_terrain;
+
+/// A run estimated to place more instances than this is refused rather
+/// than spawning that many entities (and undo-stack history) in one
+/// click. High enough for any legitimate scatter; low enough that a
+/// stray density (a pasted value, a unit mismatch) cannot hang the
+/// editor or balloon the undo stack.
+const MAX_SCATTER_INSTANCES: u32 = 100_000;
 use crate::commands::{CommandGroup, CommandHistory, DespawnEntity, EditorCommand, SpawnEntity};
 use crate::selection::Selection;
 
@@ -527,6 +534,30 @@ fn run_scatter(world: &mut World, params: &OperatorParameters) {
             .unwrap_or(state.align_to_normal),
         asset_count: assets.len(),
     };
+
+    // A mask or a weight channel only ever reduce the instance count from
+    // here, so density times the full world area is a safe upper bound
+    // on what the kernel would produce -- cheap to check before running
+    // it. Without a cap, one click at a stray density (a pasted value, a
+    // unit mismatch) can queue an unbounded number of spawns onto the
+    // undo stack.
+    let world_area = f64::from(terrain.size.x) * f64::from(terrain.size.y);
+    let estimated_instances = f64::from(scatter_params.density) * world_area;
+    if estimated_instances > MAX_SCATTER_INSTANCES as f64 {
+        set_report(
+            world,
+            TerrainScatterReport {
+                message: format!(
+                    "refused: density {} over {world_area:.0} square units would place \
+                     roughly {estimated_instances:.0} instances, over the \
+                     {MAX_SCATTER_INSTANCES} limit; lower density or spacing and try again",
+                    scatter_params.density,
+                ),
+                ..default()
+            },
+        );
+        return;
+    }
 
     let (heightmap, channels) = {
         let mut store = world.resource_mut::<TerrainDataStore>();
@@ -1258,5 +1289,61 @@ mod tests {
             &Transform::default(),
         );
         assert!((upright.rotation * Vec3::Y).angle_between(Vec3::Y) < 1e-4);
+    }
+
+    /// I7 pinning test, the exact scenario from the review finding: a
+    /// stray density over a large terrain would previously queue an
+    /// unbounded number of spawns onto the undo stack. The run must be
+    /// refused up front, with a report, and never reach the kernel.
+    #[test]
+    fn a_pathological_density_is_refused_before_running_the_kernel() {
+        let mut world = World::new();
+        world.init_resource::<Selection>();
+        world.init_resource::<TerrainScatterState>();
+        world.init_resource::<TerrainScatterReport>();
+
+        let data_path = "zone.terrain-0.jdterrain";
+        let mut store = TerrainDataStore::default();
+        store.insert(
+            data_path,
+            jackdaw_terrain::TerrainData {
+                resolution: 4,
+                heights: vec![0.0; 16],
+                channels: vec![],
+            },
+        );
+        world.insert_resource(store);
+
+        world.spawn(jackdaw_scene_types::Terrain {
+            resolution: 4,
+            size: Vec2::splat(1000.0),
+            data_path: data_path.to_string(),
+            ..default()
+        });
+
+        use jackdaw_scene_types::PropertyValue;
+
+        let mut params = OperatorParameters::default();
+        params
+            .0
+            .insert("density".to_string(), PropertyValue::Float(1000.0));
+        params.0.insert(
+            "assets".to_string(),
+            PropertyValue::String("kit/Tree.gltf".into()),
+        );
+
+        run_scatter(&mut world, &params);
+
+        let report = world.resource::<TerrainScatterReport>();
+        assert_eq!(report.placed, 0, "a refused run must place nothing");
+        assert!(
+            report.message.contains("refused") && report.message.contains("100000"),
+            "report must explain the refusal: {}",
+            report.message
+        );
+        assert!(
+            world.query::<&ScatterGroup>().iter(&world).next().is_none(),
+            "a refused run must not spawn a group",
+        );
     }
 }

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -255,7 +255,11 @@ pub fn terrain_sculpt(
     if modal.is_none() {
         sculpt_state.active = true;
         sculpt_state.stroke_snapshot = data.heights.clone();
-    } else if mouse.just_released(MouseButton::Left) {
+    }
+
+    // See `super::stroke_should_end` doc: checked every frame, including
+    // the modal's first, not gated behind `else`/`modal.is_some()`.
+    if super::stroke_should_end(&mouse) {
         sculpt_state.active = false;
         history.push_executed(Box::new(SetTerrainHeights::new(
             target,

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
-use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 
 use super::{
     CHUNK_SIZE, TerrainBrushSettings, TerrainDataStore, TerrainDirtyChunks, TerrainEditMode,
@@ -234,9 +233,7 @@ fn sculpt_invoke_trigger(
 #[operator(
     id = "terrain.sculpt",
     label = "Sculpt Terrain",
-    description = "Apply the active sculpt tool while LMB is held. Modal: commits \
-                   the height delta as a single undo entry on release; Escape \
-                   restores the pre-stroke heights.",
+    description = "Sculpt the terrain under the brush while the mouse button is held.",
     modal = true,
     allows_undo = false,
     cancel = cancel_terrain_sculpt,
@@ -251,7 +248,7 @@ pub fn terrain_sculpt(
     mut store: ResMut<TerrainDataStore>,
     mut history: ResMut<CommandHistory>,
     time: Res<Time>,
-    modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+    active: ActiveModalQuery,
 ) -> OperatorResult {
     let TerrainEditMode::Sculpt(tool) = *edit_mode else {
         return OperatorResult::Cancelled;
@@ -260,7 +257,7 @@ pub fn terrain_sculpt(
     let (terrain, mut dirty) = terrain_query.get_mut(target)?;
     let data = store.entry_for(terrain)?;
 
-    if modal.is_none() {
+    if !active.is_modal_running() {
         sculpt_state.active = true;
         sculpt_state.stroke_snapshot = data.heights.clone();
     }

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -34,6 +34,16 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 /// not to the scene document. Pushing 262,144 floats through the BSN AST
 /// on every stroke is the defect the sidecar exists to fix, so this
 /// command deliberately does not sync the heights to the document.
+///
+/// Memory model: each entry holds two full heightmap copies (`old_heights`
+/// and `new_heights`), and [`CommandHistory`](crate::commands::CommandHistory)'s
+/// `undo_stack` is a plain, uncapped `Vec`. A long sculpting session on a
+/// large terrain therefore accumulates memory proportional to
+/// `resolution^2 * strokes` for as long as the tab stays open -- there is
+/// currently no depth cap or delta compression, and none is planned this
+/// round. If this becomes a real problem, the fix belongs at
+/// `CommandHistory` (a shared depth cap for every command type), not as
+/// special-casing here.
 pub struct SetTerrainHeights {
     pub entity: Entity,
     pub old_heights: Vec<f32>,
@@ -103,19 +113,17 @@ impl SetTerrainHeights {
 
 impl EditorCommand for SetTerrainHeights {
     fn execute(&mut self, world: &mut World) {
-        self.apply(
-            world,
-            &self.new_heights.clone(),
-            self.resize.map(|(_, new)| new),
-        );
+        // `apply` already copies its `heights` slice into the store
+        // (`data.heights = heights.to_vec()`), so cloning `new_heights`
+        // here first was a second full-array copy for nothing -- a
+        // 512-resolution terrain is 262,144 floats, so that was 1 MiB
+        // wasted per undo/redo click. `&self.new_heights` borrows
+        // straight from the command.
+        self.apply(world, &self.new_heights, self.resize.map(|(_, new)| new));
     }
 
     fn undo(&mut self, world: &mut World) {
-        self.apply(
-            world,
-            &self.old_heights.clone(),
-            self.resize.map(|(old, _)| old),
-        );
+        self.apply(world, &self.old_heights, self.resize.map(|(old, _)| old));
     }
 
     fn description(&self) -> &str {

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -3,7 +3,8 @@ use jackdaw_api::prelude::*;
 use jackdaw_api_internal::lifecycle::ActiveModalOperator;
 
 use super::{
-    CHUNK_SIZE, TerrainBrushSettings, TerrainDirtyChunks, TerrainEditMode, TerrainSculptState,
+    CHUNK_SIZE, TerrainBrushSettings, TerrainDataStore, TerrainDirtyChunks, TerrainEditMode,
+    TerrainSculptState,
 };
 use crate::commands::{CommandHistory, EditorCommand};
 use crate::default_style;
@@ -28,32 +29,93 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 }
 
 /// Undo command for terrain height changes.
+///
+/// Heights are written to [`TerrainDataStore`], not to the component and
+/// not to the scene document. Pushing 262,144 floats through the BSN AST
+/// on every stroke is the defect the sidecar exists to fix, so this
+/// command deliberately does not sync the heights to the document.
 pub struct SetTerrainHeights {
     pub entity: Entity,
     pub old_heights: Vec<f32>,
     pub new_heights: Vec<f32>,
     pub label: String,
+    /// Optional `(old, new)` world size to move with the heights.
+    ///
+    /// Only the quantize operator sets this. Pinning a terrain's vertex
+    /// spacing to a metric cell size resizes it and re-snaps its heights
+    /// in one gesture, and undoing half of that leaves the terrain at a
+    /// spacing its heights were never snapped for. `size` is three
+    /// floats, not a per-cell array, so it does reach the document --
+    /// the rule this command exists to keep is about bulk data, not
+    /// about every field.
+    pub resize: Option<(Vec2, Vec2)>,
+}
+
+impl SetTerrainHeights {
+    /// Construct a heights-only entry. The overwhelmingly common case:
+    /// a stroke, a generate, an erode.
+    pub fn new(
+        entity: Entity,
+        old_heights: Vec<f32>,
+        new_heights: Vec<f32>,
+        label: String,
+    ) -> Self {
+        Self {
+            entity,
+            old_heights,
+            new_heights,
+            label,
+            resize: None,
+        }
+    }
+
+    fn apply(&self, world: &mut World, heights: &[f32], size: Option<Vec2>) {
+        if let Some(size) = size {
+            let resized = match world.get_mut::<jackdaw_scene_types::Terrain>(self.entity) {
+                Some(mut terrain) if terrain.size != size => {
+                    terrain.size = size;
+                    Some(terrain.clone())
+                }
+                _ => None,
+            };
+            if let Some(terrain) = resized {
+                crate::commands::sync_component_to_ast(
+                    world,
+                    self.entity,
+                    "jackdaw_scene_types::types::Terrain",
+                    &terrain,
+                );
+            }
+        }
+        let Some(terrain) = world.get::<jackdaw_scene_types::Terrain>(self.entity) else {
+            return;
+        };
+        let terrain = terrain.clone();
+        if let Some(data) = world.resource_mut::<TerrainDataStore>().entry_for(&terrain) {
+            data.heights = heights.to_vec();
+            data.normalize();
+        }
+        if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
+            dirty.rebuild_all = true;
+        }
+    }
 }
 
 impl EditorCommand for SetTerrainHeights {
     fn execute(&mut self, world: &mut World) {
-        if let Some(mut terrain) = world.get_mut::<jackdaw_scene_types::Terrain>(self.entity) {
-            terrain.heights = self.new_heights.clone();
-        }
-        if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
-            dirty.rebuild_all = true;
-        }
-        sync_terrain_heights_to_ast(world, self.entity);
+        self.apply(
+            world,
+            &self.new_heights.clone(),
+            self.resize.map(|(_, new)| new),
+        );
     }
 
     fn undo(&mut self, world: &mut World) {
-        if let Some(mut terrain) = world.get_mut::<jackdaw_scene_types::Terrain>(self.entity) {
-            terrain.heights = self.old_heights.clone();
-        }
-        if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
-            dirty.rebuild_all = true;
-        }
-        sync_terrain_heights_to_ast(world, self.entity);
+        self.apply(
+            world,
+            &self.old_heights.clone(),
+            self.resize.map(|(old, _)| old),
+        );
     }
 
     fn description(&self) -> &str {
@@ -61,21 +123,9 @@ impl EditorCommand for SetTerrainHeights {
     }
 }
 
-fn sync_terrain_heights_to_ast(world: &mut World, entity: Entity) {
-    if let Some(terrain) = world.get::<jackdaw_scene_types::Terrain>(entity) {
-        let terrain = terrain.clone();
-        crate::commands::sync_component_to_ast(
-            world,
-            entity,
-            "jackdaw_scene_types::types::terrain::Terrain",
-            &terrain,
-        );
-    }
-}
-
 /// Raycast the cursor against the selected terrain's XZ plane and
 /// return the (entity, grid coordinate) that the brush should target.
-fn terrain_brush_hit(
+pub(super) fn terrain_brush_hit(
     vp: &crate::viewport::ViewportCursor,
     terrain_query: &Query<(Entity, &jackdaw_scene_types::Terrain, &GlobalTransform)>,
     selection: &Selection,
@@ -107,16 +157,17 @@ fn terrain_brush_hit(
         return None;
     }
 
-    let heightmap = jackdaw_terrain::Heightmap {
-        resolution: terrain.resolution,
-        size: terrain.size,
-        max_height: terrain.max_height,
-        heights: terrain.heights.clone(),
-    };
-    Some((
-        terrain_entity,
-        heightmap.world_to_grid(Vec2::new(local.x, local.z)),
-    ))
+    Some((terrain_entity, local_to_grid(terrain, local.xz())))
+}
+
+/// Grid coordinate of a terrain-local XZ position.
+///
+/// Pure geometry, so the brush cursor does not copy a 512-resolution
+/// heightmap out of the store every frame just to learn which cell it is
+/// hovering. Mirrors `Heightmap::world_to_grid`.
+fn local_to_grid(terrain: &jackdaw_scene_types::Terrain, local: Vec2) -> Vec2 {
+    let cell = terrain.size / (terrain.resolution.max(2) - 1) as f32;
+    (local + terrain.size / 2.0) / cell
 }
 
 /// Track the brush-target grid position so the overlay gizmo follows
@@ -188,7 +239,8 @@ pub fn terrain_sculpt(
     edit_mode: Res<TerrainEditMode>,
     brush_settings: Res<TerrainBrushSettings>,
     mut sculpt_state: ResMut<TerrainSculptState>,
-    mut terrain_query: Query<(&mut jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut store: ResMut<TerrainDataStore>,
     mut history: ResMut<CommandHistory>,
     time: Res<Time>,
     modal: Option<Single<Entity, With<ActiveModalOperator>>>,
@@ -197,19 +249,20 @@ pub fn terrain_sculpt(
         return OperatorResult::Cancelled;
     };
     let target = sculpt_state.target?;
-    let (mut terrain, mut dirty) = terrain_query.get_mut(target)?;
+    let (terrain, mut dirty) = terrain_query.get_mut(target)?;
+    let data = store.entry_for(terrain)?;
 
     if modal.is_none() {
         sculpt_state.active = true;
-        sculpt_state.stroke_snapshot = terrain.heights.clone();
+        sculpt_state.stroke_snapshot = data.heights.clone();
     } else if mouse.just_released(MouseButton::Left) {
         sculpt_state.active = false;
-        history.push_executed(Box::new(SetTerrainHeights {
-            entity: target,
-            old_heights: std::mem::take(&mut sculpt_state.stroke_snapshot),
-            new_heights: terrain.heights.clone(),
-            label: format!("Terrain {tool:?}"),
-        }));
+        history.push_executed(Box::new(SetTerrainHeights::new(
+            target,
+            std::mem::take(&mut sculpt_state.stroke_snapshot),
+            data.heights.clone(),
+            format!("Terrain {tool:?}"),
+        )));
         return OperatorResult::Finished;
     }
 
@@ -218,7 +271,7 @@ pub fn terrain_sculpt(
             resolution: terrain.resolution,
             size: terrain.size,
             max_height: terrain.max_height,
-            heights: terrain.heights.clone(),
+            heights: std::mem::take(&mut data.heights),
         };
         jackdaw_terrain::apply_brush(
             &mut hm,
@@ -230,9 +283,23 @@ pub fn terrain_sculpt(
             time.delta_secs(),
             None,
         );
+        // Snap inside the stroke, not on release: the user has to watch
+        // the terraces form while dragging, or they are sculpting one
+        // surface and getting another. Only the cells the brush touched
+        // are rewritten, so this costs the brush footprint per frame
+        // rather than the whole array.
+        if let Some(step) = terrain.quantization.active_height_step() {
+            jackdaw_terrain::quantize_region(
+                &mut hm.heights,
+                terrain.resolution,
+                grid_pos,
+                brush_settings.radius,
+                step,
+            );
+        }
         let affected =
             jackdaw_terrain::affected_chunks(&hm, grid_pos, brush_settings.radius, CHUNK_SIZE);
-        terrain.heights = hm.heights;
+        data.heights = hm.heights;
         for chunk in affected {
             dirty.dirty.insert(chunk);
         }
@@ -242,7 +309,8 @@ pub fn terrain_sculpt(
 
 fn cancel_terrain_sculpt(
     mut sculpt_state: ResMut<TerrainSculptState>,
-    mut terrain_query: Query<(&mut jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut store: ResMut<TerrainDataStore>,
 ) {
     if !sculpt_state.active {
         return;
@@ -250,9 +318,11 @@ fn cancel_terrain_sculpt(
     sculpt_state.active = false;
     let snapshot = std::mem::take(&mut sculpt_state.stroke_snapshot);
     if let Some(target) = sculpt_state.target
-        && let Ok((mut terrain, mut dirty)) = terrain_query.get_mut(target)
+        && let Ok((terrain, mut dirty)) = terrain_query.get_mut(target)
+        && let Some(data) = store.entry_for(terrain)
     {
-        terrain.heights = snapshot;
+        data.heights = snapshot;
+        data.normalize();
         dirty.rebuild_all = true;
     }
 }
@@ -287,6 +357,7 @@ fn draw_terrain_brush_gizmo(
     brush_settings: Res<TerrainBrushSettings>,
     edit_mode: Res<TerrainEditMode>,
     terrains: Query<(&jackdaw_scene_types::Terrain, &GlobalTransform)>,
+    store: Res<TerrainDataStore>,
     mut gizmos: Gizmos,
 ) {
     if !matches!(*edit_mode, TerrainEditMode::Sculpt(_)) {
@@ -304,12 +375,7 @@ fn draw_terrain_brush_gizmo(
         return;
     };
 
-    let heightmap = jackdaw_terrain::Heightmap {
-        resolution: terrain.resolution,
-        size: terrain.size,
-        max_height: terrain.max_height,
-        heights: terrain.heights.clone(),
-    };
+    let heightmap = super::mesh::heightmap_from_terrain(terrain, &store);
 
     let segments = 32;
     let radius = brush_settings.radius;

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -35,12 +35,12 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 /// command deliberately does not sync the heights to the document.
 ///
 /// Memory model: each entry holds two full heightmap copies (`old_heights`
-/// and `new_heights`), and [`CommandHistory`](crate::commands::CommandHistory)'s
-/// `undo_stack` is a plain, uncapped `Vec`. A long sculpting session on a
-/// large terrain therefore accumulates memory proportional to
-/// `resolution^2 * strokes` for as long as the tab stays open -- there is
-/// currently no depth cap or delta compression, and none is planned this
-/// round. If this becomes a real problem, the fix belongs at
+/// and `new_heights`), and [`CommandHistory`]'s `undo_stack` is a plain,
+/// uncapped `Vec`. A long sculpting session on a large terrain therefore
+/// accumulates memory proportional to `resolution^2 * strokes` for as
+/// long as the tab stays open -- there is currently no depth cap or
+/// delta compression, and none is planned this round. If this becomes a
+/// real problem, the fix belongs at
 /// `CommandHistory` (a shared depth cap for every command type), not as
 /// special-casing here.
 pub struct SetTerrainHeights {

--- a/src/terrain/store.rs
+++ b/src/terrain/store.rs
@@ -5,28 +5,20 @@
 //! the scene-relative sidecar path the component carries, and they are
 //! written to that sidecar when the scene is saved.
 //!
-//! The indirection is what makes tab swaps safe. `capture_active_tab`
-//! snapshots the live scene by emitting it to BSN *text* and re-parsing
-//! it, and `activate_tab` respawns every entity from that text
-//! (`src/scenes/swap.rs`) -- no disk involved. Anything held on an entity
-//! is destroyed and rebuilt from text on every swap. A `Resource` is not,
-//! and a reflected `String` key survives the text round-trip, so nothing
-//! has to be carried across the swap at all.
+//! The active tab's decoded data lives in this resource. Inactive
+//! [`crate::scenes::SceneTab`]s own their stores directly; tab capture moves
+//! the live resource into the outgoing tab and activation restores the
+//! incoming tab's store before importing sidecars (`src/scenes/swap.rs`).
+//! This keeps identical scene-relative paths isolated between tabs while
+//! entities continue to round-trip through BSN text.
 
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use jackdaw_terrain::TerrainData;
 use jackdaw_terrain::sidecar;
 
-/// Every open terrain's bulk per-cell data, keyed by
+/// The active scene's terrain bulk data, keyed by
 /// [`jackdaw_scene_types::Terrain::data_path`].
-///
-/// Scope boundary: the key is the scene-relative path exactly as written
-/// on the component, so two scenes open at once that share both a file
-/// name and a terrain index address the same entry. Qualifying the key
-/// with the scene's own location would fix it and is not done here --
-/// untitled scenes have no location to qualify with, and the re-keying
-/// dance on first save is a bigger design decision than this issue owns.
 #[derive(Resource, Default)]
 pub struct TerrainDataStore {
     entries: HashMap<String, TerrainData>,

--- a/src/terrain/store.rs
+++ b/src/terrain/store.rs
@@ -78,8 +78,9 @@ impl TerrainDataStore {
     }
 
     /// Mark a sidecar path as failed to load: a file exists but its
-    /// contents could not be decoded. See [`Self::load_failed`] docs on
-    /// the field for why this is kept separate from "no entry".
+    /// contents could not be decoded. See the `load_failed` field's docs
+    /// (above, on this struct) for why this is kept separate from "no
+    /// entry".
     pub fn mark_load_failed(&mut self, data_path: impl Into<String>) {
         self.load_failed.insert(data_path.into());
     }

--- a/src/terrain/store.rs
+++ b/src/terrain/store.rs
@@ -12,7 +12,8 @@
 //! This keeps identical scene-relative paths isolated between tabs while
 //! entities continue to round-trip through BSN text.
 
-use bevy::platform::collections::HashMap;
+use bevy::log::warn_once;
+use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 use jackdaw_terrain::TerrainData;
 use jackdaw_terrain::sidecar;
@@ -22,6 +23,16 @@ use jackdaw_terrain::sidecar;
 #[derive(Resource, Default)]
 pub struct TerrainDataStore {
     entries: HashMap<String, TerrainData>,
+    /// Sidecar paths whose most recent read attempt found a file but
+    /// could not decode it (corrupt bytes, a newer format version, ...).
+    ///
+    /// Distinct from a path with no entry at all, which just means
+    /// "never loaded or created" -- that case is the ordinary flat-
+    /// terrain-on-a-missing-sidecar story and stays lenient. A
+    /// load-failed path is different: real data exists on disk and this
+    /// store must not fabricate a zeroed replacement for it, either for
+    /// editing or for save to write back over the original.
+    load_failed: HashSet<String>,
 }
 
 impl TerrainDataStore {
@@ -47,9 +58,13 @@ impl TerrainDataStore {
             .unwrap_or(&[])
     }
 
-    /// Install data for a sidecar path, replacing anything already there.
+    /// Install data for a sidecar path, replacing anything already there
+    /// and clearing any load-failed mark -- a fresh, successfully decoded
+    /// read supersedes a previous failure for the same path.
     pub fn insert(&mut self, data_path: impl Into<String>, data: TerrainData) {
-        self.entries.insert(data_path.into(), data);
+        let data_path = data_path.into();
+        self.load_failed.remove(&data_path);
+        self.entries.insert(data_path, data);
     }
 
     /// Drop a sidecar path's data.
@@ -62,6 +77,18 @@ impl TerrainDataStore {
         self.entries.contains_key(data_path)
     }
 
+    /// Mark a sidecar path as failed to load: a file exists but its
+    /// contents could not be decoded. See [`Self::load_failed`] docs on
+    /// the field for why this is kept separate from "no entry".
+    pub fn mark_load_failed(&mut self, data_path: impl Into<String>) {
+        self.load_failed.insert(data_path.into());
+    }
+
+    /// Whether a sidecar path's last read attempt failed to decode.
+    pub fn is_load_failed(&self, data_path: &str) -> bool {
+        self.load_failed.contains(data_path)
+    }
+
     /// Data for a terrain, created zeroed at the terrain's resolution if
     /// absent, resized if the resolution changed underneath, and
     /// reconciled against the terrain's declared channels.
@@ -70,11 +97,24 @@ impl TerrainDataStore {
     /// array can never be a different length than the terrain claims, and
     /// a channel the user just added is already zeroed at the right
     /// length by the time anything tries to paint it.
+    ///
+    /// Returns `None` and refuses the edit for a path marked
+    /// [`Self::is_load_failed`]: minting zeroed data here is exactly the
+    /// silent-data-loss path this store exists to prevent, since the
+    /// next save would otherwise write that zeroed data over the real
+    /// file.
     pub fn entry_for(
         &mut self,
         terrain: &jackdaw_scene_types::Terrain,
     ) -> Option<&mut TerrainData> {
         if terrain.data_path.is_empty() {
+            return None;
+        }
+        if self.load_failed.contains(&terrain.data_path) {
+            warn_once!(
+                "Refusing to edit terrain data that failed to load; \
+                 fix or replace the sidecar file and reload the scene"
+            );
             return None;
         }
         let data = self
@@ -352,5 +392,24 @@ mod tests {
         let path = mint_data_path(&store, "");
         assert!(path.starts_with("untitled.terrain-"));
         assert!(path.ends_with(sidecar::EXTENSION));
+    }
+
+    /// C1: a path marked load-failed must refuse edits rather than mint
+    /// zeroed data that a later save would write over the real file.
+    #[test]
+    fn entry_for_refuses_a_load_failed_path() {
+        let mut store = TerrainDataStore::default();
+        store.mark_load_failed("a.jdterrain");
+        assert!(store.entry_for(&terrain(4, "a.jdterrain")).is_none());
+        assert!(!store.contains("a.jdterrain"));
+    }
+
+    #[test]
+    fn inserting_data_clears_a_previous_load_failed_mark() {
+        let mut store = TerrainDataStore::default();
+        store.mark_load_failed("a.jdterrain");
+        store.insert("a.jdterrain", TerrainData::default());
+        assert!(!store.is_load_failed("a.jdterrain"));
+        assert!(store.entry_for(&terrain(4, "a.jdterrain")).is_some());
     }
 }

--- a/src/terrain/store.rs
+++ b/src/terrain/store.rs
@@ -1,0 +1,364 @@
+//! In-memory source of truth for terrain bulk data.
+//!
+//! Heights and paint-channel values do not live on the `Terrain`
+//! component and never enter the scene document. They live here, keyed by
+//! the scene-relative sidecar path the component carries, and they are
+//! written to that sidecar when the scene is saved.
+//!
+//! The indirection is what makes tab swaps safe. `capture_active_tab`
+//! snapshots the live scene by emitting it to BSN *text* and re-parsing
+//! it, and `activate_tab` respawns every entity from that text
+//! (`src/scenes/swap.rs`) -- no disk involved. Anything held on an entity
+//! is destroyed and rebuilt from text on every swap. A `Resource` is not,
+//! and a reflected `String` key survives the text round-trip, so nothing
+//! has to be carried across the swap at all.
+
+use bevy::platform::collections::HashMap;
+use bevy::prelude::*;
+use jackdaw_terrain::TerrainData;
+use jackdaw_terrain::sidecar;
+
+/// Every open terrain's bulk per-cell data, keyed by
+/// [`jackdaw_scene_types::Terrain::data_path`].
+///
+/// Scope boundary: the key is the scene-relative path exactly as written
+/// on the component, so two scenes open at once that share both a file
+/// name and a terrain index address the same entry. Qualifying the key
+/// with the scene's own location would fix it and is not done here --
+/// untitled scenes have no location to qualify with, and the re-keying
+/// dance on first save is a bigger design decision than this issue owns.
+#[derive(Resource, Default)]
+pub struct TerrainDataStore {
+    entries: HashMap<String, TerrainData>,
+}
+
+impl TerrainDataStore {
+    /// Data for a sidecar path, if this store has any.
+    pub fn get(&self, data_path: &str) -> Option<&TerrainData> {
+        self.entries.get(data_path)
+    }
+
+    /// Mutable data for a sidecar path, if this store has any.
+    pub fn get_mut(&mut self, data_path: &str) -> Option<&mut TerrainData> {
+        self.entries.get_mut(data_path)
+    }
+
+    /// Heights for a sidecar path, or an empty slice when absent.
+    ///
+    /// Callers that only sample heights want a slice, not an `Option`,
+    /// and a terrain with no data reads as flat -- which is exactly what
+    /// a missing sidecar is supposed to look like.
+    pub fn heights(&self, data_path: &str) -> &[f32] {
+        self.entries
+            .get(data_path)
+            .map(|data| data.heights.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Install data for a sidecar path, replacing anything already there.
+    pub fn insert(&mut self, data_path: impl Into<String>, data: TerrainData) {
+        self.entries.insert(data_path.into(), data);
+    }
+
+    /// Drop a sidecar path's data.
+    pub fn remove(&mut self, data_path: &str) -> Option<TerrainData> {
+        self.entries.remove(data_path)
+    }
+
+    /// Whether a sidecar path has data.
+    pub fn contains(&self, data_path: &str) -> bool {
+        self.entries.contains_key(data_path)
+    }
+
+    /// Data for a terrain, created zeroed at the terrain's resolution if
+    /// absent, resized if the resolution changed underneath, and
+    /// reconciled against the terrain's declared channels.
+    ///
+    /// Every mutating path goes through here, so a channel or height
+    /// array can never be a different length than the terrain claims, and
+    /// a channel the user just added is already zeroed at the right
+    /// length by the time anything tries to paint it.
+    pub fn entry_for(
+        &mut self,
+        terrain: &jackdaw_scene_types::Terrain,
+    ) -> Option<&mut TerrainData> {
+        if terrain.data_path.is_empty() {
+            return None;
+        }
+        let data = self
+            .entries
+            .entry(terrain.data_path.clone())
+            .or_insert_with(|| TerrainData {
+                resolution: terrain.resolution,
+                ..default()
+            });
+        if data.resolution != terrain.resolution {
+            data.resolution = terrain.resolution;
+        }
+        if data.heights.len() != terrain.cell_count() {
+            data.normalize();
+        }
+        reconcile_channels(data, terrain);
+        Some(data)
+    }
+
+    /// Every (sidecar path, data) pair currently held.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &TerrainData)> {
+        self.entries.iter()
+    }
+}
+
+/// Bring a terrain's stored channel values in line with the channel
+/// descriptors on its component.
+///
+/// The component owns the channel table -- names, widths, order -- and
+/// the sidecar owns the values. When the user adds, removes, renames or
+/// reorders a channel in the inspector, this is what carries the values
+/// along: matched by name, so a rename keeps what was painted and a
+/// reorder moves it rather than shuffling it into the wrong layer.
+///
+/// A channel added to a terrain that already has heights is initialised
+/// to zero at `resolution^2` here, which is the only place that can
+/// happen without the caller having to remember it.
+fn reconcile_channels(data: &mut TerrainData, terrain: &jackdaw_scene_types::Terrain) {
+    use jackdaw_terrain::{ChannelData, ChannelElement};
+
+    let wanted = |element: jackdaw_scene_types::TerrainChannelElement| match element {
+        jackdaw_scene_types::TerrainChannelElement::U8 => ChannelElement::U8,
+        jackdaw_scene_types::TerrainChannelElement::U16 => ChannelElement::U16,
+    };
+
+    if data.channels.len() == terrain.channels.len()
+        && data
+            .channels
+            .iter()
+            .zip(&terrain.channels)
+            .all(|(have, want)| have.name == want.name && have.element == wanted(want.element))
+    {
+        for channel in &mut data.channels {
+            channel.resize_to(terrain.resolution);
+        }
+        return;
+    }
+
+    let mut previous = std::mem::take(&mut data.channels);
+    data.channels = terrain
+        .channels
+        .iter()
+        .map(|descriptor| {
+            let element = wanted(descriptor.element);
+            let taken = previous
+                .iter()
+                .position(|had| had.name == descriptor.name)
+                .map(|at| previous.remove(at));
+            let mut channel = taken.unwrap_or_else(|| {
+                ChannelData::new(descriptor.name.clone(), element, terrain.resolution)
+            });
+            channel.name = descriptor.name.clone();
+            channel.element = element;
+            channel.resize_to(terrain.resolution);
+            channel
+        })
+        .collect();
+}
+
+/// Mint a sidecar path for a new terrain in `scene_stem`'s scene, unique
+/// against everything the store already holds.
+///
+/// Uniqueness is checked against the whole store rather than the current
+/// scene so two terrains created in two open tabs cannot collide.
+pub fn mint_data_path(store: &TerrainDataStore, scene_stem: &str) -> String {
+    let stem = if scene_stem.is_empty() {
+        "untitled"
+    } else {
+        scene_stem
+    };
+    for n in 0.. {
+        let candidate = format!("{stem}.terrain-{n}.{}", sidecar::EXTENSION);
+        if !store.contains(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("the candidate space is unbounded")
+}
+
+/// File stem of the scene currently being saved or edited, for naming a
+/// new terrain's sidecar. Falls back to `untitled` for unsaved scenes.
+pub fn active_scene_stem(world: &World) -> String {
+    world
+        .get_resource::<crate::scene_io::SceneFilePath>()
+        .and_then(|scene| scene.path.as_ref())
+        .and_then(|path| {
+            std::path::Path::new(path)
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "untitled".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn terrain(resolution: u32, data_path: &str) -> jackdaw_scene_types::Terrain {
+        jackdaw_scene_types::Terrain {
+            resolution,
+            data_path: data_path.to_string(),
+            ..default()
+        }
+    }
+
+    #[test]
+    fn entry_for_creates_a_zeroed_array_at_the_terrain_resolution() {
+        let mut store = TerrainDataStore::default();
+        let data = store.entry_for(&terrain(4, "a.jdterrain")).expect("keyed");
+        assert_eq!(data.heights.len(), 16);
+        assert!(data.heights.iter().all(|h| *h == 0.0));
+    }
+
+    #[test]
+    fn entry_for_resizes_when_the_resolution_changed_underneath() {
+        let mut store = TerrainDataStore::default();
+        store
+            .entry_for(&terrain(4, "a.jdterrain"))
+            .expect("keyed")
+            .heights[0] = 3.0;
+        let grown = store.entry_for(&terrain(8, "a.jdterrain")).expect("keyed");
+        assert_eq!(grown.resolution, 8);
+        assert_eq!(grown.heights.len(), 64);
+        assert_eq!(grown.heights[0], 3.0, "existing cells survive the resize");
+    }
+
+    #[test]
+    fn a_terrain_without_a_data_path_has_no_entry() {
+        let mut store = TerrainDataStore::default();
+        assert!(store.entry_for(&terrain(4, "")).is_none());
+        assert_eq!(store.iter().count(), 0);
+    }
+
+    #[test]
+    fn heights_of_an_unknown_path_read_as_flat_rather_than_panicking() {
+        let store = TerrainDataStore::default();
+        assert!(store.heights("nothing-here.jdterrain").is_empty());
+    }
+
+    /// The headline acceptance for channels: adding one to a terrain that
+    /// already has heights must give it `resolution^2` zeroes, without
+    /// the caller having to remember to size it.
+    #[test]
+    fn a_channel_added_to_a_sculpted_terrain_is_zeroed_at_the_right_length() {
+        use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement};
+
+        let mut store = TerrainDataStore::default();
+        let mut sculpted = terrain(8, "a.jdterrain");
+        store.entry_for(&sculpted).expect("keyed").heights = vec![2.0; 64];
+
+        sculpted.channels.push(TerrainChannel {
+            name: "biome".to_string(),
+            element: TerrainChannelElement::U8,
+            palette: vec![],
+        });
+        let data = store.entry_for(&sculpted).expect("keyed");
+        assert_eq!(data.channels.len(), 1);
+        assert_eq!(data.channels[0].values.len(), 64);
+        assert!(data.channels[0].values.iter().all(|v| *v == 0));
+        assert_eq!(data.heights, vec![2.0; 64], "heights are untouched");
+    }
+
+    /// Renaming a channel must carry what was painted into it. Matching
+    /// by name means a reorder moves values with their layer instead of
+    /// shuffling them into the wrong one.
+    #[test]
+    fn reordering_channels_moves_their_values_rather_than_shuffling_them() {
+        use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement};
+
+        let channel = |name: &str| TerrainChannel {
+            name: name.to_string(),
+            element: TerrainChannelElement::U8,
+            palette: vec![],
+        };
+
+        let mut store = TerrainDataStore::default();
+        let mut two = terrain(4, "a.jdterrain");
+        two.channels = vec![channel("biome"), channel("walkable")];
+        {
+            let data = store.entry_for(&two).expect("keyed");
+            data.channels[0].values[0] = 11;
+            data.channels[1].values[0] = 22;
+        }
+
+        two.channels.swap(0, 1);
+        let data = store.entry_for(&two).expect("keyed");
+        assert_eq!(data.channels[0].name, "walkable");
+        assert_eq!(data.channels[0].values[0], 22);
+        assert_eq!(data.channels[1].name, "biome");
+        assert_eq!(data.channels[1].values[0], 11);
+    }
+
+    /// Removing a channel drops its values with it, and leaves the
+    /// survivors alone.
+    #[test]
+    fn removing_a_channel_drops_only_its_own_values() {
+        use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement};
+
+        let channel = |name: &str| TerrainChannel {
+            name: name.to_string(),
+            element: TerrainChannelElement::U8,
+            palette: vec![],
+        };
+
+        let mut store = TerrainDataStore::default();
+        let mut two = terrain(4, "a.jdterrain");
+        two.channels = vec![channel("biome"), channel("walkable")];
+        store.entry_for(&two).expect("keyed").channels[1].values[3] = 9;
+
+        two.channels.remove(0);
+        let data = store.entry_for(&two).expect("keyed");
+        assert_eq!(data.channels.len(), 1);
+        assert_eq!(data.channels[0].name, "walkable");
+        assert_eq!(data.channels[0].values[3], 9);
+    }
+
+    /// A `u8` channel widened to `u16` keeps what was painted; only its
+    /// ceiling changes.
+    #[test]
+    fn widening_a_channel_keeps_its_values() {
+        use jackdaw_scene_types::{TerrainChannel, TerrainChannelElement};
+
+        let mut store = TerrainDataStore::default();
+        let mut narrow = terrain(4, "a.jdterrain");
+        narrow.channels = vec![TerrainChannel {
+            name: "biome".to_string(),
+            element: TerrainChannelElement::U8,
+            palette: vec![],
+        }];
+        store.entry_for(&narrow).expect("keyed").channels[0].values[2] = 200;
+
+        narrow.channels[0].element = TerrainChannelElement::U16;
+        let data = store.entry_for(&narrow).expect("keyed");
+        assert_eq!(
+            data.channels[0].element,
+            jackdaw_terrain::ChannelElement::U16
+        );
+        assert_eq!(data.channels[0].values[2], 200);
+    }
+
+    #[test]
+    fn minted_paths_do_not_collide_with_what_the_store_already_holds() {
+        let mut store = TerrainDataStore::default();
+        let first = mint_data_path(&store, "level");
+        assert_eq!(first, format!("level.terrain-0.{}", sidecar::EXTENSION));
+        store.insert(first.clone(), TerrainData::default());
+        let second = mint_data_path(&store, "level");
+        assert_ne!(second, first);
+        assert_eq!(second, format!("level.terrain-1.{}", sidecar::EXTENSION));
+    }
+
+    #[test]
+    fn an_unnamed_scene_still_mints_a_usable_path() {
+        let store = TerrainDataStore::default();
+        let path = mint_data_path(&store, "");
+        assert!(path.starts_with("untitled.terrain-"));
+        assert!(path.ends_with(sidecar::EXTENSION));
+    }
+}

--- a/src/terrain/store.rs
+++ b/src/terrain/store.rs
@@ -197,8 +197,16 @@ fn reconcile_channels(data: &mut TerrainData, terrain: &jackdaw_scene_types::Ter
 /// Mint a sidecar path for a new terrain in `scene_stem`'s scene, unique
 /// against everything the store already holds.
 ///
-/// Uniqueness is checked against the whole store rather than the current
-/// scene so two terrains created in two open tabs cannot collide.
+/// Uniqueness is checked against the whole store, not just the terrains
+/// currently spawned in the scene: the store can hold entries for a
+/// terrain the scene does not currently have live, e.g. one an undo
+/// brought back or a delete has not yet been redone past. Checking only
+/// live terrains could mint a path that collides with one of those once
+/// it resurfaces. This does not, on its own, prevent a collision with a
+/// path minted in a *different* open tab -- each inactive
+/// [`crate::scenes::SceneTab`] owns its own separate
+/// [`TerrainDataStore`], so this function only ever sees one tab's store
+/// at a time.
 pub fn mint_data_path(store: &TerrainDataStore, scene_stem: &str) -> String {
     let stem = if scene_stem.is_empty() {
         "untitled"

--- a/src/terrain/toolbar.rs
+++ b/src/terrain/toolbar.rs
@@ -1,8 +1,10 @@
-use bevy::feathers::controls::ButtonVariant;
+use bevy::feathers::controls::{ButtonVariant, FeathersToolButton};
 use bevy::feathers::display::label_dim;
 use bevy::prelude::*;
+use bevy::text::{FontSize, FontSourceTemplate};
 use jackdaw_api::prelude::*;
-use jackdaw_feathers::button::{ButtonOperatorCall, operator_button};
+use jackdaw_feathers::button::ButtonOperatorCall;
+use jackdaw_feathers::icons::{Icon, font_paths};
 use jackdaw_feathers::tokens;
 
 use super::TerrainEditMode;
@@ -10,19 +12,34 @@ use super::ops::{
     TerrainToolFlattenOp, TerrainToolGenerateOp, TerrainToolLowerOp, TerrainToolNoiseOp,
     TerrainToolRaiseOp, TerrainToolSmoothOp,
 };
+use super::paint::TerrainToolPaintOp;
 use crate::selection::Selection;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         Update,
-        toggle_toolbar_visibility.run_if(in_state(crate::AppState::Editor)),
+        (toggle_toolbar_visibility, update_active_tool_description)
+            .run_if(in_state(crate::AppState::Editor)),
     )
     .add_observer(update_terrain_tool_highlights);
 }
 
+/// Icon size in the terrain toolbar. Matches the main toolbar's, so the
+/// two rows read as one control surface rather than two.
+const TOOL_ICON_PX: f32 = 16.0;
+
 /// Marker for the terrain contextual toolbar node.
 #[derive(Component)]
 pub struct TerrainToolbar;
+
+/// Marker on the text node that describes the active terrain tool.
+///
+/// Every reference tool pairs its icon row with a one-line description of
+/// the selected tool -- Unity puts "Paints the selected material layer
+/// onto the terrain texture" directly under its five icons. Each terrain
+/// operator already carries a `description`; this surfaces it.
+#[derive(Component, Clone, Default)]
+struct TerrainToolDescription;
 
 /// Builds the terrain toolbar as a `bsn!` Scene. Starts hidden
 /// (`Display::None`).
@@ -30,9 +47,9 @@ pub struct TerrainToolbar;
 /// Spawned standalone via `spawn_scene`; see
 /// `viewport::build_viewport_panel`. A Scene can't nest inside a Bundle
 /// `children!` tree, and the spawn site attaches the [`TerrainToolbar`]
-/// and `EditorEntity` markers. Each button is an [`operator_button`]
-/// carrying a `ButtonOperatorCall`. The editor's operator-button glue
-/// dispatches the op on `Activate` and greys it out when unavailable.
+/// and `EditorEntity` markers. Each button is a [`tool_button`] carrying a
+/// `ButtonOperatorCall`. The editor's operator-button glue dispatches the
+/// op on `Activate` and greys it out when unavailable.
 pub fn terrain_toolbar() -> impl Scene {
     bsn! {
         Node {
@@ -48,14 +65,86 @@ pub fn terrain_toolbar() -> impl Scene {
         BackgroundColor(tokens::TOOLBAR_BG)
         Children [
             label_dim("Terrain"),
-            operator_button(TerrainToolRaiseOp::ID, TerrainToolRaiseOp::LABEL),
-            operator_button(TerrainToolLowerOp::ID, TerrainToolLowerOp::LABEL),
-            operator_button(TerrainToolFlattenOp::ID, TerrainToolFlattenOp::LABEL),
-            operator_button(TerrainToolSmoothOp::ID, TerrainToolSmoothOp::LABEL),
-            operator_button(TerrainToolNoiseOp::ID, TerrainToolNoiseOp::LABEL),
+            tool_button(TerrainToolRaiseOp::ID, Icon::ArrowUpFromLine),
+            tool_button(TerrainToolLowerOp::ID, Icon::ArrowDownToLine),
+            tool_button(TerrainToolFlattenOp::ID, Icon::Minimize2),
+            tool_button(TerrainToolSmoothOp::ID, Icon::Spline),
+            tool_button(TerrainToolNoiseOp::ID, Icon::Waves),
             vertical_separator(),
-            operator_button(TerrainToolGenerateOp::ID, TerrainToolGenerateOp::LABEL),
+            tool_button(TerrainToolPaintOp::ID, Icon::Paintbrush),
+            vertical_separator(),
+            tool_button(TerrainToolGenerateOp::ID, Icon::Mountain),
+            vertical_separator(),
+            active_tool_description(),
         ]
+    }
+}
+
+/// One terrain tool: a Lucide glyph in a `FeathersToolButton`, matching
+/// the main toolbar's idiom exactly rather than the text-label buttons
+/// this row used to carry. The operator's `label` and `description` reach
+/// the user through the hover tooltip the operator-button glue attaches
+/// and through the description line below the row.
+fn tool_button(op_id: &'static str, icon: Icon) -> impl Scene {
+    let glyph = String::from(icon.unicode());
+    bsn! {
+        @FeathersToolButton {
+            @caption: bsn! {
+                Text(glyph)
+                TextFont {
+                    font: FontSourceTemplate::Handle(font_paths::LUCIDE),
+                    font_size: FontSize::Px(TOOL_ICON_PX),
+                }
+            },
+            @variant: {ButtonVariant::Plain}
+        }
+        ButtonOperatorCall::new(op_id)
+    }
+}
+
+fn active_tool_description() -> impl Scene {
+    bsn! {
+        Text("")
+        TextFont { font_size: {tokens::TEXT_SIZE_XS} }
+        TextColor({tokens::TEXT_SECONDARY})
+        TerrainToolDescription
+    }
+}
+
+/// Human-readable summary of what the active tool does, in the same
+/// register as Unity's one-liner under its tool icons.
+fn describe(mode: &TerrainEditMode) -> &'static str {
+    use jackdaw_terrain::SculptTool;
+    match mode {
+        TerrainEditMode::None => "Pick a tool to start editing this terrain.",
+        TerrainEditMode::Sculpt(SculptTool::Raise) => "Raises the terrain under the brush.",
+        TerrainEditMode::Sculpt(SculptTool::Lower) => "Lowers the terrain under the brush.",
+        TerrainEditMode::Sculpt(SculptTool::Flatten) => {
+            "Levels the terrain under the brush toward its starting height."
+        }
+        TerrainEditMode::Sculpt(SculptTool::Smooth) => {
+            "Averages the terrain under the brush, softening hard edges."
+        }
+        TerrainEditMode::Sculpt(SculptTool::Noise) => "Adds fine random detail under the brush.",
+        TerrainEditMode::Paint => {
+            "Paints the selected palette value into the active channel. Hold Ctrl to erase."
+        }
+        TerrainEditMode::Generate => "Builds a whole heightmap from noise settings.",
+    }
+}
+
+fn update_active_tool_description(
+    edit_mode: Res<TerrainEditMode>,
+    mut labels: Query<&mut Text, With<TerrainToolDescription>>,
+) {
+    if !edit_mode.is_changed() {
+        return;
+    }
+    let text = describe(&edit_mode);
+    for mut label in &mut labels {
+        if label.0 != text {
+            label.0 = text.to_string();
+        }
     }
 }
 
@@ -145,6 +234,8 @@ fn terrain_tool_active(mode: &TerrainEditMode, op_id: &str) -> Option<bool> {
         Some(matches!(mode, TerrainEditMode::Sculpt(SculptTool::Smooth)))
     } else if op_id == TerrainToolNoiseOp::ID {
         Some(matches!(mode, TerrainEditMode::Sculpt(SculptTool::Noise)))
+    } else if op_id == TerrainToolPaintOp::ID {
+        Some(*mode == TerrainEditMode::Paint)
     } else if op_id == TerrainToolGenerateOp::ID {
         Some(*mode == TerrainEditMode::Generate)
     } else {

--- a/src/terrain/toolbar.rs
+++ b/src/terrain/toolbar.rs
@@ -34,8 +34,10 @@ pub struct TerrainToolbar;
 
 /// Marker on the text node that describes the active terrain tool.
 ///
-/// Each terrain operator already carries a `description`; this surfaces
-/// the selected one under the icon row.
+/// Every reference tool pairs its icon row with a one-line description of
+/// the selected tool -- Unity puts "Paints the selected material layer
+/// onto the terrain texture" directly under its five icons. Each terrain
+/// operator already carries a `description`; this surfaces it.
 #[derive(Component, Clone, Default)]
 struct TerrainToolDescription;
 
@@ -45,7 +47,7 @@ struct TerrainToolDescription;
 /// Spawned standalone via `spawn_scene`; see
 /// `viewport::build_viewport_panel`. A Scene can't nest inside a Bundle
 /// `children!` tree, and the spawn site attaches the [`TerrainToolbar`]
-/// and `EditorEntity` markers. Each button is a [`tool_button`] carrying a
+/// and `EditorEntity` markers. Each button is a `tool_button` carrying a
 /// `ButtonOperatorCall`. The editor's operator-button glue dispatches the
 /// op on `Activate` and greys it out when unavailable.
 pub fn terrain_toolbar() -> impl Scene {
@@ -109,7 +111,8 @@ fn active_tool_description() -> impl Scene {
     }
 }
 
-/// Human-readable summary of what the active tool does.
+/// Human-readable summary of what the active tool does, in the same
+/// register as Unity's one-liner under its tool icons.
 fn describe(mode: &TerrainEditMode) -> &'static str {
     use jackdaw_terrain::SculptTool;
     match mode {

--- a/src/terrain/toolbar.rs
+++ b/src/terrain/toolbar.rs
@@ -34,10 +34,8 @@ pub struct TerrainToolbar;
 
 /// Marker on the text node that describes the active terrain tool.
 ///
-/// Every reference tool pairs its icon row with a one-line description of
-/// the selected tool -- Unity puts "Paints the selected material layer
-/// onto the terrain texture" directly under its five icons. Each terrain
-/// operator already carries a `description`; this surfaces it.
+/// Each terrain operator already carries a `description`; this surfaces
+/// the selected one under the icon row.
 #[derive(Component, Clone, Default)]
 struct TerrainToolDescription;
 
@@ -111,8 +109,7 @@ fn active_tool_description() -> impl Scene {
     }
 }
 
-/// Human-readable summary of what the active tool does, in the same
-/// register as Unity's one-liner under its tool icons.
+/// Human-readable summary of what the active tool does.
 fn describe(mode: &TerrainEditMode) -> &'static str {
     use jackdaw_terrain::SculptTool;
     match mode {

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -15,6 +15,7 @@ use jackdaw_api_internal::keymap::PresetInput;
 use jackdaw_camera::{JackdawCameraPlugin, JackdawCameraSettings};
 
 use bevy::ecs::system::SystemParam;
+use bevy::picking::mesh_picking::ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastVisibility};
 
 use crate::core_extension::CoreExtensionInputContext;
 use crate::selection::{Selected, Selection};
@@ -579,6 +580,8 @@ fn handle_viewport_drop(
     active: Res<ActiveViewport>,
     snap_settings: Res<crate::snapping::SnapSettings>,
     mut drag: ResMut<crate::asset_browser::ActiveAssetDrag>,
+    mut ray_cast: MeshRayCast,
+    editor_entities: Query<(), With<crate::EditorEntity>>,
     mut commands: Commands,
 ) {
     // The asset browser sets `ActiveAssetDrag.path` only for entries
@@ -618,12 +621,28 @@ fn handle_viewport_drop(
         return;
     };
 
-    let position =
-        cursor_to_ground_plane_for(cursor_pos, camera, cam_tf, viewport_entity, &viewport_query)
-            .unwrap_or(Vec3::ZERO);
+    let surface = cursor_to_surface_for(
+        cursor_pos,
+        camera,
+        cam_tf,
+        viewport_entity,
+        &viewport_query,
+        &mut ray_cast,
+        &editor_entities,
+    );
+    let position = surface
+        .or_else(|| {
+            cursor_to_ground_plane_for(cursor_pos, camera, cam_tf, viewport_entity, &viewport_query)
+        })
+        .unwrap_or(Vec3::ZERO);
 
     let ctrl = false; // No Ctrl check needed for drop placement
-    let snapped_pos = snap_settings.snap_translate_vec3_if(position, ctrl);
+    let mut snapped_pos = snap_settings.snap_translate_vec3_if(position, ctrl);
+    // Landing on the surface is the point; quantizing height would lift the
+    // drop off it or bury it. Grid snap still applies across the ground.
+    if surface.is_some() {
+        snapped_pos.y = position.y;
+    }
 
     if let Some(image_path) = image_drag {
         let path = image_path.to_string_lossy().replace('\\', "/");
@@ -683,6 +702,45 @@ pub(crate) fn cursor_to_ground_plane_for(
         viewport_query,
     )?;
     raycast_to_ground(camera, cam_tf, viewport_cursor)
+}
+
+/// World point where the cursor ray meets scene geometry, or `None` when it
+/// meets nothing.
+///
+/// This is what makes a drop land on the terrain or prop under the cursor
+/// rather than on the `Y=0` plane beneath it. Callers fall back to
+/// [`cursor_to_ground_plane_for`] so an empty scene still places at the
+/// ground.
+pub(crate) fn cursor_to_surface_for(
+    cursor_pos: Vec2,
+    camera: &Camera,
+    cam_tf: &GlobalTransform,
+    viewport_entity: Entity,
+    viewport_query: &Query<(&ComputedNode, &UiGlobalTransform), With<SceneViewport>>,
+    ray_cast: &mut MeshRayCast,
+    editor_entities: &Query<(), With<crate::EditorEntity>>,
+) -> Option<Vec3> {
+    let viewport_cursor = crate::viewport_util::window_to_viewport_cursor_for(
+        cursor_pos,
+        camera,
+        viewport_entity,
+        viewport_query,
+    )?;
+    let ray = camera.viewport_to_world(cam_tf, viewport_cursor).ok()?;
+
+    // Editor-internal meshes (gizmos, previews, the per-viewport grid) carry
+    // `EditorEntity` and sit at world origin on off-screen render layers;
+    // `MeshRayCast` ignores render layers, so filter them out or the drop
+    // snaps onto an invisible mesh. Same guard the selection raycast and the
+    // image-ingest drop use.
+    let editor_filter = |entity: Entity| !editor_entities.contains(entity);
+    let settings = MeshRayCastSettings::default()
+        .with_visibility(RayCastVisibility::Any)
+        .with_filter(&editor_filter);
+    ray_cast
+        .cast_ray(ray, &settings)
+        .first()
+        .map(|(_, hit)| hit.point)
 }
 
 fn raycast_to_ground(

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -83,15 +83,16 @@ struct AxisIndicatorAsset(Handle<GizmoAsset>);
 pub struct ViewportGrid(pub Entity);
 
 /// Shared counter that hands out a unique [`RenderLayers`] index per
-/// viewport. Layer 0 is the default world; layer 1 is reserved for
-/// the material preview. Per-viewport grids start at layer 2 so
-/// they only render to "their" camera.
+/// viewport. Layer 0 is the default world; layer 1 is reserved for the
+/// material preview and layer 2 for the asset browser's model thumbnail
+/// stage ([`crate::model_thumbnail::THUMBNAIL_LAYER`]). Per-viewport grids
+/// start after those so they only render to "their" camera.
 #[derive(Resource)]
 pub(crate) struct ViewportLayerCounter(usize);
 
 impl Default for ViewportLayerCounter {
     fn default() -> Self {
-        Self(1)
+        Self(crate::model_thumbnail::THUMBNAIL_LAYER)
     }
 }
 

--- a/src/viewport_select.rs
+++ b/src/viewport_select.rs
@@ -159,10 +159,7 @@ pub(crate) fn handle_viewport_click(
         || guards.is_any_interaction_active()
         || guards.gizmo_hover.hovered_axis.is_some()
         || just_finished_draw
-        || matches!(
-            *guards.terrain_edit_mode,
-            crate::terrain::TerrainEditMode::Sculpt(_)
-        )
+        || guards.terrain_edit_mode.brush_active()
     {
         return;
     }

--- a/tests/jsn_to_bsn.rs
+++ b/tests/jsn_to_bsn.rs
@@ -391,6 +391,12 @@ fn inline_material_reference_and_terrain_survive_conversion() {
     // Author a scene with a Terrain component, then hand it an inline
     // material asset and a brush face that references it by name, the way the
     // editor's save path stores catalog-less materials.
+    //
+    // The terrain here is deliberately a *legacy* one: heights inline on
+    // the component and no `data_path`, which is what every scene written
+    // before the binary sidecar looks like. Conversion has to carry those
+    // heights through untouched -- the editor drains them into the sidecar
+    // store on load, and it can only do that if they survived the trip.
     let mut app_a = headless_app();
     let node_id = SceneNodeId::next();
     app_a.world_mut().spawn((
@@ -402,7 +408,14 @@ fn inline_material_reference_and_terrain_survive_conversion() {
             resolution: 3,
             size: Vec2::new(8.0, 8.0),
             max_height: 2.5,
+            channels: Vec::new(),
+            data_path: String::new(),
             heights: vec![0.0, 0.5, 1.0, 0.0, 0.25, 0.75, 0.1, 0.2, 0.3],
+            // A scene this old predates quantization, so it carries the
+            // default. Spelled out rather than `..default()` because the
+            // point of this literal is to enumerate what a legacy scene
+            // holds.
+            quantization: Default::default(),
         },
         jackdaw_scene_types::SceneRootTag,
     ));
@@ -462,7 +475,9 @@ fn inline_material_reference_and_terrain_survive_conversion() {
     );
     assert_eq!(converted.report.asset_count, 1);
 
-    // Terrain round-trips semantically into the BSN-loaded world.
+    // Terrain round-trips semantically into the BSN-loaded world: the
+    // small descriptive fields, the (empty) sidecar path, and the legacy
+    // inline heights the editor migrates on next load.
     let mut app_b = headless_app();
     spawn_bsn(&mut app_b, &converted.scene_bsn);
     let ground = find_by_node_id(app_b.world_mut(), node_id).expect("ground by node id");
@@ -471,9 +486,63 @@ fn inline_material_reference_and_terrain_survive_conversion() {
         .get::<Terrain>(ground)
         .expect("terrain survives");
     assert_eq!(terrain.resolution, 3);
-    assert_eq!(terrain.heights.len(), 9);
     assert!((terrain.max_height - 2.5).abs() < 1e-6);
+    assert!((terrain.size - Vec2::new(8.0, 8.0)).length() < 1e-6);
+    assert_eq!(
+        terrain.data_path, "",
+        "a legacy terrain names no sidecar; the editor mints one on load"
+    );
+    assert_eq!(terrain.heights.len(), 9);
     assert!((terrain.heights[2] - 1.0).abs() < 1e-6);
+    assert!(
+        !terrain.quantization.enabled,
+        "a scene that never mentioned quantization comes back with it off"
+    );
+}
+
+/// A terrain's quantization is a small reflected descriptor, so it has to
+/// survive the scene text the way `resolution` does. Without this the
+/// setting would look like it worked and silently reset on next load.
+#[test]
+fn terrain_quantization_survives_conversion() {
+    use jackdaw_scene_types::{Terrain, TerrainQuantization};
+
+    let mut app_a = headless_app();
+    let node_id = SceneNodeId::next();
+    app_a.world_mut().spawn((
+        Name::new("Ground"),
+        Transform::default(),
+        node_id,
+        Terrain {
+            resolution: 5,
+            quantization: TerrainQuantization {
+                enabled: true,
+                cell_size: 1.5,
+                height_step: 0.25,
+            },
+            ..Default::default()
+        },
+        jackdaw_scene_types::SceneRootTag,
+    ));
+    let scene = world_to_jsn_scene(app_a.world_mut());
+
+    let mut app_c = headless_app();
+    let converted =
+        convert_jsn_scene_to_bsn(app_c.world_mut(), &scene).expect("conversion succeeds");
+
+    let mut app_b = headless_app();
+    spawn_bsn(&mut app_b, &converted.scene_bsn);
+    let ground = find_by_node_id(app_b.world_mut(), node_id).expect("ground by node id");
+    let quantization = app_b
+        .world()
+        .get::<Terrain>(ground)
+        .expect("terrain survives")
+        .quantization
+        .clone();
+
+    assert!(quantization.enabled);
+    assert!((quantization.cell_size - 1.5).abs() < 1e-6);
+    assert!((quantization.height_step - 0.25).abs() < 1e-6);
 }
 
 #[test]

--- a/tests/scenes_swap.rs
+++ b/tests/scenes_swap.rs
@@ -169,6 +169,117 @@ fn swap_round_trips_a_single_brush() {
     assert_eq!(name_count, 1, "tab A's AST entity should respawn");
 }
 
+/// A tab swap round-trips the scene through BSN *text* and respawns every
+/// entity, with no disk involved. That is exactly what would destroy a
+/// sculpted heightmap if heights lived on the component, so this pins the
+/// arrangement that makes it safe: the sidecar path travels as an ordinary
+/// reflected `String`, the heights live in a `Resource`, and neither one
+/// depends on the entity surviving.
+#[test]
+fn swap_preserves_a_sculpted_terrain() {
+    use bevy::prelude::*;
+    use bevy::render::RenderPlugin;
+    use bevy::render::settings::{RenderCreation, WgpuSettings};
+    use bevy::winit::WinitPlugin;
+    use jackdaw::terrain::TerrainDataStore;
+    use jackdaw_scene_types::Terrain;
+    use jackdaw_terrain::TerrainData;
+
+    const DATA_PATH: &str = "zone.terrain-0.jdterrain";
+
+    let mut app = App::new();
+    app.add_plugins(
+        DefaultPlugins
+            .set(RenderPlugin {
+                render_creation: RenderCreation::Automatic(Box::new(WgpuSettings {
+                    backends: None,
+                    ..default()
+                })),
+                ..default()
+            })
+            .disable::<WinitPlugin>(),
+    );
+    app.add_plugins(jackdaw_scene_types::SceneTypesPlugin::default());
+    app.init_resource::<jackdaw::scenes::Scenes>();
+    app.init_resource::<jackdaw::commands::CommandHistory>();
+    app.init_resource::<jackdaw_bsn::SceneBsnAst>();
+    app.init_resource::<jackdaw::selection::Selection>();
+    app.init_resource::<TerrainDataStore>();
+
+    // A sculpted 4x4 terrain: heights in the store, path on the component.
+    let sculpted: Vec<f32> = (0..16).map(|i| i as f32 * 0.5).collect();
+    app.world_mut().resource_mut::<TerrainDataStore>().insert(
+        DATA_PATH.to_string(),
+        TerrainData {
+            resolution: 4,
+            heights: sculpted.clone(),
+            channels: vec![],
+        },
+    );
+    let terrain_entity = app
+        .world_mut()
+        .spawn((
+            Terrain {
+                resolution: 4,
+                data_path: DATA_PATH.to_string(),
+                ..default()
+            },
+            Name::new("ground"),
+        ))
+        .id();
+    {
+        let mut ast = app.world_mut().resource_mut::<jackdaw_bsn::SceneBsnAst>();
+        let node = ast.create_entity_node(vec![jackdaw_bsn::BsnPatch::Name("ground".to_string())]);
+        ast.add_to_roots(node);
+        ast.link(terrain_entity, node);
+    }
+    {
+        let terrain = app.world().get::<Terrain>(terrain_entity).cloned().unwrap();
+        jackdaw::commands::sync_component_to_ast(
+            app.world_mut(),
+            terrain_entity,
+            "jackdaw_scene_types::types::Terrain",
+            &terrain,
+        );
+    }
+
+    {
+        let mut scenes = app.world_mut().resource_mut::<jackdaw::scenes::Scenes>();
+        scenes.tabs.push(jackdaw::scenes::SceneTab::new_untitled(1));
+        scenes.tabs.push(jackdaw::scenes::SceneTab::new_untitled(2));
+        scenes.active = 0;
+    }
+
+    // Away and back.
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 1);
+    assert!(
+        app.world().get::<Terrain>(terrain_entity).is_none(),
+        "the original entity is despawned by the swap"
+    );
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 0);
+
+    // The respawned terrain still names the same sidecar...
+    let respawned = app
+        .world_mut()
+        .query::<&Terrain>()
+        .iter(app.world())
+        .next()
+        .cloned()
+        .expect("terrain respawns from the AST");
+    assert_eq!(
+        respawned.data_path, DATA_PATH,
+        "the sidecar path survives the BSN text round-trip"
+    );
+    assert!(
+        respawned.heights.is_empty(),
+        "heights never enter the scene document"
+    );
+
+    // ...and the sculpt itself is untouched.
+    let store = app.world().resource::<TerrainDataStore>();
+    assert_eq!(store.heights(DATA_PATH), sculpted.as_slice());
+}
+
 #[test]
 fn swap_preserves_camera_transform_per_tab() {
     use bevy::prelude::*;

--- a/tests/scenes_swap.rs
+++ b/tests/scenes_swap.rs
@@ -281,6 +281,126 @@ fn swap_preserves_a_sculpted_terrain() {
 }
 
 #[test]
+fn scene_tabs_keep_same_named_terrain_sidecars_isolated() {
+    use bevy::prelude::*;
+    use bevy::render::RenderPlugin;
+    use bevy::render::settings::{RenderCreation, WgpuSettings};
+    use bevy::winit::WinitPlugin;
+    use jackdaw::terrain::TerrainDataStore;
+    use jackdaw_scene_types::Terrain;
+    use jackdaw_terrain::{TerrainData, sidecar};
+
+    const DATA_PATH: &str = "zone.terrain-0.jdterrain";
+
+    let mut app = App::new();
+    app.add_plugins(
+        DefaultPlugins
+            .set(RenderPlugin {
+                render_creation: RenderCreation::Automatic(Box::new(WgpuSettings {
+                    backends: None,
+                    ..default()
+                })),
+                ..default()
+            })
+            .disable::<WinitPlugin>(),
+    );
+    app.add_plugins(jackdaw_scene_types::SceneTypesPlugin::default());
+    app.init_resource::<jackdaw::scenes::Scenes>();
+    app.init_resource::<jackdaw::commands::CommandHistory>();
+    app.init_resource::<jackdaw_bsn::SceneBsnAst>();
+    app.init_resource::<jackdaw::selection::Selection>();
+    app.init_resource::<jackdaw::scene_io::SceneFilePath>();
+    app.init_resource::<TerrainDataStore>();
+
+    let terrain_entity = app
+        .world_mut()
+        .spawn((
+            Terrain {
+                resolution: 4,
+                data_path: DATA_PATH.to_string(),
+                ..default()
+            },
+            Name::new("ground"),
+        ))
+        .id();
+    {
+        let mut ast = app.world_mut().resource_mut::<jackdaw_bsn::SceneBsnAst>();
+        let node = ast.create_entity_node(vec![jackdaw_bsn::BsnPatch::Name("ground".to_string())]);
+        ast.add_to_roots(node);
+        ast.link(terrain_entity, node);
+    }
+    {
+        let terrain = app.world().get::<Terrain>(terrain_entity).cloned().unwrap();
+        jackdaw::commands::sync_component_to_ast(
+            app.world_mut(),
+            terrain_entity,
+            "jackdaw_scene_types::types::Terrain",
+            &terrain,
+        );
+    }
+    let scene_text = jackdaw_bsn::emit_scene(app.world().resource::<jackdaw_bsn::SceneBsnAst>());
+    app.world_mut().despawn(terrain_entity);
+    app.world_mut()
+        .insert_resource(jackdaw_bsn::SceneBsnAst::default());
+
+    let first_dir = tempfile::tempdir().unwrap();
+    let second_dir = tempfile::tempdir().unwrap();
+    let first_scene = first_dir.path().join("zone.bsn");
+    let second_scene = second_dir.path().join("zone.bsn");
+    std::fs::write(&first_scene, &scene_text).unwrap();
+    std::fs::write(&second_scene, &scene_text).unwrap();
+
+    let first_heights = vec![1.0; 16];
+    let second_heights = vec![2.0; 16];
+    for (dir, heights) in [
+        (first_dir.path(), first_heights.as_slice()),
+        (second_dir.path(), second_heights.as_slice()),
+    ] {
+        let bytes = sidecar::encode(&TerrainData {
+            resolution: 4,
+            heights: heights.to_vec(),
+            channels: vec![],
+        })
+        .expect("terrain data encodes");
+        std::fs::write(dir.join(DATA_PATH), bytes).unwrap();
+    }
+
+    jackdaw::scenes::operators::scene_open_system(app.world_mut(), &first_scene);
+    assert_eq!(
+        app.world()
+            .resource::<TerrainDataStore>()
+            .heights(DATA_PATH),
+        first_heights,
+    );
+
+    jackdaw::scenes::operators::scene_open_system(app.world_mut(), &second_scene);
+    assert_eq!(
+        app.world()
+            .resource::<TerrainDataStore>()
+            .heights(DATA_PATH),
+        second_heights,
+        "the second tab must hydrate its own same-named sidecar",
+    );
+
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 0);
+    assert_eq!(
+        app.world()
+            .resource::<TerrainDataStore>()
+            .heights(DATA_PATH),
+        first_heights,
+        "switching back must restore the first tab's terrain data",
+    );
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 1);
+    assert_eq!(
+        app.world()
+            .resource::<TerrainDataStore>()
+            .heights(DATA_PATH),
+        second_heights,
+        "switching again must restore the second tab's terrain data",
+    );
+}
+
+#[test]
 fn swap_preserves_camera_transform_per_tab() {
     use bevy::prelude::*;
     use bevy::render::RenderPlugin;
@@ -507,6 +627,10 @@ fn scene_save_all_writes_each_path_bound_tab() {
     let _ = std::fs::remove_file(&tmp_b);
     let _ = std::fs::remove_file(&bsn_a);
     let _ = std::fs::remove_file(&bsn_b);
+    let _ = std::fs::remove_file(format!("{}.bak", tmp_a.to_string_lossy()));
+    let _ = std::fs::remove_file(format!("{}.bak", tmp_b.to_string_lossy()));
+    std::fs::write(&tmp_a, "legacy scene").expect("create legacy scene A");
+    std::fs::write(&tmp_b, "legacy scene").expect("create legacy scene B");
 
     {
         let mut scenes = app.world_mut().resource_mut::<jackdaw::scenes::Scenes>();
@@ -514,13 +638,57 @@ fn scene_save_all_writes_each_path_bound_tab() {
         scenes.tabs[1].path = Some(tmp_b.clone());
     }
 
-    jackdaw::scenes::operators::scene_save_all_system(app.world_mut());
+    assert!(jackdaw::scenes::operators::scene_save_all_system(
+        app.world_mut()
+    ));
 
     assert!(bsn_a.exists(), "tab 0 should have been saved as .bsn");
     assert!(bsn_b.exists(), "tab 1 should have been saved as .bsn");
 
     let _ = std::fs::remove_file(&bsn_a);
     let _ = std::fs::remove_file(&bsn_b);
+    let _ = std::fs::remove_file(format!("{}.bak", tmp_a.to_string_lossy()));
+    let _ = std::fs::remove_file(format!("{}.bak", tmp_b.to_string_lossy()));
+}
+
+#[test]
+fn scene_save_all_reports_failure_and_keeps_a_tab_dirty() {
+    let mut app = make_app_with_n_tabs(1);
+    let tmp = tempfile::tempdir().expect("temp directory");
+    let blocked_parent = tmp.path().join("not-a-directory");
+    std::fs::write(&blocked_parent, b"file blocks directory creation")
+        .expect("create blocking file");
+    let scene_path = blocked_parent.join("zone.bsn");
+
+    {
+        let mut scenes = app.world_mut().resource_mut::<jackdaw::scenes::Scenes>();
+        scenes.tabs[0].path = Some(scene_path);
+        scenes.tabs[0].dirty = true;
+    }
+    let data_path = "zone.terrain-0.jdterrain";
+    let mut store = jackdaw::terrain::TerrainDataStore::default();
+    store.insert(
+        data_path.to_string(),
+        jackdaw_terrain::TerrainData {
+            resolution: 2,
+            heights: vec![0.0; 4],
+            channels: vec![],
+        },
+    );
+    app.world_mut().insert_resource(store);
+    app.world_mut().spawn(jackdaw_scene_types::Terrain {
+        resolution: 2,
+        data_path: data_path.to_string(),
+        ..Default::default()
+    });
+
+    let saved = jackdaw::scenes::operators::scene_save_all_system(app.world_mut());
+
+    assert!(
+        !saved,
+        "Save All must report an authoritative write failure"
+    );
+    assert!(app.world().resource::<jackdaw::scenes::Scenes>().tabs[0].dirty);
 }
 
 #[test]
@@ -786,6 +954,7 @@ fn swap_does_not_keep_a_jsn_scene_snapshot_field() {
         content: TabContent::Scene(None),
         view_state: jackdaw::scenes::ViewState::default(),
         history: jackdaw::commands::CommandHistory::default(),
+        terrain_data_store: jackdaw::terrain::TerrainDataStore::default(),
         history_depth_at_last_check: 0,
     };
 }

--- a/tests/terrain_export.rs
+++ b/tests/terrain_export.rs
@@ -403,3 +403,31 @@ fn channel_filename_collision_is_refused_naming_both() {
     assert!(message.contains("biome/a"));
     assert!(message.contains("biome_a"));
 }
+
+/// C3: two channels with the exact same name must be refused, not
+/// silently collapsed to one exported file by the last-wins writer.
+/// Reachable through the UI: add, add, remove index 0, add mints
+/// `channel-1` twice (see `channel_ops.rs`'s `mint_channel_name`, which
+/// this pins from the export side).
+#[test]
+fn exact_duplicate_channel_names_are_refused() {
+    let heights = sample_heights();
+    let channels = vec![
+        ExportChannel {
+            name: "channel-1".to_string(),
+            element: ExportChannelElement::U8,
+            values: vec![1; 9],
+            palette: vec![],
+        },
+        ExportChannel {
+            name: "channel-1".to_string(),
+            element: ExportChannelElement::U8,
+            values: vec![2; 9],
+            palette: vec![],
+        },
+    ];
+    let input = base_input(&heights, &channels, &[]);
+
+    let error = build_export(&input).expect_err("exact-duplicate channel names must be refused");
+    assert!(error.to_string().contains("channel-1"));
+}

--- a/tests/terrain_export.rs
+++ b/tests/terrain_export.rs
@@ -95,7 +95,8 @@ fn pixel_fidelity_heightmap_and_channel_round_trip_exactly() {
         .expect("decode heightmap.png")
         .into_luma16();
     assert_eq!(decoded.dimensions(), (3, 3));
-    // Unquantized: step_m = max_height / 65535, base_m = floor(min/step)*step.
+    // Unquantized: step_m = (max - min) / 65535, base_m = floor(min/step)*step.
+    // sample_heights() spans exactly 0..22, so this coincides with 22.0 / 65535.
     let step_m = 22.0_f32 / 65535.0;
     let base_m = (0.0_f32 / step_m).floor() * step_m;
     for z in 0..3u32 {
@@ -227,6 +228,46 @@ fn manifest_quantization_populated_when_quantized() {
         serde_json::from_slice(&find_file(&files, "manifest.json").bytes).unwrap();
     assert_eq!(manifest["quantization"]["cell_size_m"], 1.0);
     assert_eq!(manifest["quantization"]["elevation_step_m"], 0.25);
+}
+
+// I1 pinning test, the exact scenario from the review finding: authored
+// heights whose span exceeds the terrain's configured `max_height` must
+// still export. The old step derivation (`max_height / 65535`) sized the
+// pixel range off the ceiling rather than the actual data, so a span
+// wider than that ceiling overflowed HeightOutOfRange on data that is
+// perfectly representable once the step is sized off the real span.
+#[test]
+fn heights_spanning_more_than_max_height_still_export() {
+    let heights: Vec<f32> = (0..9).map(|i| i as f32 * 7.5).collect(); // 0..60
+    let channels: Vec<ExportChannel> = Vec::new();
+    let mut input = base_input(&heights, &channels, &[]);
+    input.max_height = 50.0;
+
+    let files =
+        build_export(&input).expect("a span wider than max_height must still be representable");
+
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&find_file(&files, "manifest.json").bytes).unwrap();
+    let step_m = manifest["heightmap"]["step_m"].as_f64().unwrap() as f32;
+    let expected_step = 60.0_f32 / 65535.0;
+    assert!(
+        (step_m - expected_step).abs() < 1e-6,
+        "step_m {step_m} must derive from the actual 0..60 span, not max_height 50",
+    );
+
+    let decoded = image::load_from_memory(&find_file(&files, "heightmap.png").bytes)
+        .unwrap()
+        .into_luma16();
+    let base_m = manifest["heightmap"]["base_m"].as_f64().unwrap() as f32;
+    for (i, &expected_h) in heights.iter().enumerate() {
+        let (x, z) = (i as u32 % 3, i as u32 / 3);
+        let pixel = decoded.get_pixel(x, z).0[0];
+        let decoded_h = base_m + pixel as f32 * step_m;
+        assert!(
+            (decoded_h - expected_h).abs() < step_m,
+            "x={x} z={z}: decoded {decoded_h} vs expected {expected_h}"
+        );
+    }
 }
 
 // 4. Quantized heights: every decoded height is an exact multiple of the

--- a/tests/terrain_export.rs
+++ b/tests/terrain_export.rs
@@ -270,10 +270,17 @@ fn heights_spanning_more_than_max_height_still_export() {
     }
 }
 
-// 4. Quantized heights: every decoded height is an exact multiple of the
-//    elevation step.
+// M1: quantized heights decode back to the actual snapped value, not
+// merely to *some* multiple of the step. The previous assertion checked
+// only "decoded_h is a multiple of step_m" -- true of every pixel this
+// encoding can produce by construction (decoded_h = base_m + pixel *
+// step_m, and base_m is itself floor(min/step)*step), so it would still
+// pass even if quantize_heights were never actually applied to the
+// input. Comparing against jackdaw_terrain::quantize_height(original,
+// step) pins the real behavior: the encoded value must match what
+// quantization actually does to each input height.
 #[test]
-fn quantized_heights_decode_to_exact_step_multiples() {
+fn quantized_heights_decode_to_the_actual_snapped_value() {
     let heights = vec![0.1, 0.4, 0.6, -0.3, 1.55, 2.0, 0.0, -1.2, 3.05];
     let channels: Vec<ExportChannel> = Vec::new();
     let mut input = base_input(&heights, &channels, &[]);
@@ -291,12 +298,15 @@ fn quantized_heights_decode_to_exact_step_multiples() {
         .into_luma16();
     for z in 0..3u32 {
         for x in 0..3u32 {
+            let i = (z * 3 + x) as usize;
+            let expected = jackdaw_terrain::quantize_height(heights[i], 0.25);
             let pixel = decoded.get_pixel(x, z).0[0];
             let decoded_h = base_m + pixel as f32 * step_m;
-            let steps = decoded_h / step_m;
             assert!(
-                (steps - steps.round()).abs() < 1e-3,
-                "decoded height {decoded_h} is not a multiple of {step_m}"
+                (decoded_h - expected).abs() < 1e-3,
+                "x={x} z={z}: decoded {decoded_h} does not match the actual quantized \
+                 value {expected} of input {}",
+                heights[i]
             );
         }
     }
@@ -471,4 +481,27 @@ fn exact_duplicate_channel_names_are_refused() {
 
     let error = build_export(&input).expect_err("exact-duplicate channel names must be refused");
     assert!(error.to_string().contains("channel-1"));
+}
+
+/// M3: a U8 channel value over 255 must saturate on export, matching
+/// sidecar.rs's own U8 encode. Wrapping (`as u8`) would turn 256 into 0
+/// -- silently the wrong palette index, not just a clipped one.
+#[test]
+fn a_u8_channel_value_over_255_saturates_rather_than_wraps() {
+    let heights = sample_heights();
+    let channels = vec![ExportChannel {
+        name: "biome".to_string(),
+        element: ExportChannelElement::U8,
+        values: vec![256, 300, 0, 1, 2, 3, 4, 5, 6],
+        palette: vec![],
+    }];
+    let input = base_input(&heights, &channels, &[]);
+
+    let files = build_export(&input).expect("build_export succeeds");
+    let decoded = image::load_from_memory(&find_file(&files, "channels/biome.png").bytes)
+        .unwrap()
+        .into_luma8();
+    assert_eq!(decoded.get_pixel(0, 0).0[0], 255, "256 must saturate to 255, not wrap to 0");
+    assert_eq!(decoded.get_pixel(1, 0).0[0], 255, "300 must saturate to 255");
+    assert_eq!(decoded.get_pixel(2, 0).0[0], 0);
 }

--- a/tests/terrain_export.rs
+++ b/tests/terrain_export.rs
@@ -501,7 +501,15 @@ fn a_u8_channel_value_over_255_saturates_rather_than_wraps() {
     let decoded = image::load_from_memory(&find_file(&files, "channels/biome.png").bytes)
         .unwrap()
         .into_luma8();
-    assert_eq!(decoded.get_pixel(0, 0).0[0], 255, "256 must saturate to 255, not wrap to 0");
-    assert_eq!(decoded.get_pixel(1, 0).0[0], 255, "300 must saturate to 255");
+    assert_eq!(
+        decoded.get_pixel(0, 0).0[0],
+        255,
+        "256 must saturate to 255, not wrap to 0"
+    );
+    assert_eq!(
+        decoded.get_pixel(1, 0).0[0],
+        255,
+        "300 must saturate to 255"
+    );
     assert_eq!(decoded.get_pixel(2, 0).0[0], 0);
 }

--- a/tests/terrain_export.rs
+++ b/tests/terrain_export.rs
@@ -76,7 +76,7 @@ fn find_file<'a>(
 ) -> &'a jackdaw::terrain::export::ExportedFile {
     files
         .iter()
-        .find(|f| f.relative_path == std::path::PathBuf::from(relative))
+        .find(|f| f.relative_path.as_path() == std::path::Path::new(relative))
         .unwrap_or_else(|| panic!("missing output file {relative}"))
 }
 
@@ -372,7 +372,7 @@ fn heights_f32_absent_without_raw_heights_flag() {
     assert!(
         !files
             .iter()
-            .any(|f| f.relative_path == std::path::PathBuf::from("heights.f32")),
+            .any(|f| f.relative_path.as_path() == std::path::Path::new("heights.f32")),
         "heights.f32 must be absent without --raw-heights"
     );
 }

--- a/tests/terrain_export.rs
+++ b/tests/terrain_export.rs
@@ -1,0 +1,405 @@
+//! Pure-core tests for `jd export-terrain`'s output builder. Everything
+//! here exercises [`jackdaw::terrain::export::build_export`] directly on
+//! plain in-memory data -- no `.bsn` scene, no headless `World` -- per the
+//! module's pure-core/shell split.
+//!
+//! The output shape is a cross-repo contract (an importer in another repo
+//! is being built against it), so these assertions check real values, not
+//! just "it didn't panic."
+
+use jackdaw::terrain::export::{
+    ExportChannel, ExportChannelElement, ExportInput, ExportPaletteEntry, ExportPlacement,
+    build_export,
+};
+
+/// A 3x3 height field whose values are NOT symmetric under transposition:
+/// swapping x and z would change every off-diagonal value, so a writer that
+/// transposed the grid would fail the pixel-fidelity assertions below.
+///
+/// It must be SQUARE. A `Terrain` is described by a single `resolution`
+/// (vertices per edge), so a heightmap is always `resolution^2`; an earlier
+/// 3x2 fixture here supplied 6 values for a resolution of 3 and every test
+/// using it failed inside the PNG encoder with "pixel buffer size mismatch".
+fn sample_heights() -> Vec<f32> {
+    vec![
+        0.0, 1.0, 2.0, // z = 0
+        10.0, 11.0, 12.0, // z = 1
+        20.0, 21.0, 22.0, // z = 2
+    ]
+}
+
+fn sample_channel() -> ExportChannel {
+    ExportChannel {
+        name: "biome".to_string(),
+        element: ExportChannelElement::U16,
+        values: vec![5, 6, 7, 8, 9, 10, 11, 12, 13],
+        palette: vec![
+            ExportPaletteEntry {
+                value: 2,
+                label: "forest".to_string(),
+                color_hex: "#224411".to_string(),
+            },
+            ExportPaletteEntry {
+                value: 1,
+                label: "meadow".to_string(),
+                color_hex: "#66aa44".to_string(),
+            },
+        ],
+    }
+}
+
+fn base_input<'a>(
+    heights: &'a [f32],
+    channels: &'a [ExportChannel],
+    placements: &'a [ExportPlacement],
+) -> ExportInput<'a> {
+    ExportInput {
+        resolution: 3,
+        heights,
+        channels,
+        // 3 vertices -> 2 cells per edge. x and z must agree: the exporter
+        // checks the declared cell size against size/(resolution-1) on BOTH
+        // axes, so a terrain whose axes disagree has no single cell size.
+        size: (2.0, 2.0),
+        terrain_origin_m: [-1.0, -1.0],
+        max_height: 22.0,
+        quantization: None,
+        source_scene: "scenes/sample.bsn",
+        placements,
+        raw_heights: false,
+    }
+}
+
+fn find_file<'a>(
+    files: &'a [jackdaw::terrain::export::ExportedFile],
+    relative: &str,
+) -> &'a jackdaw::terrain::export::ExportedFile {
+    files
+        .iter()
+        .find(|f| f.relative_path == std::path::PathBuf::from(relative))
+        .unwrap_or_else(|| panic!("missing output file {relative}"))
+}
+
+// 1. Pixel fidelity: heightmap and channel PNGs decode back to the exact
+//    in-memory arrays, in z-major row order.
+#[test]
+fn pixel_fidelity_heightmap_and_channel_round_trip_exactly() {
+    let heights = sample_heights();
+    let channel = sample_channel();
+    let channels = vec![channel];
+    let input = base_input(&heights, &channels, &[]);
+    let files = build_export(&input).expect("build_export succeeds");
+
+    let heightmap = find_file(&files, "heightmap.png");
+    let decoded = image::load_from_memory(&heightmap.bytes)
+        .expect("decode heightmap.png")
+        .into_luma16();
+    assert_eq!(decoded.dimensions(), (3, 3));
+    // Unquantized: step_m = max_height / 65535, base_m = floor(min/step)*step.
+    let step_m = 22.0_f32 / 65535.0;
+    let base_m = (0.0_f32 / step_m).floor() * step_m;
+    for z in 0..3u32 {
+        for x in 0..3u32 {
+            let expected_h = heights[(z * 3 + x) as usize];
+            let pixel = decoded.get_pixel(x, z).0[0];
+            let decoded_h = base_m + pixel as f32 * step_m;
+            assert!(
+                (decoded_h - expected_h).abs() < step_m,
+                "x={x} z={z}: decoded {decoded_h} vs expected {expected_h}"
+            );
+        }
+    }
+
+    let channel_file = find_file(&files, "channels/biome.png");
+    let decoded_channel = image::load_from_memory(&channel_file.bytes)
+        .expect("decode channels/biome.png")
+        .into_luma16();
+    assert_eq!(decoded_channel.dimensions(), (3, 3));
+    let expected_values = [5u16, 6, 7, 8, 9, 10, 11, 12, 13];
+    for z in 0..3u32 {
+        for x in 0..3u32 {
+            let expected = expected_values[(z * 3 + x) as usize];
+            let pixel = decoded_channel.get_pixel(x, z).0[0];
+            assert_eq!(pixel, expected, "x={x} z={z}");
+        }
+    }
+}
+
+// 2. Byte-stability: running the pure core twice on the same input
+//    produces byte-identical output for every file.
+#[test]
+fn byte_stability_across_repeated_runs() {
+    let heights = sample_heights();
+    let channels = vec![sample_channel()];
+    let placements = vec![ExportPlacement {
+        name: "Rock_02".to_string(),
+        asset: Some("models/Rock.glb".to_string()),
+        translation: [1.0, 0.0, 2.0],
+        rotation: [0.0, 0.0, 0.0, 1.0],
+        scale: [1.0, 1.0, 1.0],
+        components: serde_json::Map::new(),
+    }];
+    let input = base_input(&heights, &channels, &placements);
+
+    let first = build_export(&input).expect("first run");
+    let second = build_export(&input).expect("second run");
+
+    assert_eq!(first.len(), second.len());
+    for a in &first {
+        let b = find_file(&second, a.relative_path.to_str().unwrap());
+        assert_eq!(
+            a.bytes,
+            b.bytes,
+            "{} differs across runs",
+            a.relative_path.display()
+        );
+    }
+}
+
+// 3. Manifest shape: parses, documented keys present, quantization null vs
+//    populated, channels sorted, palette sorted.
+#[test]
+fn manifest_shape_and_sort_order() {
+    let heights = sample_heights();
+    let channel_z = ExportChannel {
+        name: "zoning".to_string(),
+        element: ExportChannelElement::U8,
+        values: vec![1; 9],
+        palette: vec![],
+    };
+    let channel_a = sample_channel(); // "biome"
+    let channels = vec![channel_z, channel_a];
+    let input = base_input(&heights, &channels, &[]);
+
+    let files = build_export(&input).expect("build_export succeeds");
+    let manifest_bytes = &find_file(&files, "manifest.json").bytes;
+    let manifest: serde_json::Value =
+        serde_json::from_slice(manifest_bytes).expect("manifest.json parses");
+
+    assert_eq!(manifest["format"], "jackdaw-terrain-export");
+    assert_eq!(manifest["format_version"], 2);
+    assert_eq!(manifest["source_scene"], "scenes/sample.bsn");
+    assert_eq!(manifest["terrain"]["resolution"], 3);
+    assert_eq!(
+        manifest["terrain"]["world_size_m"],
+        serde_json::json!([2.0, 2.0])
+    );
+    assert_eq!(manifest["terrain"]["max_height_m"], 22.0);
+    assert_eq!(
+        manifest["terrain"]["terrain_origin_m"],
+        serde_json::json!([-1.0, -1.0])
+    );
+    assert!(manifest["quantization"].is_null(), "unquantized export");
+    assert_eq!(manifest["heightmap"]["file"], "heightmap.png");
+    assert_eq!(manifest["heightmap"]["bit_depth"], 16);
+    assert_eq!(manifest["placements_file"], "placements.json");
+
+    let channels_json = manifest["channels"].as_array().expect("channels array");
+    assert_eq!(channels_json.len(), 2);
+    // Sorted by name: "biome" before "zoning".
+    assert_eq!(channels_json[0]["name"], "biome");
+    assert_eq!(channels_json[1]["name"], "zoning");
+
+    // "biome" palette sorted by value: 1 (meadow) before 2 (forest).
+    let palette = channels_json[0]["palette"].as_array().expect("palette");
+    assert_eq!(palette[0]["value"], 1);
+    assert_eq!(palette[0]["label"], "meadow");
+    assert_eq!(palette[1]["value"], 2);
+    assert_eq!(palette[1]["label"], "forest");
+
+    // The trailing-newline / 2-space-indent contract.
+    let text = String::from_utf8(manifest_bytes.clone()).unwrap();
+    assert!(text.ends_with('\n'), "single trailing newline");
+    assert!(!text.ends_with("\n\n"), "exactly one trailing newline");
+    assert!(text.contains("\n  \""), "2-space indent");
+}
+
+// Quantized manifest: "quantization" is populated, not null.
+#[test]
+fn manifest_quantization_populated_when_quantized() {
+    let heights = sample_heights();
+    let channels: Vec<ExportChannel> = Vec::new();
+    let mut input = base_input(&heights, &channels, &[]);
+    input.quantization = Some((1.0, 0.25));
+
+    let files = build_export(&input).expect("build_export succeeds");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&find_file(&files, "manifest.json").bytes).unwrap();
+    assert_eq!(manifest["quantization"]["cell_size_m"], 1.0);
+    assert_eq!(manifest["quantization"]["elevation_step_m"], 0.25);
+}
+
+// 4. Quantized heights: every decoded height is an exact multiple of the
+//    elevation step.
+#[test]
+fn quantized_heights_decode_to_exact_step_multiples() {
+    let heights = vec![0.1, 0.4, 0.6, -0.3, 1.55, 2.0, 0.0, -1.2, 3.05];
+    let channels: Vec<ExportChannel> = Vec::new();
+    let mut input = base_input(&heights, &channels, &[]);
+    input.quantization = Some((1.0, 0.25));
+
+    let files = build_export(&input).expect("build_export succeeds");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&find_file(&files, "manifest.json").bytes).unwrap();
+    let base_m = manifest["heightmap"]["base_m"].as_f64().unwrap() as f32;
+    let step_m = manifest["heightmap"]["step_m"].as_f64().unwrap() as f32;
+    assert_eq!(step_m, 0.25);
+
+    let decoded = image::load_from_memory(&find_file(&files, "heightmap.png").bytes)
+        .unwrap()
+        .into_luma16();
+    for z in 0..3u32 {
+        for x in 0..3u32 {
+            let pixel = decoded.get_pixel(x, z).0[0];
+            let decoded_h = base_m + pixel as f32 * step_m;
+            let steps = decoded_h / step_m;
+            assert!(
+                (steps - steps.round()).abs() < 1e-3,
+                "decoded height {decoded_h} is not a multiple of {step_m}"
+            );
+        }
+    }
+}
+
+// 5. Refusal: a declared cell_size_m inconsistent with size/(resolution-1)
+//    is rejected, naming both values.
+#[test]
+fn cell_size_mismatch_is_refused_naming_both_values() {
+    let heights = sample_heights();
+    let channels: Vec<ExportChannel> = Vec::new();
+    let mut input = base_input(&heights, &channels, &[]);
+    // size.x = 2.0, resolution = 3 -> derived cell size 1.0; declare 5.0.
+    input.quantization = Some((5.0, 0.25));
+
+    let error = build_export(&input).expect_err("mismatched cell size must be refused");
+    let message = error.to_string();
+    assert!(message.contains("5"), "names the declared value: {message}");
+    assert!(message.contains("1"), "names the derived value: {message}");
+}
+
+// 6. Placements determinism: an unsorted input set of placements
+//    serialises in sorted order, identically across runs.
+#[test]
+fn placements_serialize_in_sorted_order_deterministically() {
+    let heights = sample_heights();
+    let channels: Vec<ExportChannel> = Vec::new();
+    let placements = vec![
+        ExportPlacement {
+            name: "Zebra".to_string(),
+            asset: Some("models/Zebra.glb".to_string()),
+            translation: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+            components: serde_json::Map::new(),
+        },
+        ExportPlacement {
+            name: "Anchor".to_string(),
+            asset: None,
+            translation: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+            components: serde_json::Map::new(),
+        },
+        ExportPlacement {
+            name: "Anchor".to_string(),
+            asset: Some("models/AnchorB.glb".to_string()),
+            translation: [5.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+            components: {
+                let mut m = serde_json::Map::new();
+                m.insert(
+                    "SpawnPoint".to_string(),
+                    serde_json::json!({"species": "meadow_hopper", "count": 3, "respawn_seconds": 120}),
+                );
+                m
+            },
+        },
+    ];
+    let input = base_input(&heights, &channels, &placements);
+
+    let first = build_export(&input).expect("first run");
+    let second = build_export(&input).expect("second run");
+
+    let doc: serde_json::Value =
+        serde_json::from_slice(&find_file(&first, "placements.json").bytes).unwrap();
+    assert_eq!(doc["format_version"], 1);
+    let list = doc["placements"].as_array().expect("placements array");
+    assert_eq!(list.len(), 3);
+    // Sorted by name, then asset (None < Some): "Anchor"/None, "Anchor"/Some, "Zebra".
+    assert_eq!(list[0]["name"], "Anchor");
+    assert!(list[0]["asset"].is_null());
+    assert_eq!(list[1]["name"], "Anchor");
+    assert_eq!(list[1]["asset"], "models/AnchorB.glb");
+    assert_eq!(
+        list[1]["components"]["SpawnPoint"]["species"],
+        "meadow_hopper"
+    );
+    assert_eq!(list[2]["name"], "Zebra");
+
+    let first_placements_bytes = &find_file(&first, "placements.json").bytes;
+    let second_placements_bytes = &find_file(&second, "placements.json").bytes;
+    assert_eq!(first_placements_bytes, second_placements_bytes);
+}
+
+// --raw-heights writes heights.f32 as little-endian f32, row-major, and
+// carries the ORIGINAL (unsnapped) heights even when quantized.
+#[test]
+fn raw_heights_writes_original_little_endian_f32() {
+    let heights = vec![0.1_f32, 0.4, 0.6, -0.3, 1.55, 2.0, 0.0, -1.2, 3.05];
+    let channels: Vec<ExportChannel> = Vec::new();
+    let mut input = base_input(&heights, &channels, &[]);
+    input.quantization = Some((1.0, 0.25));
+    input.raw_heights = true;
+
+    let files = build_export(&input).expect("build_export succeeds");
+    let raw = &find_file(&files, "heights.f32").bytes;
+    assert_eq!(raw.len(), heights.len() * 4);
+    for (i, h) in heights.iter().enumerate() {
+        let bytes: [u8; 4] = raw[i * 4..i * 4 + 4].try_into().unwrap();
+        assert_eq!(f32::from_le_bytes(bytes), *h);
+    }
+}
+
+// No --raw-heights: heights.f32 is not written at all.
+#[test]
+fn heights_f32_absent_without_raw_heights_flag() {
+    let heights = sample_heights();
+    let channels: Vec<ExportChannel> = Vec::new();
+    let input = base_input(&heights, &channels, &[]);
+
+    let files = build_export(&input).expect("build_export succeeds");
+    assert!(
+        !files
+            .iter()
+            .any(|f| f.relative_path == std::path::PathBuf::from("heights.f32")),
+        "heights.f32 must be absent without --raw-heights"
+    );
+}
+
+// Channel filename collision: two channel names that sanitize to the same
+// filename are refused, naming both.
+#[test]
+fn channel_filename_collision_is_refused_naming_both() {
+    let heights = sample_heights();
+    let channels = vec![
+        ExportChannel {
+            name: "biome/a".to_string(),
+            element: ExportChannelElement::U8,
+            values: vec![0; 9],
+            palette: vec![],
+        },
+        ExportChannel {
+            name: "biome_a".to_string(),
+            element: ExportChannelElement::U8,
+            values: vec![0; 9],
+            palette: vec![],
+        },
+    ];
+    let input = base_input(&heights, &channels, &[]);
+
+    let error = build_export(&input).expect_err("colliding channel names must be refused");
+    let message = error.to_string();
+    assert!(message.contains("biome/a"));
+    assert!(message.contains("biome_a"));
+}

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -41,14 +41,20 @@ name = "jackdaw_cli_internal"
 version = "0.19.0"
 dependencies = [
  "dunce",
+ "jackdaw_env",
  "jackdaw_project_build",
  "jackdaw_schema",
 ]
 
 [[package]]
+name = "jackdaw_env"
+version = "0.19.0"
+
+[[package]]
 name = "jackdaw_project_build"
 version = "0.19.0"
 dependencies = [
+ "jackdaw_env",
  "jackdaw_schema",
  "serde",
  "serde_json",


### PR DESCRIPTION
- Add versioned terrain sidecars with sculpting, paint channels, grid quantization, and deterministic scatter.
- Add safe per-scene terrain storage plus headless height, channel, and placement export.
- Add exact grid sizing, model thumbnails, viewport capture, and boot-time operator automation.