### PR TITLE
Start using command for keybinds on macOS

### DIFF
--- a/crates/jackdaw_api_internal/src/keymap/apply.rs
+++ b/crates/jackdaw_api_internal/src/keymap/apply.rs
@@ -95,12 +95,13 @@ pub fn apply_keymap_preset(world: &mut World, preset: &KeymapPreset) -> KeymapAp
                 ctrl,
                 shift,
                 alt,
+                super_,
             } => {
                 let Some(key_code) = key_code_from_name(key) else {
                     report.skipped_unparseable_key.push(key.clone());
                     continue;
                 };
-                let mod_keys = mod_keys_from_bools(*ctrl, *shift, *alt);
+                let mod_keys = mod_keys_from_bools(*ctrl, *shift, *alt, *super_);
                 ResolvedBinding::Press {
                     binding: key_code.with_mod_keys(mod_keys),
                     phase: entry.phase,
@@ -111,6 +112,7 @@ pub fn apply_keymap_preset(world: &mut World, preset: &KeymapPreset) -> KeymapAp
                 ctrl,
                 shift,
                 alt,
+                super_,
             } => {
                 let Some(mb) = mouse_button_from_name(button) else {
                     report
@@ -118,7 +120,7 @@ pub fn apply_keymap_preset(world: &mut World, preset: &KeymapPreset) -> KeymapAp
                         .push(format!("{}: {button}", entry.operator));
                     continue;
                 };
-                let mod_keys = mod_keys_from_bools(*ctrl, *shift, *alt);
+                let mod_keys = mod_keys_from_bools(*ctrl, *shift, *alt, *super_);
                 ResolvedBinding::Press {
                     binding: mb.with_mod_keys(mod_keys),
                     phase: entry.phase,
@@ -129,8 +131,9 @@ pub fn apply_keymap_preset(world: &mut World, preset: &KeymapPreset) -> KeymapAp
                 ctrl,
                 shift,
                 alt,
+                super_,
             } => {
-                let mod_keys = mod_keys_from_bools(*ctrl, *shift, *alt);
+                let mod_keys = mod_keys_from_bools(*ctrl, *shift, *alt, *super_);
                 ResolvedBinding::Scroll {
                     // Scroll phase is irrelevant; ScrollTick replaces it.
                     binding: Binding::MouseWheel { mod_keys },
@@ -197,7 +200,7 @@ pub fn apply_keymap_preset(world: &mut World, preset: &KeymapPreset) -> KeymapAp
 }
 
 /// Build a `ModKeys` bitmask from the three preset boolean fields.
-fn mod_keys_from_bools(ctrl: bool, shift: bool, alt: bool) -> ModKeys {
+fn mod_keys_from_bools(ctrl: bool, shift: bool, alt: bool, super_: bool) -> ModKeys {
     let mut mk = ModKeys::empty();
     if ctrl {
         mk |= ModKeys::CONTROL;
@@ -207,6 +210,9 @@ fn mod_keys_from_bools(ctrl: bool, shift: bool, alt: bool) -> ModKeys {
     }
     if alt {
         mk |= ModKeys::ALT;
+    }
+    if super_ {
+        mk |= ModKeys::SUPER;
     }
     mk
 }
@@ -518,6 +524,7 @@ mod tests {
                     ctrl: false,
                     shift: false,
                     alt: false,
+                    super_: false,
                 },
                 phase: PresetPhase::Press,
                 context: PresetContext::Operators,

--- a/crates/jackdaw_api_internal/src/keymap/types.rs
+++ b/crates/jackdaw_api_internal/src/keymap/types.rs
@@ -20,6 +20,8 @@ pub enum PresetInput {
         shift: bool,
         #[serde(default, skip_serializing_if = "core::ops::Not::not")]
         alt: bool,
+        #[serde(default, rename = "super", skip_serializing_if = "core::ops::Not::not")]
+        super_: bool,
     },
     /// Mouse button, optionally combined with modifier keys.
     /// `button` is one of `"Left"`, `"Right"`, `"Middle"`, `"Back"`, `"Forward"`.
@@ -31,6 +33,8 @@ pub enum PresetInput {
         shift: bool,
         #[serde(default, skip_serializing_if = "core::ops::Not::not")]
         alt: bool,
+        #[serde(default, rename = "super", skip_serializing_if = "core::ops::Not::not")]
+        super_: bool,
     },
     /// One wheel tick; `up: false` is a downward tick.
     Scroll {
@@ -41,6 +45,8 @@ pub enum PresetInput {
         shift: bool,
         #[serde(default, skip_serializing_if = "core::ops::Not::not")]
         alt: bool,
+        #[serde(default, rename = "super", skip_serializing_if = "core::ops::Not::not")]
+        super_: bool,
     },
 }
 
@@ -51,6 +57,7 @@ impl PresetInput {
             ctrl: false,
             shift: false,
             alt: false,
+            super_: false,
         }
     }
 
@@ -62,6 +69,7 @@ impl PresetInput {
             ctrl: false,
             shift: false,
             alt: false,
+            super_: false,
         }
     }
 
@@ -72,6 +80,7 @@ impl PresetInput {
             ctrl: false,
             shift: false,
             alt: false,
+            super_: false,
         }
     }
 
@@ -83,6 +92,27 @@ impl PresetInput {
             }
         }
         self
+    }
+
+    /// Set the Super modifier.
+    pub fn super_(mut self) -> Self {
+        match &mut self {
+            Self::Key { super_, .. }
+            | Self::MouseButton { super_, .. }
+            | Self::Scroll { super_, .. } => {
+                *super_ = true;
+            }
+        }
+        self
+    }
+
+    /// Set the Ctrl modifier, Super on macOS.
+    pub fn ctrl_or_super(self) -> Self {
+        if cfg!(target_os = "macos") {
+            self.super_()
+        } else {
+            self.ctrl()
+        }
     }
 
     /// Set the Shift modifier.

--- a/src/scene_ops.rs
+++ b/src/scene_ops.rs
@@ -22,12 +22,16 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<SceneOpenRecentOp>();
 
     ctx.bind_operator::<CoreExtensionInputContext, SceneNewOp>([PresetInput::key("KeyN")
-        .ctrl()
+        .ctrl_or_super()
         .shift()]);
-    ctx.bind_operator::<CoreExtensionInputContext, SceneOpenOp>([PresetInput::key("KeyO").ctrl()]);
-    ctx.bind_operator::<CoreExtensionInputContext, SceneSaveOp>([PresetInput::key("KeyS").ctrl()]);
+    ctx.bind_operator::<CoreExtensionInputContext, SceneOpenOp>([
+        PresetInput::key("KeyO").ctrl_or_super()
+    ]);
+    ctx.bind_operator::<CoreExtensionInputContext, SceneSaveOp>([
+        PresetInput::key("KeyS").ctrl_or_super()
+    ]);
     ctx.bind_operator::<CoreExtensionInputContext, SceneSaveAsOp>([PresetInput::key("KeyS")
-        .ctrl()
+        .ctrl_or_super()
         .shift()]);
 }
 


### PR DESCRIPTION
Only went through and did the basic scene ops (save, open, ...)