### PR TITLE
Fix various bsn issues

### DIFF
--- a/crates/jackdaw_bsn/src/apply.rs
+++ b/crates/jackdaw_bsn/src/apply.rs
@@ -47,27 +47,28 @@ pub struct BsnSceneAssets(
 /// AST nodes. All entities are marked [`AstDirty`] so a following call to
 /// [`apply_dirty_ast_patches`] populates ECS components.
 pub fn spawn_from_ast(world: &mut World) -> Vec<Entity> {
-    let roots: Vec<Entity> = world.resource::<SceneBsnAst>().roots.clone();
     let registry = world.resource::<AppTypeRegistry>().clone();
+    let roots = {
+        let reg = registry.read();
+        let ast = world.resource::<SceneBsnAst>();
+        // Named asset entries stay in the document for round-trip save but
+        // are not scene entities; the loader routes them into asset stores.
+        crate::catalog::entity_roots(ast, &reg)
+    };
     let mut spawned = Vec::new();
 
     for root in roots {
-        // Named asset entries stay in the document for round-trip save but
-        // are not scene entities; the loader routes them into asset stores.
-        {
-            let reg = registry.read();
-            let ast = world.resource::<SceneBsnAst>();
-            if crate::catalog::is_asset_root(ast, root, &reg) {
-                continue;
-            }
-        }
         spawn_ast_node(world, root, None, &mut spawned);
     }
 
     spawned
 }
 
-fn spawn_ast_node(
+/// Spawn an ECS entity for `ast_entity` (and recursively its authored children),
+/// link them in [`SceneBsnAst`], and mark them [`AstDirty`]. `parent` is the
+/// live ECS parent (`ChildOf`), when any. Callers must follow with
+/// [`apply_dirty_ast_patches`].
+pub fn spawn_ast_node(
     world: &mut World,
     ast_entity: Entity,
     parent: Option<Entity>,

--- a/crates/jackdaw_bsn/src/apply.rs
+++ b/crates/jackdaw_bsn/src/apply.rs
@@ -1396,7 +1396,7 @@ fn get_tuple_field_type_path(
 fn empty_component_patch_for_type(type_path: &str, registry: &TypeRegistry) -> BsnPatch {
     match registry
         .get_with_type_path(type_path)
-        .map(|registration| registration.type_info())
+        .map(bevy::reflect::TypeRegistration::type_info)
     {
         Some(bevy::reflect::TypeInfo::TupleStruct(_)) => {
             BsnPatch::TupleStruct(BsnTupleStructData {
@@ -1415,7 +1415,7 @@ fn empty_component_patch_for_type(type_path: &str, registry: &TypeRegistry) -> B
 fn empty_container_value_for_type(type_path: &str, registry: &TypeRegistry) -> BsnValue {
     match registry
         .get_with_type_path(type_path)
-        .map(|registration| registration.type_info())
+        .map(bevy::reflect::TypeRegistration::type_info)
     {
         Some(bevy::reflect::TypeInfo::TupleStruct(_)) => {
             BsnValue::TupleStruct(BsnTupleStructData {

--- a/crates/jackdaw_bsn/src/apply.rs
+++ b/crates/jackdaw_bsn/src/apply.rs
@@ -972,16 +972,13 @@ pub fn set_bsn_field(
         return;
     }
 
-    // Ensure a Struct patch exists for this type.
+    // Ensure a patch exists for this type.
     let patch_entity = match ast.find_patch_by_type_path(patches_entity, type_path) {
         Some(pe) => pe,
         None => {
             let pe = ast
                 .world
-                .spawn(BsnPatch::Struct(BsnStructData {
-                    type_path: type_path.to_string(),
-                    fields: BsnStructFields::default(),
-                }))
+                .spawn(empty_component_patch_for_type(type_path, registry))
                 .id();
             if let Some(patches) = ast.get_patches_mut(patches_entity) {
                 patches.0.push(pe);
@@ -1003,14 +1000,11 @@ pub fn set_bsn_field(
         return;
     }
 
-    // If the patch is a bare Type (all defaults), promote to Struct,
+    // If the patch is a bare Type (all defaults), promote to Struct/TupleStruct,
     // preserving the original type path (which may be variant-qualified).
     if let BsnPatch::Type(existing_tp) = patch {
         let preserved_tp = existing_tp.clone();
-        *patch = BsnPatch::Struct(BsnStructData {
-            type_path: preserved_tp,
-            fields: BsnStructFields::default(),
-        });
+        *patch = empty_component_patch_for_type(&preserved_tp, registry);
     }
 
     // View the patch as a navigable value, descend the path, and store it back.
@@ -1167,9 +1161,6 @@ fn index_into_value<'a>(value: &'a BsnValue, inner: &str) -> Option<&'a BsnValue
     }
 }
 
-/// Write `value` at `segments` within `current`, mirroring the read navigation.
-/// Named struct fields (and intermediate structs) are created on demand; tuple
-/// struct / list / map elements are only navigated when they already exist.
 /// Remove one named field from a component's sparse patch: the inverse of a
 /// [`set_bsn_field`] that authored a previously-absent field. Only dotted
 /// struct paths are supported; the leaf field is dropped from its enclosing
@@ -1267,10 +1258,7 @@ fn set_nested_value(
                 None => {
                     data.fields.0.push(BsnField {
                         name: segment.to_string(),
-                        value: BsnValue::Struct(BsnStructData {
-                            type_path: nested_type_path.clone(),
-                            fields: BsnStructFields::default(),
-                        }),
+                        value: empty_container_value_for_type(&nested_type_path, registry),
                     });
                     data.fields.0.len() - 1
                 }
@@ -1283,21 +1271,44 @@ fn set_nested_value(
                     | BsnValue::List(_)
                     | BsnValue::Map(_)
             ) {
-                field.value = BsnValue::Struct(BsnStructData {
-                    type_path: nested_type_path.clone(),
-                    fields: BsnStructFields::default(),
-                });
+                field.value = empty_container_value_for_type(&nested_type_path, registry);
             }
             set_nested_value(&mut field.value, rest, value, &nested_type_path, registry);
         }
         BsnValue::TupleStruct(data) => {
-            if let Some(target) = segment
-                .parse::<usize>()
-                .ok()
-                .and_then(|i| data.values.get_mut(i))
-            {
-                set_nested_value(target, rest, value, "", registry);
+            let Ok(index) = segment.parse::<usize>() else {
+                return;
+            };
+            while data.values.len() <= index {
+                let field_index = data.values.len();
+                let nested_type_path =
+                    get_tuple_field_type_path(current_type_path, field_index, registry)
+                        .unwrap_or_default();
+                data.values
+                    .push(empty_container_value_for_type(&nested_type_path, registry));
             }
+            let nested_type_path =
+                get_tuple_field_type_path(current_type_path, index, registry).unwrap_or_default();
+            if rest.is_empty() {
+                data.values[index] = value;
+                return;
+            }
+            if !matches!(
+                data.values[index],
+                BsnValue::Struct(_)
+                    | BsnValue::TupleStruct(_)
+                    | BsnValue::List(_)
+                    | BsnValue::Map(_)
+            ) {
+                data.values[index] = empty_container_value_for_type(&nested_type_path, registry);
+            }
+            set_nested_value(
+                &mut data.values[index],
+                rest,
+                value,
+                &nested_type_path,
+                registry,
+            );
         }
         BsnValue::List(items) => {
             if let Some(target) = segment.parse::<usize>().ok().and_then(|i| items.get_mut(i)) {
@@ -1367,6 +1378,58 @@ fn get_field_type_path(
     let field_info = struct_info.field(field_name)?;
     let field_reg = registry.get(field_info.ty().id())?;
     Some(field_reg.type_info().type_path().to_string())
+}
+
+fn get_tuple_field_type_path(
+    parent_type_path: &str,
+    index: usize,
+    registry: &TypeRegistry,
+) -> Option<String> {
+    let registration = registry.get_with_type_path(parent_type_path)?;
+    let tuple_info = registration.type_info().as_tuple_struct().ok()?;
+    let field_info = tuple_info.field_at(index)?;
+    let field_reg = registry.get(field_info.ty().id())?;
+    Some(field_reg.type_info().type_path().to_string())
+}
+
+/// Empty component patch shaped like the reflected type kind.
+fn empty_component_patch_for_type(type_path: &str, registry: &TypeRegistry) -> BsnPatch {
+    match registry
+        .get_with_type_path(type_path)
+        .map(|registration| registration.type_info())
+    {
+        Some(bevy::reflect::TypeInfo::TupleStruct(_)) => {
+            BsnPatch::TupleStruct(BsnTupleStructData {
+                type_path: type_path.to_string(),
+                values: Vec::new(),
+            })
+        }
+        _ => BsnPatch::Struct(BsnStructData {
+            type_path: type_path.to_string(),
+            fields: BsnStructFields::default(),
+        }),
+    }
+}
+
+/// Empty nested value for a type, used when minting intermediate path segments.
+fn empty_container_value_for_type(type_path: &str, registry: &TypeRegistry) -> BsnValue {
+    match registry
+        .get_with_type_path(type_path)
+        .map(|registration| registration.type_info())
+    {
+        Some(bevy::reflect::TypeInfo::TupleStruct(_)) => {
+            BsnValue::TupleStruct(BsnTupleStructData {
+                type_path: type_path.to_string(),
+                values: Vec::new(),
+            })
+        }
+        Some(bevy::reflect::TypeInfo::List(_)) => BsnValue::List(Vec::new()),
+        Some(bevy::reflect::TypeInfo::Map(_)) => BsnValue::Map(Vec::new()),
+        _ => BsnValue::Struct(BsnStructData {
+            type_path: type_path.to_string(),
+            fields: BsnStructFields::default(),
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -1444,6 +1507,60 @@ mod tests {
 
         let val = get_bsn_field(&ast, patches_entity, &type_path, "value");
         assert!(matches!(val, Some(BsnValue::Bool(true))));
+    }
+
+    #[derive(Reflect, Default, Clone)]
+    #[reflect(Default)]
+    struct Axis {
+        x: f32,
+        y: f32,
+        z: f32,
+    }
+
+    #[derive(Component, Reflect, Default, Clone)]
+    #[reflect(Default, Component)]
+    struct Spin(Axis);
+
+    fn spin_registry() -> (TypeRegistry, String) {
+        let mut registry = TypeRegistry::new();
+        registry.register::<Spin>();
+        registry.register::<Axis>();
+        registry.register::<f32>();
+        let type_path = registry
+            .get(std::any::TypeId::of::<Spin>())
+            .unwrap()
+            .type_info()
+            .type_path()
+            .to_string();
+        (registry, type_path)
+    }
+
+    #[test]
+    fn set_field_on_newtype_tuple_struct_authors_tuple_patch() {
+        let mut ast = SceneBsnAst::default();
+        let (registry, type_path) = spin_registry();
+        let patches_entity = ast.world.spawn(BsnPatches(Vec::new())).id();
+
+        set_bsn_field(
+            &mut ast,
+            patches_entity,
+            &type_path,
+            "0.x",
+            BsnValue::Float(1.5),
+            &registry,
+        );
+
+        let patch_entity = ast
+            .find_patch_by_type_path(patches_entity, &type_path)
+            .expect("patch should be created");
+        let patch = ast.get_patch(patch_entity).expect("patch entity");
+        assert!(
+            matches!(patch, BsnPatch::TupleStruct(_)),
+            "newtype components must author as TupleStruct, got {patch:?}"
+        );
+
+        let val = get_bsn_field(&ast, patches_entity, &type_path, "0.x");
+        assert!(matches!(val, Some(BsnValue::Float(f)) if (f - 1.5).abs() < f64::EPSILON));
     }
 
     // A struct component that registers no ReflectDefault, standing in for the

--- a/crates/jackdaw_bsn/src/catalog.rs
+++ b/crates/jackdaw_bsn/src/catalog.rs
@@ -94,7 +94,7 @@ pub fn load_bsn_assets(
 /// Whether a document root is a named asset entry (its type patch resolves to
 /// a registered `Asset` type). Scene loading routes these into `Assets<T>`
 /// stores instead of spawning them as entities.
-pub(crate) fn is_asset_root(
+pub fn is_asset_root(
     ast: &SceneBsnAst,
     root: bevy::ecs::entity::Entity,
     reg: &bevy::reflect::TypeRegistry,
@@ -102,6 +102,30 @@ pub(crate) fn is_asset_root(
     asset_value_from_root(ast, root)
         .and_then(|(type_path, _)| reg.get_with_type_path(&type_path))
         .is_some_and(|registration| registration.data::<ReflectAsset>().is_some())
+}
+
+/// Document roots that are named asset catalog entries.
+pub fn asset_roots(
+    ast: &SceneBsnAst,
+    reg: &bevy::reflect::TypeRegistry,
+) -> Vec<bevy::ecs::entity::Entity> {
+    ast.roots
+        .iter()
+        .copied()
+        .filter(|&root| is_asset_root(ast, root, reg))
+        .collect()
+}
+
+/// Document roots that spawn as scene entities (not named asset entries).
+pub fn entity_roots(
+    ast: &SceneBsnAst,
+    reg: &bevy::reflect::TypeRegistry,
+) -> Vec<bevy::ecs::entity::Entity> {
+    ast.roots
+        .iter()
+        .copied()
+        .filter(|&root| !is_asset_root(ast, root, reg))
+        .collect()
 }
 
 /// The result of loading a scene `.bsn`: spawned entities plus the named
@@ -122,11 +146,7 @@ pub fn load_bsn_scene(world: &mut World, text: &str) -> Result<LoadedBsnScene, B
     let mut assets = Vec::new();
     {
         let reg = registry.read();
-        let roots = ast.roots.clone();
-        for root in roots {
-            if !is_asset_root(&ast, root, &reg) {
-                continue;
-            }
+        for root in asset_roots(&ast, &reg) {
             let Some(name) = ast.get_name(root).map(str::to_owned) else {
                 continue;
             };

--- a/crates/jackdaw_bsn/src/document/mod.rs
+++ b/crates/jackdaw_bsn/src/document/mod.rs
@@ -19,7 +19,7 @@ pub use from_reflect::{
     BsnAssetContext, component_to_bsn_patch, component_to_bsn_patch_with_assets,
 };
 pub use mutate::{clone_node_into, clone_subtree_into};
-pub use query::bsn_value_as_int;
+pub use query::{bsn_value_as_int, is_enum_variant_of, type_paths_include};
 
 /// A list of patches that together define one BSN entity.
 /// Each child entity has a [`BsnPatch`] component.

--- a/crates/jackdaw_bsn/src/document/mod.rs
+++ b/crates/jackdaw_bsn/src/document/mod.rs
@@ -18,7 +18,7 @@ mod query;
 pub use from_reflect::{
     BsnAssetContext, component_to_bsn_patch, component_to_bsn_patch_with_assets,
 };
-pub use mutate::clone_node_into;
+pub use mutate::{clone_node_into, clone_subtree_into};
 pub use query::bsn_value_as_int;
 
 /// A list of patches that together define one BSN entity.

--- a/crates/jackdaw_bsn/src/document/mod.rs
+++ b/crates/jackdaw_bsn/src/document/mod.rs
@@ -107,12 +107,6 @@ pub struct SceneBsnAst {
     pub ast_to_ecs: HashMap<Entity, Entity>,
 }
 
-/// Component types on a document node that were computed by editor systems
-/// rather than authored by the user. Derived components are skipped on save;
-/// an explicit user edit promotes the component to authored.
-#[derive(Component, Debug, Default)]
-pub struct DerivedComponents(pub bevy::platform::collections::HashSet<String>);
-
 /// Component on every ECS entity that was spawned from (or synced to) BSN.
 /// Points back to the AST node entity in [`SceneBsnAst::world`].
 #[derive(Component)]

--- a/crates/jackdaw_bsn/src/document/mutate.rs
+++ b/crates/jackdaw_bsn/src/document/mutate.rs
@@ -216,12 +216,6 @@ impl SceneBsnAst {
     }
 }
 
-/// Create a new AST node in `dst` under `dst_parent`, deep-copying the component
-/// patches of `src_node` from `src`. Every patch except the
-/// [`BsnPatch::Children`] relation is cloned, so the new node keeps its
-/// components, name, and base reference but adopts none of `src_node`'s
-/// children. `dst_parent` gains the new node as a child. Returns the new node's
-/// AST entity in `dst`.
 impl SceneBsnAst {
     /// Deep-copy the whole document into a fresh one: every root and its
     /// subtree, all component patches, and the node-to-ECS links (re-keyed to
@@ -229,33 +223,13 @@ impl SceneBsnAst {
     /// the linked ECS entities carry over. Useful for read-only emission or
     /// resolution passes that must not mutate the live document.
     pub fn deep_clone(&self) -> SceneBsnAst {
-        fn clone_subtree(
-            dst: &mut SceneBsnAst,
-            src: &SceneBsnAst,
-            src_node: Entity,
-            dst_parent: Option<Entity>,
-        ) -> Entity {
-            let new_node = match dst_parent {
-                Some(parent) => clone_node_into(dst, src, src_node, parent),
-                None => {
-                    let patches = src.cloned_component_patches(src_node);
-                    let node = dst.create_entity_node(patches);
-                    dst.add_to_roots(node);
-                    node
-                }
-            };
-            if let Some(ecs) = src.ecs_for_ast(src_node) {
-                dst.link(ecs, new_node);
-            }
-            for child in src.get_children_ast(src_node) {
-                clone_subtree(dst, src, child, Some(new_node));
-            }
-            new_node
-        }
-
         let mut dst = SceneBsnAst::default();
         for &root in &self.roots {
-            clone_subtree(&mut dst, self, root, None);
+            let new_root = clone_subtree_into(&mut dst, self, root, None);
+            if let Some(ecs) = self.ecs_for_ast(root) {
+                dst.link(ecs, new_root);
+            }
+            link_cloned_subtree(&mut dst, self, root, new_root);
         }
         dst
     }
@@ -278,6 +252,30 @@ impl SceneBsnAst {
     }
 }
 
+/// Graft `src_node`'s full subtree into `dst` under `dst_parent` (`None` = new root).
+pub fn clone_subtree_into(
+    dst: &mut SceneBsnAst,
+    src: &SceneBsnAst,
+    src_node: Entity,
+    dst_parent: Option<Entity>,
+) -> Entity {
+    let new_node = match dst_parent {
+        Some(parent) => clone_node_into(dst, src, src_node, parent),
+        None => {
+            let patches = src.cloned_component_patches(src_node);
+            let node = dst.create_entity_node(patches);
+            dst.add_to_roots(node);
+            node
+        }
+    };
+    for child in src.get_children_ast(src_node) {
+        clone_subtree_into(dst, src, child, Some(new_node));
+    }
+    new_node
+}
+
+/// Create a new AST node in `dst` under `dst_parent`, deep-copying the component
+/// patches of `src_node` from `src`.
 pub fn clone_node_into(
     dst: &mut SceneBsnAst,
     src: &SceneBsnAst,
@@ -288,4 +286,21 @@ pub fn clone_node_into(
     let new_node = dst.create_entity_node(cloned_patches);
     dst.add_child_to_ast(dst_parent, new_node);
     new_node
+}
+
+/// Copy ECS links from `src`'s subtree onto the already-cloned nodes in `dst`
+fn link_cloned_subtree(
+    dst: &mut SceneBsnAst,
+    src: &SceneBsnAst,
+    src_node: Entity,
+    dst_node: Entity,
+) {
+    let src_children = src.get_children_ast(src_node);
+    let dst_children = dst.get_children_ast(dst_node);
+    for (src_child, dst_child) in src_children.into_iter().zip(dst_children) {
+        if let Some(ecs) = src.ecs_for_ast(src_child) {
+            dst.link(ecs, dst_child);
+        }
+        link_cloned_subtree(dst, src, src_child, dst_child);
+    }
 }

--- a/crates/jackdaw_bsn/src/document/mutate.rs
+++ b/crates/jackdaw_bsn/src/document/mutate.rs
@@ -3,7 +3,7 @@
 
 use bevy::ecs::entity::Entity;
 
-use super::{BsnPatch, BsnPatches, DerivedComponents, SceneBsnAst};
+use super::{BsnPatch, BsnPatches, SceneBsnAst};
 
 impl SceneBsnAst {
     /// Create a new AST node for an entity with the given patches.
@@ -52,28 +52,6 @@ impl SceneBsnAst {
         self.world
             .get_mut::<BsnPatches>(patches_entity)
             .map(bevy::ecs::change_detection::Mut::into_inner)
-    }
-
-    /// Clear the derived mark on `type_path` (a user edit makes it authored).
-    /// Returns true when the component was previously derived.
-    pub fn promote_derived(&mut self, patches_entity: Entity, type_path: &str) -> bool {
-        self.world
-            .get_mut::<DerivedComponents>(patches_entity)
-            .map(|mut d| d.0.remove(type_path))
-            .unwrap_or(false)
-    }
-
-    /// Mark `type_path` as derived on this node.
-    pub fn demote_to_derived(&mut self, patches_entity: Entity, type_path: &str) {
-        if let Some(mut d) = self.world.get_mut::<DerivedComponents>(patches_entity) {
-            d.0.insert(type_path.to_string());
-            return;
-        }
-        let mut set = bevy::platform::collections::HashSet::default();
-        set.insert(type_path.to_string());
-        if let Ok(mut node) = self.world.get_entity_mut(patches_entity) {
-            node.insert(DerivedComponents(set));
-        }
     }
 
     /// Remove the component patch for `type_path` from a node (the undo of

--- a/crates/jackdaw_bsn/src/document/query.rs
+++ b/crates/jackdaw_bsn/src/document/query.rs
@@ -7,11 +7,19 @@ use super::{BsnPatch, BsnPatches, BsnValue, SceneBsnAst};
 
 /// Check if `stored_path` is an enum variant of `base_path`.
 /// e.g. `foo::Bar::Sphere` is a variant of `foo::Bar`.
-fn is_enum_variant_of(stored_path: &str, base_path: &str) -> bool {
+pub fn is_enum_variant_of(stored_path: &str, base_path: &str) -> bool {
     stored_path.starts_with(base_path)
         && stored_path.as_bytes().get(base_path.len()) == Some(&b':')
         && stored_path[base_path.len()..].starts_with("::")
         && !stored_path[base_path.len() + 2..].contains("::")
+}
+
+/// Whether `paths` includes `type_path`, treating a stored `Enum::Variant`
+/// patch as covering the base enum type.
+pub fn type_paths_include<'a>(paths: impl IntoIterator<Item = &'a str>, type_path: &str) -> bool {
+    paths
+        .into_iter()
+        .any(|path| path == type_path || is_enum_variant_of(path, type_path))
 }
 
 impl SceneBsnAst {
@@ -442,5 +450,33 @@ mod query_tests {
 
         // The single-node clone must not drag the source's children across.
         assert!(dst.get_children_ast(cloned).is_empty());
+    }
+
+    #[test]
+    fn type_paths_include_matches_enum_variant_patches() {
+        let paths = [
+            "avian3d::dynamics::rigid_body::RigidBody::Dynamic",
+            "bevy_transform::components::transform::Transform",
+        ];
+        assert!(type_paths_include(
+            paths,
+            "avian3d::dynamics::rigid_body::RigidBody"
+        ));
+        assert!(type_paths_include(
+            paths,
+            "bevy_transform::components::transform::Transform"
+        ));
+        assert!(!type_paths_include(
+            paths,
+            "avian3d::dynamics::rigid_body::RigidBodyDisabled"
+        ));
+        assert!(is_enum_variant_of(
+            "avian3d::dynamics::rigid_body::RigidBody::Static",
+            "avian3d::dynamics::rigid_body::RigidBody"
+        ));
+        assert!(!is_enum_variant_of(
+            "avian3d::dynamics::rigid_body::RigidBody",
+            "avian3d::dynamics::rigid_body::RigidBody"
+        ));
     }
 }

--- a/crates/jackdaw_bsn/src/document/query.rs
+++ b/crates/jackdaw_bsn/src/document/query.rs
@@ -167,7 +167,7 @@ impl SceneBsnAst {
 
     /// Find which AST entity contains `child_ast` in a Children patch.
     /// Returns `None` if `child_ast` is a root (or not found).
-    pub(super) fn find_ast_parent_of(&self, child_ast: Entity) -> Option<Entity> {
+    pub fn find_ast_parent_of(&self, child_ast: Entity) -> Option<Entity> {
         if self.roots.contains(&child_ast) {
             return None;
         }

--- a/crates/jackdaw_bsn/src/document/query.rs
+++ b/crates/jackdaw_bsn/src/document/query.rs
@@ -3,7 +3,7 @@
 
 use bevy::ecs::entity::Entity;
 
-use super::{BsnPatch, BsnPatches, BsnValue, DerivedComponents, SceneBsnAst};
+use super::{BsnPatch, BsnPatches, BsnValue, SceneBsnAst};
 
 /// Check if `stored_path` is an enum variant of `base_path`.
 /// e.g. `foo::Bar::Sphere` is a variant of `foo::Bar`.
@@ -65,14 +65,6 @@ impl SceneBsnAst {
             }
         }
         None
-    }
-
-    /// Whether `type_path` is marked derived (computed, not authored) on this
-    /// node.
-    pub fn is_derived(&self, patches_entity: Entity, type_path: &str) -> bool {
-        self.world
-            .get::<DerivedComponents>(patches_entity)
-            .is_some_and(|d| d.0.contains(type_path))
     }
 
     /// The stable node id carried by a document node's `SceneNodeId(id)`

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -17,8 +17,8 @@ pub mod sync;
 pub mod writer;
 
 pub use catalog::{
-    CatalogAssetRef, CatalogEntry, LoadedBsnScene, append_assets_to_ast, load_bsn_assets,
-    load_bsn_scene, serialize_assets_to_bsn,
+    CatalogAssetRef, CatalogEntry, LoadedBsnScene, append_assets_to_ast, asset_roots, entity_roots,
+    is_asset_root, load_bsn_assets, load_bsn_scene, serialize_assets_to_bsn,
 };
 
 pub use parse::{ParseError, parse_bsn};
@@ -28,7 +28,7 @@ pub use delta::{apply_deltas, bsn_value_eq, shallow_diff};
 pub use document::{
     AstNodeRef, BsnAssetContext, BsnField, BsnPatch, BsnPatches, BsnStructData, BsnStructFields,
     BsnTupleStructData, BsnValue, SceneBsnAst, bsn_value_as_int, clone_node_into,
-    component_to_bsn_patch, component_to_bsn_patch_with_assets,
+    clone_subtree_into, component_to_bsn_patch, component_to_bsn_patch_with_assets,
 };
 pub use emitter::{emit_entities, emit_entity, emit_scene};
 pub use loader::{BsnLoadError, parse_bsn_text};
@@ -36,7 +36,7 @@ pub use loader::{BsnLoadError, parse_bsn_text};
 pub use apply::{
     AstDirty, BsnApplyAssets, BsnSceneAssets, apply_ast_to_ecs, apply_component_patch,
     apply_dirty_ast_patches, bsn_value_to_reflect, get_bsn_field, remove_bsn_field, set_bsn_field,
-    spawn_from_ast,
+    spawn_ast_node, spawn_from_ast,
 };
 
 pub use sync::{

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -27,8 +27,8 @@ pub use delta::{apply_deltas, bsn_value_eq, shallow_diff};
 
 pub use document::{
     AstNodeRef, BsnAssetContext, BsnField, BsnPatch, BsnPatches, BsnStructData, BsnStructFields,
-    BsnTupleStructData, BsnValue, DerivedComponents, SceneBsnAst, bsn_value_as_int,
-    clone_node_into, component_to_bsn_patch, component_to_bsn_patch_with_assets,
+    BsnTupleStructData, BsnValue, SceneBsnAst, bsn_value_as_int, clone_node_into,
+    component_to_bsn_patch, component_to_bsn_patch_with_assets,
 };
 pub use emitter::{emit_entities, emit_entity, emit_scene};
 pub use loader::{BsnLoadError, parse_bsn_text};

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -29,6 +29,7 @@ pub use document::{
     AstNodeRef, BsnAssetContext, BsnField, BsnPatch, BsnPatches, BsnStructData, BsnStructFields,
     BsnTupleStructData, BsnValue, SceneBsnAst, bsn_value_as_int, clone_node_into,
     clone_subtree_into, component_to_bsn_patch, component_to_bsn_patch_with_assets,
+    is_enum_variant_of, type_paths_include,
 };
 pub use emitter::{emit_entities, emit_entity, emit_scene};
 pub use loader::{BsnLoadError, parse_bsn_text};

--- a/crates/jackdaw_bsn/src/loader.rs
+++ b/crates/jackdaw_bsn/src/loader.rs
@@ -63,6 +63,12 @@ pub fn parse_bsn_text(text: &str) -> Result<SceneBsnAst, BsnLoadError> {
     }
 
     strip_scene_root_marker(&mut ast, root);
+
+    // No patches means an empty document, not a blank scene root.
+    if ast.get_patches(root).is_none_or(|p| p.0.is_empty()) {
+        return Ok(SceneBsnAst::default());
+    }
+
     ast.add_to_roots(root);
     Ok(ast)
 }

--- a/crates/jackdaw_bsn/tests/document_mutation.rs
+++ b/crates/jackdaw_bsn/tests/document_mutation.rs
@@ -7,7 +7,8 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::world::World;
 
 use jackdaw_bsn::{
-    BsnPatch, BsnValue, SceneBsnAst, clone_node_into, get_bsn_field, parse_bsn_text,
+    BsnPatch, BsnValue, SceneBsnAst, clone_node_into, clone_subtree_into, get_bsn_field,
+    parse_bsn_text,
 };
 
 const TRANSFORM: &str = "test_types::Transform";
@@ -311,6 +312,61 @@ fn clone_node_into_preserves_nested_and_handle_bearing_values() {
         Some(BsnValue::String("#Mat0".to_string())),
         "the handle reference string survives the copy verbatim"
     );
+}
+
+// ---------------------------------------------------------------------------
+// clone_subtree_into
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clone_subtree_into_copies_hierarchy_without_ecs_links() {
+    let (src, ecs_root, _) = clone_fixture();
+    let src_root = root_named(&src, "Root");
+    let src_child = child_named(&src, src_root, "Child");
+
+    let mut dst = SceneBsnAst::default();
+    let grafted = clone_subtree_into(&mut dst, &src, src_root, None);
+
+    assert_eq!(dst.roots, vec![grafted]);
+    assert_eq!(dst.get_name(grafted), Some("Root"));
+    let grafted_child = child_named(&dst, grafted, "Child");
+    assert_eq!(
+        get_bsn_field(&dst, grafted_child, MATERIAL, "base"),
+        Some(BsnValue::String("#Mat0".to_string())),
+    );
+    assert_eq!(
+        get_bsn_field(&src, src_child, MATERIAL, "base"),
+        get_bsn_field(&dst, grafted_child, MATERIAL, "base"),
+    );
+    assert!(
+        dst.ecs_for_ast(grafted).is_none(),
+        "graft must not adopt the source ECS link"
+    );
+    assert_eq!(
+        src.ecs_for_ast(src_root),
+        Some(ecs_root),
+        "source links stay intact"
+    );
+}
+
+#[test]
+fn clone_subtree_into_under_parent_does_not_add_a_root() {
+    let src = parse_bsn_text(
+        "#Leaf\n\
+         test_types::Tag(1)\n",
+    )
+    .expect("fixture parses");
+    let leaf = root_named(&src, "Leaf");
+
+    let mut dst = SceneBsnAst::default();
+    let parent = dst.create_entity_node(vec![BsnPatch::Name("Parent".to_string())]);
+    dst.add_to_roots(parent);
+
+    let grafted = clone_subtree_into(&mut dst, &src, leaf, Some(parent));
+
+    assert_eq!(dst.roots, vec![parent]);
+    assert_eq!(dst.get_children_ast(parent), vec![grafted]);
+    assert_eq!(dst.get_name(grafted), Some("Leaf"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/jackdaw_bsn/tests/loader.rs
+++ b/crates/jackdaw_bsn/tests/loader.rs
@@ -127,6 +127,18 @@ fn malformed_input_returns_error() {
 }
 
 #[test]
+fn empty_input_yields_no_roots() {
+    for text in ["", "   ", "\n\t\n", "// comment only\n"] {
+        let ast = parse_bsn_text(text).expect("empty-ish input should load");
+        assert!(
+            ast.roots.is_empty(),
+            "expected no roots for {text:?}, got {}",
+            ast.roots.len()
+        );
+    }
+}
+
+#[test]
 fn scene_load_routes_embedded_assets_and_resolves_references() {
     use bevy::app::{App, TaskPoolPlugin};
     use bevy::asset::{Asset, AssetApp, AssetPlugin, Assets, Handle, ReflectAsset, ReflectHandle};

--- a/crates/jackdaw_camera/src/lib.rs
+++ b/crates/jackdaw_camera/src/lib.rs
@@ -59,7 +59,7 @@ impl Default for JackdawCameraSettings {
     fn default() -> Self {
         Self {
             sensitivity: 0.003,
-            speed: 5.0,
+            speed: 15.0,
             run_multiplier: 2.0,
             enabled: true,
             scroll_speed: 1.0,

--- a/crates/jackdaw_camera/src/lib.rs
+++ b/crates/jackdaw_camera/src/lib.rs
@@ -59,7 +59,7 @@ impl Default for JackdawCameraSettings {
     fn default() -> Self {
         Self {
             sensitivity: 0.003,
-            speed: 15.0,
+            speed: 10.0,
             run_multiplier: 2.0,
             enabled: true,
             scroll_speed: 1.0,

--- a/crates/jackdaw_project_build/src/plan.rs
+++ b/crates/jackdaw_project_build/src/plan.rs
@@ -944,11 +944,9 @@ mod tests {
         let contents = String::from_utf8(contents).unwrap();
 
         assert_eq!(edges, 1, "{contents}");
+        let resolved = resolve_artifact("libglam-abc.rlib", &deps_dir);
         assert!(
-            contents.contains(&format!(
-                "my_game@0.1.0:glam={}\n",
-                deps_dir.join("libglam-abc.rlib").display()
-            )),
+            contents.contains(&format!("my_game@0.1.0:glam={resolved}\n")),
             "{contents}"
         );
         assert!(contents.contains("replaced:glam\n"), "{contents}");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -474,8 +474,7 @@ pub struct AddComponent {
     pub component_id: ComponentId,
     pub type_path: String,
     /// Type paths of components inserted by `#[require]` (or other side
-    /// effects) during `execute`. Tracked for ECS cleanup on `undo` only —
-    /// they are never written into the scene document.
+    /// effects) during `execute`.
     required_companions: Vec<String>,
 }
 
@@ -1092,9 +1091,7 @@ impl EditorCommand for SetBsnField {
         let live_before =
             !is_project && entity_has_reflected_component(world, self.entity, &self.type_path);
         // First override of a derived component: capture the pre-edit live
-        // field when the caller did not supply a baseline. Do not fill when a
-        // patch already exists — `old_value: None` then means "field was
-        // absent from the sparse patch" and undo must remove it.
+        // field when the caller did not supply a baseline.
         if self.old_value.is_none() && !self.field_path.is_empty() && live_before && !had_patch {
             self.old_value = live_bsn_field(world, self.entity, &self.type_path, &self.field_path);
         }
@@ -1256,7 +1253,7 @@ impl EditorCommand for SetBsnField {
     }
 }
 
-/// Apply a JSON value to an ECS component — either full component replacement
+/// Apply a JSON value to an ECS component -- either full component replacement
 /// (empty `field_path`) or field-level update.
 ///
 /// Writes only the live ECS component, leaving the scene document untouched.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -61,9 +61,9 @@ fn document_has_component_patch(world: &World, entity: Entity, type_path: &str) 
 
 fn clear_field_edit_session(world: &mut World, type_path: &str, field_path: &str) {
     let mut sessions = world.resource_mut::<FieldEditSessions>();
-    sessions.live_at_begin.retain(|key, _| {
-        key.type_path != type_path || key.field_path != field_path
-    });
+    sessions
+        .live_at_begin
+        .retain(|key, _| key.type_path != type_path || key.field_path != field_path);
 }
 
 fn peek_live_at_begin(
@@ -1062,11 +1062,7 @@ fn bsn_value_string(value: &jackdaw_bsn::BsnValue) -> Option<&str> {
 
 /// Set, replace, or remove the [`jackdaw_bsn::BsnPatch::Name`] patch on a
 /// document node.
-pub(crate) fn set_name_patch(
-    ast: &mut jackdaw_bsn::SceneBsnAst,
-    node: Entity,
-    name: Option<&str>,
-) {
+pub(crate) fn set_name_patch(ast: &mut jackdaw_bsn::SceneBsnAst, node: Entity, name: Option<&str>) {
     let existing = ast.get_patches(node).and_then(|patches| {
         patches
             .0
@@ -1156,24 +1152,19 @@ impl EditorCommand for SetBsnField {
             .is_some_and(|pt| pt.is_project_component(&self.type_path));
         let had_patch = {
             let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
-            ast.ast_for(self.entity).is_some_and(|node| {
-                ast.find_patch_by_type_path(node, &self.type_path).is_some()
-            })
+            ast.ast_for(self.entity)
+                .is_some_and(|node| ast.find_patch_by_type_path(node, &self.type_path).is_some())
         };
         // Derived = on the live entity with no document patch. Project
         // components are document-only; a missing patch is still a first
         // author that undo should drop entirely.
-        let live_before = !is_project
-            && entity_has_reflected_component(world, self.entity, &self.type_path);
+        let live_before =
+            !is_project && entity_has_reflected_component(world, self.entity, &self.type_path);
         // First override of a derived component: capture the pre-edit live
         // field when the caller did not supply a baseline. Do not fill when a
         // patch already exists — `old_value: None` then means "field was
         // absent from the sparse patch" and undo must remove it.
-        if self.old_value.is_none()
-            && !self.field_path.is_empty()
-            && live_before
-            && !had_patch
-        {
+        if self.old_value.is_none() && !self.field_path.is_empty() && live_before && !had_patch {
             self.old_value = live_bsn_field(world, self.entity, &self.type_path, &self.field_path);
         }
         // First override of a derived component: seed the full live value into

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1062,7 +1062,11 @@ fn bsn_value_string(value: &jackdaw_bsn::BsnValue) -> Option<&str> {
 
 /// Set, replace, or remove the [`jackdaw_bsn::BsnPatch::Name`] patch on a
 /// document node.
-fn set_name_patch(ast: &mut jackdaw_bsn::SceneBsnAst, node: Entity, name: Option<&str>) {
+pub(crate) fn set_name_patch(
+    ast: &mut jackdaw_bsn::SceneBsnAst,
+    node: Entity,
+    name: Option<&str>,
+) {
     let existing = ast.get_patches(node).and_then(|patches| {
         patches
             .0

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,11 +35,10 @@ struct FieldEditSessionKey {
 /// Live field values at [`field_edit_begin`] for in-progress gestures.
 ///
 /// Lifecycle: [`field_edit_begin`] → [`field_edit_preview`]* →
-/// [`field_edit_commit`] | [`field_edit_cancel`].
+/// [`field_edit_commit`].
 ///
 /// Preview mutates ECS before any `SetBsnField` exists. Capturing live values
-/// at begin lets commit build undo baselines for derived (no-patch) components
-/// and lets cancel restore the pre-preview ECS state.
+/// at begin lets commit build undo baselines for derived (no-patch) components.
 #[derive(Resource, Default)]
 pub(crate) struct FieldEditSessions {
     /// Live field value at gesture start, keyed by entity + field.
@@ -211,74 +210,6 @@ pub(crate) fn field_edit_commit(
     };
     cmd.execute(world);
     world.resource_mut::<CommandHistory>().push_executed(cmd);
-}
-
-/// Cancel an in-progress gesture: restore each target's live field to the
-/// value captured at begin, then clear the session. No document write.
-///
-/// Call from pointer-cancel / Escape abort paths once those emit into the
-/// inspector; unit tests cover the restore semantics today.
-#[allow(dead_code)]
-pub(crate) fn field_edit_cancel(world: &mut World, type_path: &str, field_path: &str) {
-    let restores: Vec<(Entity, jackdaw_bsn::BsnValue)> = world
-        .resource::<FieldEditSessions>()
-        .live_at_begin
-        .iter()
-        .filter(|(key, _)| key.type_path == type_path && key.field_path == field_path)
-        .map(|(key, value)| (key.entity, value.clone()))
-        .collect();
-    for (entity, value) in restores {
-        apply_bsn_field_to_ecs(world, entity, type_path, field_path, &value);
-    }
-    clear_field_edit_session(world, type_path, field_path);
-}
-
-/// Apply a [`jackdaw_bsn::BsnValue`] to one live ECS field (or whole component
-/// when `field_path` is empty). Document is untouched.
-#[allow(dead_code)]
-fn apply_bsn_field_to_ecs(
-    world: &mut World,
-    entity: Entity,
-    type_path: &str,
-    field_path: &str,
-    value: &jackdaw_bsn::BsnValue,
-) {
-    use bevy::reflect::GetPath;
-
-    let registry = world.resource::<AppTypeRegistry>().clone();
-    let registry = registry.read();
-    let Some(registration) = registry.get_with_type_path(type_path) else {
-        return;
-    };
-    let Some(reflect_component) = registration.data::<ReflectComponent>() else {
-        return;
-    };
-
-    if field_path.is_empty() {
-        let Some(reflected) =
-            jackdaw_bsn::bsn_value_to_reflect(value, registration.type_id(), &registry, None)
-        else {
-            return;
-        };
-        reflect_component.insert(&mut world.entity_mut(entity), reflected.as_ref(), &registry);
-        return;
-    }
-
-    let Some(component) = reflect_component.reflect_mut(world.entity_mut(entity)) else {
-        return;
-    };
-    let Ok(field) = component.into_inner().reflect_path_mut(field_path) else {
-        return;
-    };
-    let Some(type_info) = field.get_represented_type_info() else {
-        return;
-    };
-    let Some(reflected) =
-        jackdaw_bsn::bsn_value_to_reflect(value, type_info.type_id(), &registry, None)
-    else {
-        return;
-    };
-    field.apply(reflected.as_ref());
 }
 
 pub struct SetTransform {
@@ -2128,51 +2059,6 @@ mod set_bsn_field_tests {
             app.world().get::<Transform>(entity).unwrap().translation,
             Vec3::new(2.0, 5.0, 8.0),
             "undo restores the gesture-start live value, not the previewed value"
-        );
-    }
-
-    #[test]
-    fn field_edit_cancel_restores_live_without_document_write() {
-        let mut app = field_app();
-        let entity = app
-            .world_mut()
-            .spawn(Transform::from_xyz(2.0, 5.0, 8.0))
-            .id();
-        create_entity_in_ast(app.world_mut(), entity, None);
-        app.world_mut().resource_mut::<Selection>().entities = vec![entity];
-
-        let type_path = "bevy_transform::components::transform::Transform";
-        let field_path = "translation.x";
-
-        field_edit_preview(
-            app.world_mut(),
-            type_path,
-            field_path,
-            &serde_json::json!(9.0),
-        );
-        assert_eq!(
-            app.world().get::<Transform>(entity).unwrap().translation.x,
-            9.0
-        );
-
-        field_edit_cancel(app.world_mut(), type_path, field_path);
-        assert_eq!(
-            app.world().get::<Transform>(entity).unwrap().translation,
-            Vec3::new(2.0, 5.0, 8.0),
-            "cancel restores the begin baseline"
-        );
-        {
-            let ast = app.world().resource::<SceneBsnAst>();
-            let pe = ast.ast_for(entity).unwrap();
-            assert!(
-                !ast.component_type_paths(pe).iter().any(|p| p == type_path),
-                "cancel must not author a document patch"
-            );
-        }
-        assert_eq!(
-            app.world().resource::<CommandHistory>().undo_stack.len(),
-            0,
-            "cancel mints no undo entry"
         );
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1095,13 +1095,6 @@ impl EditorCommand for SetBsnField {
         if self.old_value.is_none() && !self.field_path.is_empty() && live_before && !had_patch {
             self.old_value = live_bsn_field(world, self.entity, &self.type_path, &self.field_path);
         }
-        // First override of a derived component: seed the full live value into
-        // the document before the field write. Otherwise `set_bsn_field` mints
-        // an empty struct + one field, and save/load resets sibling fields to
-        // type defaults.
-        if !had_patch && live_before && !self.field_path.is_empty() {
-            seed_live_component_to_bsn_doc(world, self.entity, &self.type_path);
-        }
         {
             let registry = world.resource::<AppTypeRegistry>().clone();
             let registry = registry.read();
@@ -1632,33 +1625,6 @@ pub(crate) fn sync_component_to_bsn_doc(
     }
 }
 
-/// Copy a live ECS component into the scene document as a full patch.
-///
-/// Used when minting the first authored override for a derived component so
-/// sibling fields that only existed as runtime state are pinned before the
-/// field edit runs. No-ops when the entity is untracked or the component is
-/// missing / not reflectable.
-fn seed_live_component_to_bsn_doc(world: &mut World, entity: Entity, type_path: &str) {
-    let registry = world.resource::<AppTypeRegistry>().clone();
-    let dynamic = {
-        let registry = registry.read();
-        let Some(registration) = registry.get_with_type_path(type_path) else {
-            return;
-        };
-        let Some(reflect_component) = registration.data::<ReflectComponent>() else {
-            return;
-        };
-        let Ok(entity_ref) = world.get_entity(entity) else {
-            return;
-        };
-        let Some(component) = reflect_component.reflect(entity_ref) else {
-            return;
-        };
-        component.to_dynamic()
-    };
-    sync_component_to_bsn_doc(world, entity, dynamic.as_partial_reflect(), &registry);
-}
-
 /// Reflected component type paths currently on `entity`, excluding structural
 /// / skip-listed types. Used to diff `#[require]` companions around an insert
 /// without writing them into the scene document.
@@ -1975,17 +1941,13 @@ mod set_bsn_field_tests {
                 get_bsn_field(ast, pe, type_path, "translation.x"),
                 Some(BsnValue::Float(7.0))
             );
-            // Live sibling fields must be pinned at mint time so save/load
-            // does not reset them to type defaults.
-            assert_eq!(
-                get_bsn_field(ast, pe, type_path, "translation.y"),
-                Some(BsnValue::Float(5.0)),
-                "mint seeds live translation.y into the document"
+            assert!(
+                get_bsn_field(ast, pe, type_path, "translation.y").is_none(),
+                "sibling fields stay unauthored (sparse override)"
             );
-            assert_eq!(
-                get_bsn_field(ast, pe, type_path, "translation.z"),
-                Some(BsnValue::Float(8.0)),
-                "mint seeds live translation.z into the document"
+            assert!(
+                get_bsn_field(ast, pe, type_path, "translation.z").is_none(),
+                "sibling fields stay unauthored (sparse override)"
             );
         }
         let translation = app.world().get::<Transform>(entity).unwrap().translation;
@@ -2003,7 +1965,7 @@ mod set_bsn_field_tests {
         assert_eq!(
             app.world().get::<Transform>(entity).unwrap().translation,
             Vec3::new(2.0, 5.0, 8.0),
-            "undo restores the pre-edit live value"
+            "undo restores the pre-edit live field; siblings unchanged"
         );
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,74 +19,266 @@ pub struct CommandHistoryPlugin;
 
 impl Plugin for CommandHistoryPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(CommandHistory::default());
+        app.insert_resource(CommandHistory::default())
+            .init_resource::<FieldEditSessions>();
     }
 }
 
-pub struct SetComponentField {
-    pub entity: Entity,
-    pub component_type_id: TypeId,
-    pub field_path: String,
-    pub old_value: Box<dyn PartialReflect>,
-    pub new_value: Box<dyn PartialReflect>,
+/// Key for an in-progress field-edit gesture session entry.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct FieldEditSessionKey {
+    entity: Entity,
+    type_path: String,
+    field_path: String,
 }
 
-impl EditorCommand for SetComponentField {
-    fn execute(&mut self, world: &mut World) {
-        apply_reflected_value(
-            world,
-            self.entity,
-            self.component_type_id,
-            &self.field_path,
-            &*self.new_value,
+/// Live field values at [`field_edit_begin`] for in-progress gestures.
+///
+/// Lifecycle: [`field_edit_begin`] → [`field_edit_preview`]* →
+/// [`field_edit_commit`] | [`field_edit_cancel`].
+///
+/// Preview mutates ECS before any `SetBsnField` exists. Capturing live values
+/// at begin lets commit build undo baselines for derived (no-patch) components
+/// and lets cancel restore the pre-preview ECS state.
+#[derive(Resource, Default)]
+pub(crate) struct FieldEditSessions {
+    /// Live field value at gesture start, keyed by entity + field.
+    live_at_begin: std::collections::HashMap<FieldEditSessionKey, jackdaw_bsn::BsnValue>,
+}
+
+fn field_edit_session_targets(world: &World) -> Vec<Entity> {
+    world
+        .get_resource::<Selection>()
+        .map(|selection| selection.entities.clone())
+        .unwrap_or_default()
+}
+
+fn document_has_component_patch(world: &World, entity: Entity, type_path: &str) -> bool {
+    let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
+    ast.ast_for(entity)
+        .is_some_and(|node| ast.find_patch_by_type_path(node, type_path).is_some())
+}
+
+fn clear_field_edit_session(world: &mut World, type_path: &str, field_path: &str) {
+    let mut sessions = world.resource_mut::<FieldEditSessions>();
+    sessions.live_at_begin.retain(|key, _| {
+        key.type_path != type_path || key.field_path != field_path
+    });
+}
+
+fn peek_live_at_begin(
+    world: &World,
+    entity: Entity,
+    type_path: &str,
+    field_path: &str,
+) -> Option<jackdaw_bsn::BsnValue> {
+    world
+        .resource::<FieldEditSessions>()
+        .live_at_begin
+        .get(&FieldEditSessionKey {
+            entity,
+            type_path: type_path.to_string(),
+            field_path: field_path.to_string(),
+        })
+        .cloned()
+}
+
+/// Undo baseline for one target: authored document field, else `None` when
+/// the component patch exists but the field does not (sparse absence), else
+/// the live value captured at begin (derived), else the current live field.
+fn resolve_field_edit_old_value(
+    world: &World,
+    entity: Entity,
+    type_path: &str,
+    field_path: &str,
+) -> Option<jackdaw_bsn::BsnValue> {
+    if let Some(authored) = authored_bsn_field(world, entity, type_path, field_path) {
+        return Some(authored);
+    }
+    if document_has_component_patch(world, entity, type_path) {
+        // Sparse patch: field was not authored. Undo must remove it, not
+        // write back the live default captured for cancel.
+        return None;
+    }
+    peek_live_at_begin(world, entity, type_path, field_path)
+        .or_else(|| live_bsn_field(world, entity, type_path, field_path))
+}
+
+/// Begin a field-edit gesture for the current selection.
+///
+/// Captures each target's live field value so later preview ticks can mutate
+/// ECS without losing the pre-gesture baseline. Idempotent for entities that
+/// already have an entry for this field.
+pub(crate) fn field_edit_begin(world: &mut World, type_path: &str, field_path: &str) {
+    let targets = field_edit_session_targets(world);
+    if targets.is_empty() {
+        return;
+    }
+
+    let already_captured: std::collections::HashSet<Entity> = world
+        .resource::<FieldEditSessions>()
+        .live_at_begin
+        .keys()
+        .filter(|key| key.type_path == type_path && key.field_path == field_path)
+        .map(|key| key.entity)
+        .collect();
+
+    let mut to_capture: Vec<(Entity, jackdaw_bsn::BsnValue)> = Vec::new();
+    for &entity in &targets {
+        if already_captured.contains(&entity) {
+            continue;
+        }
+        if let Some(live) = live_bsn_field(world, entity, type_path, field_path) {
+            to_capture.push((entity, live));
+        }
+    }
+    if to_capture.is_empty() {
+        return;
+    }
+    let mut sessions = world.resource_mut::<FieldEditSessions>();
+    for (entity, live) in to_capture {
+        sessions.live_at_begin.insert(
+            FieldEditSessionKey {
+                entity,
+                type_path: type_path.to_string(),
+                field_path: field_path.to_string(),
+            },
+            live,
         );
     }
+}
 
-    fn undo(&mut self, world: &mut World) {
-        apply_reflected_value(
-            world,
-            self.entity,
-            self.component_type_id,
-            &self.field_path,
-            &*self.old_value,
-        );
-    }
-
-    fn description(&self) -> &str {
-        "Set component field"
+/// Preview a field value on live ECS for the current selection.
+///
+/// Does not touch the scene document or mint undo. Calls [`field_edit_begin`]
+/// so a baseline exists before the first write.
+pub(crate) fn field_edit_preview(
+    world: &mut World,
+    type_path: &str,
+    field_path: &str,
+    value: &serde_json::Value,
+) {
+    field_edit_begin(world, type_path, field_path);
+    let targets = field_edit_session_targets(world);
+    for target in targets {
+        apply_json_field_to_ecs(world, target, type_path, field_path, value);
     }
 }
 
-fn apply_reflected_value(
+/// Commit a field edit: build [`SetBsnField`] commands from session / document
+/// baselines, execute them, push history, and clear the gesture session.
+pub(crate) fn field_edit_commit(
+    world: &mut World,
+    type_path: &str,
+    field_path: &str,
+    new_json: &serde_json::Value,
+    group_label: &str,
+) {
+    // Immediate commits (no prior preview) still need a derived baseline.
+    field_edit_begin(world, type_path, field_path);
+    let targets = field_edit_session_targets(world);
+
+    let mut sub_commands: Vec<Box<dyn EditorCommand>> = Vec::new();
+    for &target in &targets {
+        let old_value = resolve_field_edit_old_value(world, target, type_path, field_path);
+        let Some(new_value) =
+            json_field_edit_to_bsn_value(world, target, type_path, field_path, new_json)
+        else {
+            continue;
+        };
+        sub_commands.push(Box::new(SetBsnField {
+            entity: target,
+            type_path: type_path.to_string(),
+            field_path: field_path.to_string(),
+            old_value,
+            new_value,
+            was_derived: false,
+        }));
+    }
+    clear_field_edit_session(world, type_path, field_path);
+
+    if sub_commands.is_empty() {
+        return;
+    }
+
+    let mut cmd: Box<dyn EditorCommand> = if sub_commands.len() == 1 {
+        sub_commands.remove(0)
+    } else {
+        Box::new(CommandGroup {
+            label: group_label.to_string(),
+            commands: sub_commands,
+        })
+    };
+    cmd.execute(world);
+    world.resource_mut::<CommandHistory>().push_executed(cmd);
+}
+
+/// Cancel an in-progress gesture: restore each target's live field to the
+/// value captured at begin, then clear the session. No document write.
+///
+/// Call from pointer-cancel / Escape abort paths once those emit into the
+/// inspector; unit tests cover the restore semantics today.
+#[allow(dead_code)]
+pub(crate) fn field_edit_cancel(world: &mut World, type_path: &str, field_path: &str) {
+    let restores: Vec<(Entity, jackdaw_bsn::BsnValue)> = world
+        .resource::<FieldEditSessions>()
+        .live_at_begin
+        .iter()
+        .filter(|(key, _)| key.type_path == type_path && key.field_path == field_path)
+        .map(|(key, value)| (key.entity, value.clone()))
+        .collect();
+    for (entity, value) in restores {
+        apply_bsn_field_to_ecs(world, entity, type_path, field_path, &value);
+    }
+    clear_field_edit_session(world, type_path, field_path);
+}
+
+/// Apply a [`jackdaw_bsn::BsnValue`] to one live ECS field (or whole component
+/// when `field_path` is empty). Document is untouched.
+#[allow(dead_code)]
+fn apply_bsn_field_to_ecs(
     world: &mut World,
     entity: Entity,
-    component_type_id: TypeId,
+    type_path: &str,
     field_path: &str,
-    value: &dyn PartialReflect,
+    value: &jackdaw_bsn::BsnValue,
 ) {
+    use bevy::reflect::GetPath;
+
     let registry = world.resource::<AppTypeRegistry>().clone();
     let registry = registry.read();
-
-    let Some(registration) = registry.get(component_type_id) else {
+    let Some(registration) = registry.get_with_type_path(type_path) else {
         return;
     };
     let Some(reflect_component) = registration.data::<ReflectComponent>() else {
         return;
     };
 
-    let Some(reflected) = reflect_component.reflect_mut(world.entity_mut(entity)) else {
-        return;
-    };
-
     if field_path.is_empty() {
-        // Apply to the entire component (e.g. a top-level enum component)
-        reflected.into_inner().apply(value);
-    } else {
-        let Ok(field) = reflected.into_inner().reflect_path_mut(field_path) else {
+        let Some(reflected) =
+            jackdaw_bsn::bsn_value_to_reflect(value, registration.type_id(), &registry, None)
+        else {
             return;
         };
-        field.apply(value);
+        reflect_component.insert(&mut world.entity_mut(entity), reflected.as_ref(), &registry);
+        return;
     }
+
+    let Some(component) = reflect_component.reflect_mut(world.entity_mut(entity)) else {
+        return;
+    };
+    let Ok(field) = component.into_inner().reflect_path_mut(field_path) else {
+        return;
+    };
+    let Some(type_info) = field.get_represented_type_info() else {
+        return;
+    };
+    let Some(reflected) =
+        jackdaw_bsn::bsn_value_to_reflect(value, type_info.type_id(), &registry, None)
+    else {
+        return;
+    };
+    field.apply(reflected.as_ref());
 }
 
 pub struct SetTransform {
@@ -350,9 +542,10 @@ pub struct AddComponent {
     pub type_id: TypeId,
     pub component_id: ComponentId,
     pub type_path: String,
-    /// Type paths of components that were auto-promoted to the AST via
-    /// `#[require]` during `execute`. Cleaned up on `undo`.
-    promoted_components: Vec<String>,
+    /// Type paths of components inserted by `#[require]` (or other side
+    /// effects) during `execute`. Tracked for ECS cleanup on `undo` only —
+    /// they are never written into the scene document.
+    required_companions: Vec<String>,
 }
 
 impl AddComponent {
@@ -367,7 +560,7 @@ impl AddComponent {
             type_id,
             component_id,
             type_path,
-            promoted_components: Vec::new(),
+            required_companions: Vec::new(),
         }
     }
 }
@@ -404,14 +597,20 @@ impl EditorCommand for AddComponent {
             );
             return;
         };
-        let Some(reflect_component) = registration.data::<ReflectComponent>() else {
+        if registration.data::<ReflectComponent>().is_none() {
             warn!(
                 "AddComponent::execute: type {} has no ReflectComponent. Add `Component` \
                  to `#[reflect(...)]`.",
                 self.type_path
             );
             return;
-        };
+        }
+
+        // Snapshot reflected components before insert so we can tell which
+        // companions `#[require]` (and similar) added, without writing them
+        // into the document.
+        drop(registry);
+        let before = reflected_component_type_paths(world, self.entity);
 
         // Insert triggers `#[require]`, which may pull in
         // dependents (e.g. `RigidBody` requires `Position`,
@@ -420,11 +619,21 @@ impl EditorCommand for AddComponent {
             "AddComponent: inserting `{}` (type_id {:?}, component_id {:?}) on entity {:?}",
             self.type_path, self.type_id, self.component_id, self.entity
         );
-        reflect_component.insert(
-            &mut world.entity_mut(self.entity),
-            default_value.as_partial_reflect(),
-            &registry,
-        );
+        {
+            let registry = world.resource::<AppTypeRegistry>().clone();
+            let registry = registry.read();
+            let Some(registration) = registry.get(self.type_id) else {
+                return;
+            };
+            let Some(reflect_component) = registration.data::<ReflectComponent>() else {
+                return;
+            };
+            reflect_component.insert(
+                &mut world.entity_mut(self.entity),
+                default_value.as_partial_reflect(),
+                &registry,
+            );
+        }
         let has_after = world
             .get_entity(self.entity)
             .ok()
@@ -435,13 +644,22 @@ impl EditorCommand for AddComponent {
             self.entity, self.component_id
         );
 
-        // Sync the explicitly-added component into the scene document so it
-        // round-trips through scene save/load and the inspector's document
-        // filter recognises it. An entity that is not tracked in the
-        // document (e.g. spawned outside the scene-loader path) keeps the
-        // component on the entity, but it won't persist through save/load;
-        // that is worth a warning because the inspector might gloss over it.
-        drop(registry);
+        let after = reflected_component_type_paths(world, self.entity);
+        self.required_companions = after
+            .into_iter()
+            .filter(|type_path| type_path != &self.type_path && !before.contains(type_path))
+            .collect();
+        if !self.required_companions.is_empty() {
+            info!(
+                "AddComponent: {} #[require] companions stay ECS-only (not authored): {:?}",
+                self.required_companions.len(),
+                self.required_companions
+            );
+        }
+
+        // Sync only the explicitly-added component into the scene document.
+        // Companions remain live ECS state until the user edits one (which
+        // mints an authored override patch).
         let tracked = world
             .resource::<jackdaw_bsn::SceneBsnAst>()
             .ast_for(self.entity)
@@ -461,20 +679,15 @@ impl EditorCommand for AddComponent {
                 self.entity, self.type_path
             );
         }
-
-        // Sync any components added by #[require] to the document so
-        // they're editable and persist with the scene. This captures avian
-        // physics internals, required transform components, etc.
-        self.promoted_components = sync_required_to_ast(world, self.entity);
     }
 
     fn undo(&mut self, world: &mut World) {
-        // Resolve promoted components' ComponentIds via the type registry
-        // so we can remove them from the ECS as well as the AST.
+        // Resolve require-companions' ComponentIds so undo strips them from
+        // the live entity. They were never written to the document.
         let registry = world.resource::<AppTypeRegistry>().clone();
         let reg = registry.read();
-        let promoted_component_ids: Vec<bevy::ecs::component::ComponentId> = self
-            .promoted_components
+        let companion_ids: Vec<bevy::ecs::component::ComponentId> = self
+            .required_companions
             .iter()
             .filter_map(|type_path| {
                 let type_id = reg.get_with_type_path(type_path)?.type_id();
@@ -485,21 +698,15 @@ impl EditorCommand for AddComponent {
 
         if let Ok(mut entity) = world.get_entity_mut(self.entity) {
             entity.remove_by_id(self.component_id);
-            for cid in &promoted_component_ids {
+            for cid in &companion_ids {
                 entity.remove_by_id(*cid);
             }
         }
-        // Remove the explicitly-added component + all promoted components
-        // from the document.
+        // Remove only the explicitly-added component from the document.
         {
             let mut ast = world.resource_mut::<jackdaw_bsn::SceneBsnAst>();
             if let Some(node) = ast.ast_for(self.entity) {
                 ast.remove_component_patch(node, &self.type_path);
-                ast.promote_derived(node, &self.type_path);
-                for promoted in &self.promoted_components.clone() {
-                    ast.remove_component_patch(node, promoted);
-                    ast.promote_derived(node, promoted);
-                }
             }
         }
         // Trigger inspector rebuild so the UI reflects the removal immediately.
@@ -823,12 +1030,20 @@ pub struct SetBsnField {
     pub entity: Entity,
     pub type_path: String,
     pub field_path: String,
-    /// `None` when the component did not exist before this edit; undo then
-    /// removes the authored component instead of writing a value back.
+    /// Pre-edit baseline for undo. `None` when the field/component did not
+    /// exist before this edit; undo then removes what execute authored.
+    ///
+    /// For derived (ECS-only) components, callers should supply the pre-edit
+    /// live value via [`field_edit_commit`] / the gesture session. If still
+    /// `None` at execute, the live field is captured as a fallback for
+    /// immediate edits that never preview-mutated ECS.
     pub old_value: Option<jackdaw_bsn::BsnValue>,
     pub new_value: jackdaw_bsn::BsnValue,
-    /// True if the component was derived before this command ran. Set on
-    /// first execute so undo can demote the component back.
+    /// True when execute authored an override for a component that was not
+    /// already in the document: either a derived (ECS-only) component, or a
+    /// project (document-only) component. Undo drops that override patch;
+    /// for derived components the live ECS value stays (optionally restored
+    /// from [`Self::old_value`]).
     pub was_derived: bool,
 }
 
@@ -935,6 +1150,35 @@ impl EditorCommand for SetBsnField {
         let is_project = world
             .get_resource::<crate::project_types::ProjectTypes>()
             .is_some_and(|pt| pt.is_project_component(&self.type_path));
+        let had_patch = {
+            let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
+            ast.ast_for(self.entity).is_some_and(|node| {
+                ast.find_patch_by_type_path(node, &self.type_path).is_some()
+            })
+        };
+        // Derived = on the live entity with no document patch. Project
+        // components are document-only; a missing patch is still a first
+        // author that undo should drop entirely.
+        let live_before = !is_project
+            && entity_has_reflected_component(world, self.entity, &self.type_path);
+        // First override of a derived component: capture the pre-edit live
+        // field when the caller did not supply a baseline. Do not fill when a
+        // patch already exists — `old_value: None` then means "field was
+        // absent from the sparse patch" and undo must remove it.
+        if self.old_value.is_none()
+            && !self.field_path.is_empty()
+            && live_before
+            && !had_patch
+        {
+            self.old_value = live_bsn_field(world, self.entity, &self.type_path, &self.field_path);
+        }
+        // First override of a derived component: seed the full live value into
+        // the document before the field write. Otherwise `set_bsn_field` mints
+        // an empty struct + one field, and save/load resets sibling fields to
+        // type defaults.
+        if !had_patch && live_before && !self.field_path.is_empty() {
+            seed_live_component_to_bsn_doc(world, self.entity, &self.type_path);
+        }
         {
             let registry = world.resource::<AppTypeRegistry>().clone();
             let registry = registry.read();
@@ -960,12 +1204,14 @@ impl EditorCommand for SetBsnField {
                     &registry,
                 );
             }
-            if ast.promote_derived(patches_entity, &self.type_path) {
+            if !had_patch && (is_project || live_before) {
                 self.was_derived = true;
-                info!(
-                    "Promoted derived component '{}' to authored (user edited it)",
-                    self.type_path
-                );
+                if live_before {
+                    info!(
+                        "Authored override for previously derived component '{}'",
+                        self.type_path
+                    );
+                }
             }
         }
         // A project component has no real ECS counterpart to mirror into; the
@@ -1001,7 +1247,22 @@ impl EditorCommand for SetBsnField {
             let Some(patches_entity) = ast.ast_for(self.entity) else {
                 return;
             };
-            if removes_component {
+            if self.was_derived {
+                // Drop the override so the component is derived (or absent
+                // from the document) again. Restore the pre-edit live field
+                // onto the temporary patch when we have one, so mirror can
+                // put ECS back before the patch is removed.
+                if let Some(old_value) = &self.old_value {
+                    jackdaw_bsn::set_bsn_field(
+                        &mut ast,
+                        patches_entity,
+                        &self.type_path,
+                        &self.field_path,
+                        old_value.clone(),
+                        &registry,
+                    );
+                }
+            } else if removes_component {
                 ast.remove_component_patch(patches_entity, &self.type_path);
             } else if removes_field {
                 jackdaw_bsn::remove_bsn_field(
@@ -1029,17 +1290,30 @@ impl EditorCommand for SetBsnField {
                         &registry,
                     );
                 }
-                if self.was_derived {
-                    ast.demote_to_derived(patches_entity, &self.type_path);
-                }
             }
         }
         // Project components have no ECS counterpart; the document write above
         // is the whole of the undo.
         if is_project {
+            if self.was_derived {
+                let mut ast = world.resource_mut::<jackdaw_bsn::SceneBsnAst>();
+                if let Some(patches_entity) = ast.ast_for(self.entity) {
+                    ast.remove_component_patch(patches_entity, &self.type_path);
+                }
+            }
             return;
         }
-        if removes_component {
+        if self.was_derived {
+            // Demote only: restore the pre-edit live field when captured,
+            // then drop the override. The component stays on the entity.
+            if self.old_value.is_some() {
+                self.mirror_patch_to_ecs(world);
+            }
+            let mut ast = world.resource_mut::<jackdaw_bsn::SceneBsnAst>();
+            if let Some(patches_entity) = ast.ast_for(self.entity) {
+                ast.remove_component_patch(patches_entity, &self.type_path);
+            }
+        } else if removes_component {
             remove_component_from_ecs(world, self.entity, &self.type_path);
         } else if removes_field {
             // The doc field is gone; restore the ECS field to the type's
@@ -1056,15 +1330,12 @@ impl EditorCommand for SetBsnField {
     }
 }
 
-/// Apply a JSON value to an ECS component  -- either full component replacement
+/// Apply a JSON value to an ECS component — either full component replacement
 /// (empty `field_path`) or field-level update.
 ///
 /// Writes only the live ECS component, leaving the scene document untouched.
-/// The document is the undo source of truth. The inspector's drag-scrub
-/// fields call this on each non-final tick so the viewport tracks the drag
-/// without minting an undo entry or dirtying the document; the pre-drag value
-/// stays in the document for the single `SetBsnField` undo pushed when the
-/// drag ends.
+/// Prefer [`field_edit_preview`] for inspector gestures; this is the live write
+/// primitive that preview uses.
 pub(crate) fn apply_json_field_to_ecs(
     world: &mut World,
     entity: Entity,
@@ -1156,6 +1427,24 @@ fn remove_component_from_ecs(world: &mut World, entity: Entity, type_path: &str)
         return;
     };
     reflect_component.remove(&mut entity_mut);
+}
+
+/// Whether `entity` currently carries the reflected component named by
+/// `type_path`. Used to distinguish derived (ECS-only) components from
+/// components that execute will mint for the first time.
+fn entity_has_reflected_component(world: &World, entity: Entity, type_path: &str) -> bool {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let registry = registry.read();
+    let Some(registration) = registry.get_with_type_path(type_path) else {
+        return false;
+    };
+    let Some(reflect_component) = registration.data::<ReflectComponent>() else {
+        return false;
+    };
+    let Ok(entity_ref) = world.get_entity(entity) else {
+        return false;
+    };
+    reflect_component.reflect(entity_ref).is_some()
 }
 
 /// Convert a `serde_json::Value` into the matching reflect primitive and apply it.
@@ -1420,87 +1709,87 @@ pub(crate) fn sync_component_to_bsn_doc(
     }
 }
 
-/// Scan an entity for reflected components that exist in the ECS but not yet
-/// in the JSN AST, and serialize them into the AST.
+/// Copy a live ECS component into the scene document as a full patch.
 ///
-/// This captures components added implicitly by Bevy's `#[require]`
-/// attributes (e.g., `RigidBody` requiring `Position`, `Rotation`,
-/// `LinearVelocity`, etc.). After this call, those components are editable
-/// in the inspector via the normal `SetBsnField` path and persist with
-/// scene save/load.
-///
-/// Designed to be upstream-compatible with BSN  -- the AST becomes the full
-/// authoritative representation, not just the user's explicit additions.
-///
-/// Returns the type paths of newly-promoted components (for undo cleanup).
-pub fn sync_required_to_ast(world: &mut World, entity: Entity) -> Vec<String> {
+/// Used when minting the first authored override for a derived component so
+/// sibling fields that only existed as runtime state are pinned before the
+/// field edit runs. No-ops when the entity is untracked or the component is
+/// missing / not reflectable.
+fn seed_live_component_to_bsn_doc(world: &mut World, entity: Entity, type_path: &str) {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let dynamic = {
+        let registry = registry.read();
+        let Some(registration) = registry.get_with_type_path(type_path) else {
+            return;
+        };
+        let Some(reflect_component) = registration.data::<ReflectComponent>() else {
+            return;
+        };
+        let Ok(entity_ref) = world.get_entity(entity) else {
+            return;
+        };
+        let Some(component) = reflect_component.reflect(entity_ref) else {
+            return;
+        };
+        component.to_dynamic()
+    };
+    sync_component_to_bsn_doc(world, entity, dynamic.as_partial_reflect(), &registry);
+}
+
+/// Reflected component type paths currently on `entity`, excluding structural
+/// / skip-listed types. Used to diff `#[require]` companions around an insert
+/// without writing them into the scene document.
+fn reflected_component_type_paths(
+    world: &World,
+    entity: Entity,
+) -> std::collections::HashSet<String> {
     use std::collections::HashSet;
 
     let registry = world.resource::<AppTypeRegistry>().clone();
-
-    // Snapshot what the document already carries for this entity.
-    let existing: HashSet<String> = {
-        let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
-        ast.ast_for(entity)
-            .map(|node| ast.component_type_paths(node).into_iter().collect())
-            .unwrap_or_default()
-    };
-
+    let reg = registry.read();
     let skip_ids = crate::scene_io::structural_skip_type_ids();
-
-    // Collect reflected components not yet in the document as patches.
-    let to_add: Vec<(String, jackdaw_bsn::BsnPatch)> = {
-        let reg = registry.read();
-        let Ok(entity_ref) = world.get_entity(entity) else {
-            return vec![];
-        };
-        reg.iter()
-            .filter(|registration| !skip_ids.contains(&registration.type_id()))
-            .filter_map(|registration| {
-                let type_path = registration
-                    .type_info()
-                    .type_path_table()
-                    .path()
-                    .to_string();
-                if existing.contains(&type_path) {
-                    return None;
-                }
-                if crate::scene_io::should_skip_component(&type_path) {
-                    return None;
-                }
-                let reflect_component = registration.data::<ReflectComponent>()?;
-                let component = reflect_component.reflect(entity_ref)?;
-                let patch =
-                    jackdaw_bsn::component_to_bsn_patch(component.as_partial_reflect(), &reg);
-                Some((type_path, patch))
-            })
-            .collect()
+    let Ok(entity_ref) = world.get_entity(entity) else {
+        return HashSet::new();
     };
-
-    let promoted: Vec<String> = to_add.iter().map(|(path, _)| path.clone()).collect();
-
-    if !promoted.is_empty() {
-        info!(
-            "sync_required_to_ast: {} derived components promoted for entity {entity}",
-            promoted.len()
-        );
-        let mut ast = world.resource_mut::<jackdaw_bsn::SceneBsnAst>();
-        if let Some(node) = ast.ast_for(entity) {
-            for (_, patch) in to_add {
-                let pe = ast.world.spawn(patch).id();
-                if let Some(patches) = ast.get_patches_mut(node) {
-                    patches.0.push(pe);
-                }
+    reg.iter()
+        .filter(|registration| !skip_ids.contains(&registration.type_id()))
+        .filter_map(|registration| {
+            let type_path = registration
+                .type_info()
+                .type_path_table()
+                .path()
+                .to_string();
+            if crate::scene_io::should_skip_component(&type_path) {
+                return None;
             }
-            // Mark as derived -- displayed in inspector but NOT persisted on
-            // save; an explicit user edit promotes them to authored.
-            for path in &promoted {
-                ast.demote_to_derived(node, path);
-            }
-        }
-    }
+            let reflect_component = registration.data::<ReflectComponent>()?;
+            reflect_component.reflect(entity_ref)?;
+            Some(type_path)
+        })
+        .collect()
+}
 
-    promoted
+/// Reflect a live ECS component field into a [`jackdaw_bsn::BsnValue`] for
+/// undo when the field was not previously authored in the document.
+pub(crate) fn live_bsn_field(
+    world: &World,
+    entity: Entity,
+    type_path: &str,
+    field_path: &str,
+) -> Option<jackdaw_bsn::BsnValue> {
+    use bevy::reflect::GetPath;
+
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let registry = registry.read();
+    let registration = registry.get_with_type_path(type_path)?;
+    let reflect_component = registration.data::<ReflectComponent>()?;
+    let entity_ref = world.get_entity(entity).ok()?;
+    let component = reflect_component.reflect(entity_ref)?;
+    let field = component.reflect_path(field_path).ok()?;
+    Some(jackdaw_bsn::BsnValue::from_reflect(
+        field.as_partial_reflect(),
+        &registry,
+    ))
 }
 
 #[cfg(test)]
@@ -1512,6 +1801,9 @@ mod set_bsn_field_tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.init_resource::<SceneBsnAst>();
+        app.init_resource::<FieldEditSessions>();
+        app.init_resource::<Selection>();
+        app.init_resource::<CommandHistory>();
         app
     }
 
@@ -1629,20 +1921,27 @@ mod set_bsn_field_tests {
         create_entity_in_ast(app.world_mut(), entity, None);
 
         let type_path = "bevy_transform::components::transform::Transform";
+        let registry = app.world().resource::<AppTypeRegistry>().clone();
+        let registry = registry.read();
+        let new_value = BsnValue::from_reflect(&Transform::from_xyz(4.0, 0.0, 0.0), &registry);
+        drop(registry);
+
+        // Whole-component mint: no prior ECS component, empty field path.
         let mut command = SetBsnField {
             entity,
             type_path: type_path.to_string(),
-            field_path: "translation.x".to_string(),
+            field_path: String::new(),
             old_value: None,
-            new_value: BsnValue::Float(4.0),
+            new_value,
             was_derived: false,
         };
-        // Execute authors the component; use an empty field path marker for
-        // the removal case per the command contract.
         command.execute(app.world_mut());
+        assert!(
+            !command.was_derived,
+            "mint from nothing is not a derived promote"
+        );
         assert!(app.world().get::<Transform>(entity).is_some());
 
-        command.field_path = String::new();
         command.undo(app.world_mut());
         assert!(
             app.world().get::<Transform>(entity).is_none(),
@@ -1657,41 +1956,283 @@ mod set_bsn_field_tests {
     }
 
     #[test]
-    fn derived_component_promotes_on_edit_and_demotes_on_undo() {
+    fn whole_component_author_of_derived_undo_keeps_ecs() {
         let mut app = field_app();
         let entity = app
             .world_mut()
-            .spawn(Transform::from_xyz(2.0, 0.0, 0.0))
+            .spawn(Transform::from_xyz(2.0, 5.0, 8.0))
             .id();
         create_entity_in_ast(app.world_mut(), entity, None);
-        jackdaw_bsn::sync_to_ast(app.world_mut(), entity, std::any::TypeId::of::<Transform>());
+
+        let type_path = "bevy_transform::components::transform::Transform";
+        let registry = app.world().resource::<AppTypeRegistry>().clone();
+        let registry = registry.read();
+        let new_value = BsnValue::from_reflect(&Transform::from_xyz(9.0, 5.0, 8.0), &registry);
+        drop(registry);
+
+        let mut command = SetBsnField {
+            entity,
+            type_path: type_path.to_string(),
+            field_path: String::new(),
+            old_value: None,
+            new_value,
+            was_derived: false,
+        };
+        command.execute(app.world_mut());
+        assert!(
+            command.was_derived,
+            "pre-existing ECS-only component is a derived promote"
+        );
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation.x,
+            9.0
+        );
+
+        command.undo(app.world_mut());
+        {
+            let ast = app.world().resource::<SceneBsnAst>();
+            let pe = ast.ast_for(entity).unwrap();
+            assert!(
+                !ast.component_type_paths(pe).iter().any(|p| p == type_path),
+                "undo drops the authored override"
+            );
+        }
+        assert!(
+            app.world().get::<Transform>(entity).is_some(),
+            "demote keeps the live component"
+        );
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation.x,
+            9.0,
+            "without an old_value baseline, live state stays at the post-edit value"
+        );
+    }
+
+    #[test]
+    fn editing_derived_component_authors_override_and_undo_drops_it() {
+        let mut app = field_app();
+        let entity = app
+            .world_mut()
+            .spawn(Transform::from_xyz(2.0, 5.0, 8.0))
+            .id();
+        create_entity_in_ast(app.world_mut(), entity, None);
+        // Transform is on the entity but not in the document → derived.
         let type_path = "bevy_transform::components::transform::Transform";
         {
-            let mut ast = app.world_mut().resource_mut::<SceneBsnAst>();
+            let ast = app.world().resource::<SceneBsnAst>();
             let pe = ast.ast_for(entity).unwrap();
-            ast.demote_to_derived(pe, type_path);
+            assert!(
+                !ast.component_type_paths(pe).iter().any(|p| p == type_path),
+                "precondition: Transform is not authored"
+            );
         }
 
         let mut command = SetBsnField {
             entity,
             type_path: type_path.to_string(),
             field_path: "translation.x".to_string(),
-            old_value: Some(BsnValue::Float(2.0)),
+            old_value: None,
             new_value: BsnValue::Float(7.0),
             was_derived: false,
         };
         command.execute(app.world_mut());
         assert!(command.was_derived, "execute records prior derived state");
+        assert!(
+            command.old_value.is_some(),
+            "execute captures the live field for undo"
+        );
         {
             let ast = app.world().resource::<SceneBsnAst>();
             let pe = ast.ast_for(entity).unwrap();
-            assert!(!ast.is_derived(pe, type_path), "edit promotes to authored");
+            assert!(
+                ast.component_type_paths(pe).iter().any(|p| p == type_path),
+                "edit authors an override patch"
+            );
+            assert_eq!(
+                get_bsn_field(ast, pe, type_path, "translation.x"),
+                Some(BsnValue::Float(7.0))
+            );
+            // Live sibling fields must be pinned at mint time so save/load
+            // does not reset them to type defaults.
+            assert_eq!(
+                get_bsn_field(ast, pe, type_path, "translation.y"),
+                Some(BsnValue::Float(5.0)),
+                "mint seeds live translation.y into the document"
+            );
+            assert_eq!(
+                get_bsn_field(ast, pe, type_path, "translation.z"),
+                Some(BsnValue::Float(8.0)),
+                "mint seeds live translation.z into the document"
+            );
         }
+        let translation = app.world().get::<Transform>(entity).unwrap().translation;
+        assert_eq!(translation, Vec3::new(7.0, 5.0, 8.0));
 
         command.undo(app.world_mut());
-        let ast = app.world().resource::<SceneBsnAst>();
-        let pe = ast.ast_for(entity).unwrap();
-        assert!(ast.is_derived(pe, type_path), "undo restores derived state");
+        {
+            let ast = app.world().resource::<SceneBsnAst>();
+            let pe = ast.ast_for(entity).unwrap();
+            assert!(
+                !ast.component_type_paths(pe).iter().any(|p| p == type_path),
+                "undo drops the override; component is derived again"
+            );
+        }
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation,
+            Vec3::new(2.0, 5.0, 8.0),
+            "undo restores the pre-edit live value"
+        );
+    }
+
+    #[test]
+    fn gesture_session_baseline_survives_live_preview_mutation() {
+        let mut app = field_app();
+        let entity = app
+            .world_mut()
+            .spawn(Transform::from_xyz(2.0, 5.0, 8.0))
+            .id();
+        create_entity_in_ast(app.world_mut(), entity, None);
+        app.world_mut().resource_mut::<Selection>().entities = vec![entity];
+
+        let type_path = "bevy_transform::components::transform::Transform";
+        let field_path = "translation.x";
+
+        // Preview ticks capture begin baseline then mutate live ECS.
+        field_edit_preview(
+            app.world_mut(),
+            type_path,
+            field_path,
+            &serde_json::json!(7.0),
+        );
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation.x,
+            7.0
+        );
+
+        // Commit must use the session baseline, not the post-preview live value.
+        field_edit_commit(
+            app.world_mut(),
+            type_path,
+            field_path,
+            &serde_json::json!(7.0),
+            "test",
+        );
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation.x,
+            7.0
+        );
+        {
+            let history = app.world().resource::<CommandHistory>();
+            assert_eq!(history.undo_stack.len(), 1);
+        }
+        app.world_mut()
+            .resource_scope(|world, mut history: Mut<CommandHistory>| {
+                history.undo(world);
+            });
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation,
+            Vec3::new(2.0, 5.0, 8.0),
+            "undo restores the gesture-start live value, not the previewed value"
+        );
+    }
+
+    #[test]
+    fn field_edit_cancel_restores_live_without_document_write() {
+        let mut app = field_app();
+        let entity = app
+            .world_mut()
+            .spawn(Transform::from_xyz(2.0, 5.0, 8.0))
+            .id();
+        create_entity_in_ast(app.world_mut(), entity, None);
+        app.world_mut().resource_mut::<Selection>().entities = vec![entity];
+
+        let type_path = "bevy_transform::components::transform::Transform";
+        let field_path = "translation.x";
+
+        field_edit_preview(
+            app.world_mut(),
+            type_path,
+            field_path,
+            &serde_json::json!(9.0),
+        );
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation.x,
+            9.0
+        );
+
+        field_edit_cancel(app.world_mut(), type_path, field_path);
+        assert_eq!(
+            app.world().get::<Transform>(entity).unwrap().translation,
+            Vec3::new(2.0, 5.0, 8.0),
+            "cancel restores the begin baseline"
+        );
+        {
+            let ast = app.world().resource::<SceneBsnAst>();
+            let pe = ast.ast_for(entity).unwrap();
+            assert!(
+                !ast.component_type_paths(pe).iter().any(|p| p == type_path),
+                "cancel must not author a document patch"
+            );
+        }
+        assert_eq!(
+            app.world().resource::<CommandHistory>().undo_stack.len(),
+            0,
+            "cancel mints no undo entry"
+        );
+    }
+
+    #[test]
+    fn sparse_missing_field_commit_undo_removes_field() {
+        let mut app = field_app();
+        let entity = app
+            .world_mut()
+            .spawn(Transform::from_xyz(5.0, 0.0, 0.0))
+            .id();
+        create_entity_in_ast(app.world_mut(), entity, None);
+        app.world_mut().resource_mut::<Selection>().entities = vec![entity];
+        let type_path = "bevy_transform::components::transform::Transform";
+
+        // Author only translation.x (sparse patch).
+        let mut cmd_translation = SetBsnField {
+            entity,
+            type_path: type_path.to_string(),
+            field_path: "translation.x".to_string(),
+            old_value: None,
+            new_value: BsnValue::Float(5.0),
+            was_derived: false,
+        };
+        cmd_translation.execute(app.world_mut());
+
+        // Preview+commit a previously-absent field; undo must remove it,
+        // not write the live default back into the sparse patch.
+        field_edit_preview(
+            app.world_mut(),
+            type_path,
+            "scale.x",
+            &serde_json::json!(3.0),
+        );
+        field_edit_commit(
+            app.world_mut(),
+            type_path,
+            "scale.x",
+            &serde_json::json!(3.0),
+            "test",
+        );
+        assert_eq!(app.world().get::<Transform>(entity).unwrap().scale.x, 3.0);
+
+        app.world_mut()
+            .resource_scope(|world, mut history: Mut<CommandHistory>| {
+                history.undo(world);
+            });
+        {
+            let ast = app.world().resource::<SceneBsnAst>();
+            let node = ast.ast_for(entity).expect("linked");
+            assert!(
+                get_bsn_field(ast, node, type_path, "scale.x").is_none(),
+                "undo removes the authored field from the sparse patch"
+            );
+        }
+        assert_eq!(app.world().get::<Transform>(entity).unwrap().scale.x, 1.0);
     }
 
     /// The `#name` reference patches on an entity's document node.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -964,7 +964,7 @@ pub struct SetBsnField {
     /// exist before this edit; undo then removes what execute authored.
     ///
     /// For derived (ECS-only) components, callers should supply the pre-edit
-    /// live value via [`field_edit_commit`] / the gesture session. If still
+    /// live value via `field_edit_commit` / the gesture session. If still
     /// `None` at execute, the live field is captured as a fallback for
     /// immediate edits that never preview-mutated ECS.
     pub old_value: Option<jackdaw_bsn::BsnValue>,

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -483,6 +483,8 @@ pub fn delete_selected(world: &mut World) {
     }
 }
 
+/// Duplicate selected entities by grafting authored AST subtrees into the live
+/// document and spawning from those patches.
 pub fn duplicate_selected(world: &mut World) {
     let selection = world.resource::<Selection>();
     let entities: Vec<Entity> = selection.entities.clone();
@@ -498,111 +500,115 @@ pub fn duplicate_selected(world: &mut World) {
         }
     }
 
+    // Snapshot authored subtrees (and their live parents) before mutating the document.
+    let to_duplicate: Vec<Entity> = entities
+        .iter()
+        .copied()
+        .filter(|&entity| {
+            world.get_entity(entity).is_ok() && world.get::<EditorEntity>(entity).is_none()
+        })
+        .collect();
+    let plans: Vec<(jackdaw_bsn::SceneBsnAst, Option<Entity>)> = {
+        let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
+        let mut plans = Vec::new();
+        for entity in to_duplicate {
+            let Some(src_node) = ast.ast_for(entity) else {
+                warn!("Duplicate: entity {entity:?} has no document node");
+                continue;
+            };
+            let parent_ast = ast.find_ast_parent_of(src_node);
+            let mut temp = jackdaw_bsn::SceneBsnAst::default();
+            jackdaw_bsn::clone_subtree_into(&mut temp, ast, src_node, None);
+            plans.push((temp, parent_ast));
+        }
+        plans
+    };
+
     let mut new_entities = Vec::new();
-
-    for &entity in &entities {
-        if world.get_entity(entity).is_err() {
-            continue;
+    for (mut temp, parent_ast) in plans {
+        prepare_authored_subtree_for_spawn(world, &mut temp);
+        let spawned = graft_and_spawn(world, &temp, parent_ast);
+        if let Some(&root) = spawned.first() {
+            new_entities.push(root);
         }
-        if world.get::<EditorEntity>(entity).is_some() {
-            continue;
-        }
-
-        // Snapshot the entity (and descendants) via DynamicSceneBuilder.
-        // `collect_entity_ids` keeps real children (e.g. a tree's trunk brush)
-        // but excludes runtime face-mesh children. The brush's `Children`
-        // component still references those excluded meshes, and `write_to_world`
-        // allocates a live placeholder entity for each unmapped reference, which
-        // would otherwise surface as empty orphan children on the clone. We
-        // despawn those placeholders below; the clone's brush regenerates its
-        // own face meshes on the next remesh.
-        let mut snapshot_entities = Vec::new();
-        crate::commands::collect_entity_ids(world, entity, &mut snapshot_entities);
-        let snapshot_set: std::collections::HashSet<Entity> =
-            snapshot_entities.iter().copied().collect();
-        let type_registry = world.resource::<AppTypeRegistry>().read();
-        let scene = DynamicWorldBuilder::from_world(world, &type_registry)
-            .extract_entities(snapshot_entities.into_iter())
-            .build();
-        drop(type_registry);
-
-        // Write the snapshot back to create a clone
-        let mut entity_map = Default::default();
-        if scene.write_to_world(world, &mut entity_map).is_err() {
-            continue;
-        }
-
-        // Despawn placeholder clones created for child references that were not
-        // part of the snapshot (the brush's runtime face meshes), so the clone
-        // does not gain empty orphan children.
-        let placeholders: Vec<Entity> = entity_map
-            .iter()
-            .filter(|(src, _)| !snapshot_set.contains(src))
-            .map(|(_, dst)| *dst)
-            .collect();
-        for placeholder in placeholders {
-            if let Ok(ec) = world.get_entity_mut(placeholder) {
-                ec.despawn();
-            }
-        }
-
-        // Find the cloned root entity
-        let Some(&new_root) = entity_map.get(&entity) else {
-            continue;
-        };
-
-        // Rename with incremented number suffix
-        if let Some(name) = world.get::<Name>(new_root) {
-            // Strip trailing " (Copy)" chains and trailing " N" to find base name
-            let mut base = name.as_str().to_string();
-            while base.ends_with(" (Copy)") {
-                base.truncate(base.len() - 7);
-            }
-            if let Some(pos) = base.rfind(' ')
-                && base[pos + 1..].parse::<u32>().is_ok()
-            {
-                base.truncate(pos);
-            }
-
-            // Find highest existing number for this base name
-            let mut max_num = 0u32;
-            let mut query = world.query::<&Name>();
-            for existing in query.iter(world) {
-                let s = existing.as_str();
-                if s == base {
-                    max_num = max_num.max(1);
-                } else if let Some(rest) = s.strip_prefix(base.as_str())
-                    && let Some(num_str) = rest.strip_prefix(' ')
-                    && let Ok(n) = num_str.parse::<u32>()
-                {
-                    max_num = max_num.max(n);
-                }
-            }
-
-            let new_name = format!("{} {}", base, max_num + 1);
-            world.entity_mut(new_root).insert(Name::new(new_name));
-        }
-
-        // Preserve parent relationship from original
-        let parent = world.get::<ChildOf>(entity).map(|c| c.0);
-        if let Some(parent) = parent {
-            world.entity_mut(new_root).insert(ChildOf(parent));
-        } else {
-            // Original was a root entity, remove any ChildOf the scene write may have added.
-            world.entity_mut(new_root).remove::<ChildOf>();
-        }
-
-        new_entities.push(new_root);
     }
 
-    // Register duplicates in AST
-    crate::scene_io::register_entities_in_ast(world, &new_entities);
-
-    // Select the new entities
     let mut selection = world.resource_mut::<Selection>();
     selection.entities = new_entities;
     for &entity in &selection.entities.clone() {
         world.entity_mut(entity).insert(Selected);
+    }
+}
+
+/// Mint fresh ids and unique root names on an authored subtree before it is
+/// grafted/spawned.
+fn prepare_authored_subtree_for_spawn(world: &mut World, ast: &mut jackdaw_bsn::SceneBsnAst) {
+    remap_brush_stable_ids(world, ast);
+    mint_scene_node_ids(world, ast);
+    assign_unique_entity_root_names(world, ast);
+}
+
+/// SceneNodeIds on entity roots of `ast`.
+fn entity_root_scene_node_ids(
+    world: &World,
+    ast: &jackdaw_bsn::SceneBsnAst,
+) -> Vec<jackdaw_scene_types::SceneNodeId> {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let reg = registry.read();
+    jackdaw_bsn::entity_roots(ast, &reg)
+        .into_iter()
+        .filter_map(|root| ast.stable_id_of(root).map(jackdaw_scene_types::SceneNodeId))
+        .collect()
+}
+
+/// Give each entity root in `ast` a `#Name` that does not collide with live
+/// scene-entity names (or with earlier roots in the same batch). Editor chrome
+/// (`EditorEntity`) is ignored so UI labels do not force renames. Collisions
+/// get the next `Base N` suffix.
+fn assign_unique_entity_root_names(world: &mut World, ast: &mut jackdaw_bsn::SceneBsnAst) {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let entity_roots = {
+        let reg = registry.read();
+        jackdaw_bsn::entity_roots(ast, &reg)
+    };
+
+    let mut taken: std::collections::HashSet<String> = {
+        let mut names = std::collections::HashSet::new();
+        let mut query = world.query_filtered::<&Name, Without<EditorEntity>>();
+        for existing in query.iter(world) {
+            names.insert(existing.as_str().to_owned());
+        }
+        names
+    };
+
+    for root in entity_roots {
+        let Some(name) = ast.get_name(root).map(str::to_owned) else {
+            continue;
+        };
+        if taken.insert(name.clone()) {
+            continue;
+        }
+
+        let mut base = name;
+        if let Some(pos) = base.rfind(' ')
+            && base[pos + 1..].parse::<u32>().is_ok()
+        {
+            base.truncate(pos);
+        }
+        let mut max_num = 0u32;
+        for existing in &taken {
+            if existing == &base {
+                max_num = max_num.max(1);
+            } else if let Some(rest) = existing.strip_prefix(base.as_str())
+                && let Some(num_str) = rest.strip_prefix(' ')
+                && let Ok(n) = num_str.parse::<u32>()
+            {
+                max_num = max_num.max(n);
+            }
+        }
+        let new_name = format!("{} {}", base, max_num + 1);
+        taken.insert(new_name.clone());
+        crate::commands::set_name_patch(ast, root, Some(&new_name));
     }
 }
 
@@ -826,7 +832,7 @@ fn copy_components(world: &mut World) {
 
     // Clipboard text is BSN: the selected subtrees plus embedded asset
     // entries, the same shape a saved scene uses, so it pastes into code
-    // editors readably. Stable node ids are stripped; paste mints fresh ones.
+    // editors readably. Paste mints fresh SceneNodeIds before grafting.
     let parent_path = world
         .resource::<crate::scene_io::SceneFilePath>()
         .path
@@ -865,15 +871,14 @@ fn copy_components(world: &mut World) {
     }
 }
 
-/// Undo command for a paste operation. On undo, finds each pasted entity by its
-/// `BrushStableId` and despawns it. On redo, re-spawns from the remapped
-/// clipboard text and restores the same stable IDs that were assigned at
-/// first paste.
+/// Undo command for a paste operation. On undo, finds each pasted root by its
+/// `SceneNodeId` and despawns it (children go with the hierarchy). On redo,
+/// re-spawns from the remapped clipboard text that already carries those ids.
 struct PasteEntitiesCommand {
-    /// Stable IDs assigned to the pasted entities at first paste.
-    spawned_stable_ids: Vec<crate::draw_brush::BrushStableId>,
-    /// Clipboard BSN with the fresh stable IDs already written in, preserved
-    /// so redo re-spawns the same entities.
+    /// SceneNodeIds assigned to pasted entity roots at first paste.
+    spawned_node_ids: Vec<jackdaw_scene_types::SceneNodeId>,
+    /// Clipboard BSN with fresh ids and unique names already written in,
+    /// preserved so redo re-spawns the same authored patches.
     remapped_text: String,
     label: String,
     /// False on first push (paste already happened); true on subsequent executes (redo).
@@ -907,17 +912,16 @@ impl crate::commands::EditorCommand for PasteEntitiesCommand {
     }
 
     fn undo(&mut self, world: &mut World) {
-        // Find entities by stable ID and despawn them.
         let id_to_entity: std::collections::HashMap<_, _> = world
-            .query::<(Entity, &crate::draw_brush::BrushStableId)>()
+            .query::<(Entity, &jackdaw_scene_types::SceneNodeId)>()
             .iter(world)
-            .map(|(e, sid)| (*sid, e))
+            .map(|(entity, node_id)| (*node_id, entity))
             .collect();
 
         let mut to_despawn: Vec<Entity> = Vec::new();
-        for sid in &self.spawned_stable_ids {
-            if let Some(&e) = id_to_entity.get(sid) {
-                to_despawn.push(e);
+        for node_id in &self.spawned_node_ids {
+            if let Some(&entity) = id_to_entity.get(node_id) {
+                to_despawn.push(entity);
             }
         }
 
@@ -937,43 +941,63 @@ impl crate::commands::EditorCommand for PasteEntitiesCommand {
     }
 }
 
-/// Spawn clipboard BSN text into the live world without disturbing the open
-/// scene's document: the live document and scene-asset table are stashed
-/// while `load_bsn_scene` runs against the parsed clipboard, then restored,
-/// and the spawned entities are registered into the live document (minting
-/// fresh stable node ids).
+/// Graft entity roots from `source` into the live document and spawn
+/// them under `parent_ast` (`None` = scene roots).
+fn graft_and_spawn(
+    world: &mut World,
+    source: &jackdaw_bsn::SceneBsnAst,
+    parent_ast: Option<Entity>,
+) -> Vec<Entity> {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let entity_roots = {
+        let reg = registry.read();
+        jackdaw_bsn::entity_roots(source, &reg)
+    };
+
+    let ecs_parent = parent_ast.and_then(|parent| {
+        world
+            .resource::<jackdaw_bsn::SceneBsnAst>()
+            .ecs_for_ast(parent)
+    });
+
+    let mut grafted_roots = Vec::new();
+    {
+        let mut live = world.resource_mut::<jackdaw_bsn::SceneBsnAst>();
+        for src_root in entity_roots {
+            let new_root = jackdaw_bsn::clone_subtree_into(&mut live, source, src_root, parent_ast);
+            grafted_roots.push(new_root);
+        }
+    }
+
+    let mut spawned_roots = Vec::new();
+    let mut all_spawned = Vec::new();
+    for &ast_root in &grafted_roots {
+        let before = all_spawned.len();
+        jackdaw_bsn::spawn_ast_node(world, ast_root, ecs_parent, &mut all_spawned);
+        if let Some(&ecs_root) = all_spawned.get(before) {
+            spawned_roots.push(ecs_root);
+        }
+    }
+    jackdaw_bsn::apply_dirty_ast_patches(world);
+    spawned_roots
+}
+
+/// Parse clipboard BSN text and graft it into the live scene document.
 fn spawn_bsn_clipboard(world: &mut World, text: &str) -> Vec<Entity> {
-    let live_doc = world.remove_resource::<jackdaw_bsn::SceneBsnAst>();
-    let live_assets = world.remove_resource::<jackdaw_bsn::BsnSceneAssets>();
-    let result = jackdaw_bsn::load_bsn_scene(world, text);
-    world.remove_resource::<jackdaw_bsn::SceneBsnAst>();
-    world.remove_resource::<jackdaw_bsn::BsnSceneAssets>();
-    if let Some(doc) = live_doc {
-        world.insert_resource(doc);
-    }
-    if let Some(assets) = live_assets {
-        world.insert_resource(assets);
-    }
-    match result {
-        Ok(loaded) => {
-            crate::scene_io::register_entities_in_ast(world, &loaded.entities);
-            loaded.entities
-        }
+    let parsed = match jackdaw_bsn::parse_bsn_text(text) {
+        Ok(ast) => ast,
         Err(e) => {
-            warn!("Paste: failed to spawn clipboard BSN: {e}");
-            Vec::new()
+            warn!("Paste: failed to parse clipboard BSN: {e}");
+            return Vec::new();
         }
-    }
+    };
+    graft_and_spawn(world, &parsed, None)
 }
 
 /// Rewrite `BrushStableId` values in a parsed clipboard document, replacing
-/// each with a fresh ID minted from `StableIdCounter`. Returns the list of
-/// newly-assigned stable IDs (one per node that had one).
-fn remap_stable_ids(
-    world: &mut World,
-    ast: &mut jackdaw_bsn::SceneBsnAst,
-) -> Vec<crate::draw_brush::BrushStableId> {
-    let mut assigned = Vec::new();
+/// each with a fresh ID minted from `StableIdCounter`. No-ops on nodes that
+/// do not carry one (cameras, empties, etc.).
+fn remap_brush_stable_ids(world: &mut World, ast: &mut jackdaw_bsn::SceneBsnAst) {
     let mut stack: Vec<Entity> = ast.roots.clone();
     let mut nodes = Vec::new();
     while let Some(node) = stack.pop() {
@@ -1003,15 +1027,19 @@ fn remap_stable_ids(
                     values: vec![jackdaw_bsn::BsnValue::Int(fresh.0 as i128)],
                 }),
             );
-            assigned.push(fresh);
         }
     }
-    assigned
 }
 
-/// Strip stable node id patches from a parsed clipboard document so the
-/// registration step mints fresh ids for the pasted entities.
-fn strip_scene_node_ids(ast: &mut jackdaw_bsn::SceneBsnAst) {
+/// Ensure every entity node in `ast` carries a fresh `SceneNodeId` patch so
+/// spawn/apply installs unique ids.
+fn mint_scene_node_ids(world: &World, ast: &mut jackdaw_bsn::SceneBsnAst) {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let asset_roots: std::collections::HashSet<Entity> = {
+        let reg = registry.read();
+        jackdaw_bsn::asset_roots(ast, &reg).into_iter().collect()
+    };
+
     let mut stack: Vec<Entity> = ast.roots.clone();
     let mut nodes = Vec::new();
     while let Some(node) = stack.pop() {
@@ -1019,7 +1047,10 @@ fn strip_scene_node_ids(ast: &mut jackdaw_bsn::SceneBsnAst) {
         stack.extend(ast.get_children_ast(node));
     }
     for node in nodes {
-        let found = ast.get_patches(node).and_then(|patches| {
+        if asset_roots.contains(&node) {
+            continue;
+        }
+        let existing = ast.get_patches(node).and_then(|patches| {
             patches.0.iter().copied().find(|&pe| {
                 matches!(
                     ast.get_patch(pe),
@@ -1028,11 +1059,18 @@ fn strip_scene_node_ids(ast: &mut jackdaw_bsn::SceneBsnAst) {
                 )
             })
         });
-        if let Some(pe) = found {
+        let fresh = jackdaw_scene_types::SceneNodeId::next();
+        let patch = jackdaw_bsn::BsnPatch::TupleStruct(jackdaw_bsn::BsnTupleStructData {
+            type_path: jackdaw_scene_types::SCENE_NODE_ID_TYPE_PATH.to_string(),
+            values: vec![jackdaw_bsn::BsnValue::Int(fresh.0 as i128)],
+        });
+        if let Some(pe) = existing {
+            ast.set_patch(pe, patch);
+        } else {
+            let pe = ast.world.spawn(patch).id();
             if let Some(patches) = ast.get_patches_mut(node) {
-                patches.0.retain(|&x| x != pe);
+                patches.0.push(pe);
             }
-            ast.world.despawn(pe);
         }
     }
 }
@@ -1067,14 +1105,11 @@ fn paste_components(world: &mut World) {
         return;
     }
 
-    // Mint fresh BrushStableIds for the pasted entities so they don't
-    // collide with their source, and drop any stable node ids so the
-    // registration step mints fresh ones.
-    let spawned_stable_ids = remap_stable_ids(world, &mut parsed);
-    strip_scene_node_ids(&mut parsed);
+    prepare_authored_subtree_for_spawn(world, &mut parsed);
+    let spawned_node_ids = entity_root_scene_node_ids(world, &parsed);
     let remapped_text = jackdaw_bsn::emit_scene(&parsed);
 
-    let spawned = spawn_bsn_clipboard(world, &remapped_text);
+    let spawned = graft_and_spawn(world, &parsed, None);
     if spawned.is_empty() {
         return;
     }
@@ -1093,7 +1128,7 @@ fn paste_components(world: &mut World) {
     info!("Pasted {} entities from BSN clipboard", spawned.len());
 
     let cmd = PasteEntitiesCommand {
-        spawned_stable_ids,
+        spawned_node_ids,
         remapped_text,
         label: "Paste entities".to_string(),
         is_redo: false,
@@ -1872,7 +1907,7 @@ pub(crate) fn entity_add_prefab(
 mod tests {
     use super::*;
 
-    /// Verifies that `remap_stable_ids` replaces existing `BrushStableId`
+    /// Verifies that `remap_brush_stable_ids` replaces existing `BrushStableId`
     /// values in a parsed clipboard document with fresh IDs from
     /// `StableIdCounter`, so pasted copies don't share IDs with their
     /// originals.
@@ -1893,28 +1928,17 @@ mod tests {
         )]);
         ast.add_to_roots(node);
 
-        let assigned = remap_stable_ids(&mut world, &mut ast);
+        remap_brush_stable_ids(&mut world, &mut ast);
 
-        // One node had a BrushStableId, so one fresh ID should have been minted.
-        assert_eq!(assigned.len(), 1);
-
-        // The freshly-assigned ID must differ from the original.
-        let fresh_id = assigned[0].0;
-        assert_ne!(
-            fresh_id, original_id,
-            "pasted entity should have a new stable ID"
-        );
-
-        // The document patch should hold the new value.
         let stored = jackdaw_bsn::get_bsn_field(&ast, node, STABLE_ID_PATH, "0");
         assert!(
-            matches!(stored, Some(jackdaw_bsn::BsnValue::Int(v)) if v == i128::from(fresh_id)),
-            "the patch holds the fresh stable ID"
+            matches!(stored, Some(jackdaw_bsn::BsnValue::Int(v)) if v != i128::from(original_id)),
+            "pasted entity should have a new stable ID, got {stored:?}"
         );
     }
 
     /// Verifies that nodes without a `BrushStableId` patch are untouched by
-    /// `remap_stable_ids` and that no spurious IDs are returned.
+    /// `remap_brush_stable_ids`.
     #[test]
     fn paste_does_not_add_stable_ids_to_non_brush_entities() {
         let mut world = World::new();
@@ -1924,10 +1948,8 @@ mod tests {
         let node = ast.create_entity_node(vec![jackdaw_bsn::BsnPatch::Name("Empty".to_string())]);
         ast.add_to_roots(node);
 
-        let assigned = remap_stable_ids(&mut world, &mut ast);
+        remap_brush_stable_ids(&mut world, &mut ast);
 
-        // No BrushStableId present: nothing should be assigned or added.
-        assert!(assigned.is_empty());
         assert_eq!(
             ast.component_type_paths(node),
             Vec::<String>::new(),
@@ -1935,10 +1957,13 @@ mod tests {
         );
     }
 
-    /// `strip_scene_node_ids` removes stable node id patches so a paste
-    /// mints fresh ids, and leaves other patches alone.
+    /// `mint_scene_node_ids` replaces any existing `SceneNodeId` with a fresh
+    /// sparse id and leaves other patches alone.
     #[test]
-    fn strip_scene_node_ids_drops_only_id_patches() {
+    fn mint_scene_node_ids_replaces_existing_ids() {
+        let mut world = World::new();
+        world.init_resource::<AppTypeRegistry>();
+
         let mut ast = jackdaw_bsn::SceneBsnAst::default();
         let node = ast.create_entity_node(vec![
             jackdaw_bsn::BsnPatch::TupleStruct(jackdaw_bsn::BsnTupleStructData {
@@ -1949,9 +1974,50 @@ mod tests {
         ]);
         ast.add_to_roots(node);
 
-        strip_scene_node_ids(&mut ast);
+        mint_scene_node_ids(&world, &mut ast);
 
-        assert_eq!(ast.stable_id_of(node), None, "the id patch is gone");
+        let id = ast.stable_id_of(node).expect("id patch present");
+        assert_ne!(id, 42, "the stale id must be replaced");
+        assert!(
+            id >= jackdaw_scene_types::SPARSE_MIN,
+            "minted id must be in the sparse range"
+        );
         assert_eq!(ast.get_name(node), Some("Kept"), "other patches survive");
+    }
+
+    #[test]
+    fn assign_unique_entity_root_names_keeps_free_names_and_numbers_collisions() {
+        let mut world = World::new();
+        world.init_resource::<AppTypeRegistry>();
+        world.spawn(Name::new("Brush"));
+        world.spawn(Name::new("Brush 2"));
+        world.spawn((Name::new("Camera"), EditorEntity));
+
+        let mut ast = jackdaw_bsn::SceneBsnAst::default();
+        let free = ast.create_entity_node(vec![jackdaw_bsn::BsnPatch::Name("Camera".to_string())]);
+        let taken = ast.create_entity_node(vec![jackdaw_bsn::BsnPatch::Name("Brush".to_string())]);
+        let also_taken =
+            ast.create_entity_node(vec![jackdaw_bsn::BsnPatch::Name("Brush".to_string())]);
+        ast.add_to_roots(free);
+        ast.add_to_roots(taken);
+        ast.add_to_roots(also_taken);
+
+        assign_unique_entity_root_names(&mut world, &mut ast);
+
+        assert_eq!(
+            ast.get_name(free),
+            Some("Camera"),
+            "editor chrome names do not force renames"
+        );
+        assert_eq!(
+            ast.get_name(taken),
+            Some("Brush 3"),
+            "colliding name takes the next free number"
+        );
+        assert_eq!(
+            ast.get_name(also_taken),
+            Some("Brush 4"),
+            "batch collisions advance past names assigned earlier in the same pass"
+        );
     }
 }

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -548,7 +548,7 @@ fn prepare_authored_subtree_for_spawn(world: &mut World, ast: &mut jackdaw_bsn::
     assign_unique_entity_root_names(world, ast);
 }
 
-/// SceneNodeIds on entity roots of `ast`.
+/// `SceneNodeIds` on entity roots of `ast`.
 fn entity_root_scene_node_ids(
     world: &World,
     ast: &jackdaw_bsn::SceneBsnAst,
@@ -875,7 +875,7 @@ fn copy_components(world: &mut World) {
 /// `SceneNodeId` and despawns it (children go with the hierarchy). On redo,
 /// re-spawns from the remapped clipboard text that already carries those ids.
 struct PasteEntitiesCommand {
-    /// SceneNodeIds assigned to pasted entity roots at first paste.
+    /// `SceneNodeIds` assigned to pasted entity roots at first paste.
     spawned_node_ids: Vec<jackdaw_scene_types::SceneNodeId>,
     /// Clipboard BSN with fresh ids and unique names already written in,
     /// preserved so redo re-spawns the same authored patches.

--- a/src/gizmos.rs
+++ b/src/gizmos.rs
@@ -464,6 +464,7 @@ pub fn gizmo_drag(
     mut drag_state: ResMut<GizmoDragState>,
     snap_settings: Res<SnapSettings>,
     modal: Option<Single<Entity, With<ActiveModalOperator>>>,
+    mut commands: Commands,
 ) -> OperatorResult {
     let cursor_pos = viewport_ctx.cursor.get()?;
     // First-frame: pick the active (hovered) viewport. Subsequent
@@ -533,9 +534,10 @@ pub fn gizmo_drag(
     }
 
     if mouse.just_released(MouseButton::Left) {
-        // Undo is handled by the framework: the modal captured a
-        // before-snapshot on start; returning Finished triggers an
-        // after-snapshot + SnapshotDiff push.
+        // Sync ECS → AST before Finished so the framework's after-snapshot
+        // (and a later save) see the dragged Transforms. Undo is still the
+        // SnapshotDiff; this only brings the document up to date.
+        queue_sync_gizmo_transforms_to_ast(&drag_state, &transforms, &mut commands);
         clear_gizmo_drag_state(&mut drag_state, &mut cursor_query);
         return OperatorResult::Finished;
     }
@@ -629,6 +631,41 @@ pub fn gizmo_drag(
         ActiveTool::Select => return OperatorResult::Finished,
     }
     OperatorResult::Running
+}
+
+/// Mirror each gizmo target's live ECS [`Transform`] into the scene document.
+///
+/// Object gizmo mutates ECS every frame and relies on `SnapshotDiff` for undo.
+/// Save / after-snapshot emit the document, so without this the dragged pose
+/// never reaches the `.bsn`.
+fn queue_sync_gizmo_transforms_to_ast(
+    drag_state: &GizmoDragState,
+    transforms: &Query<(&GlobalTransform, &mut Transform), With<Selected>>,
+    commands: &mut Commands,
+) {
+    let to_sync: Vec<(Entity, Transform)> = drag_state
+        .targets
+        .iter()
+        .filter_map(|target| {
+            transforms
+                .get(target.entity)
+                .ok()
+                .map(|(_, transform)| (target.entity, *transform))
+        })
+        .collect();
+    if to_sync.is_empty() {
+        return;
+    }
+    commands.queue(move |world: &mut World| {
+        for (entity, transform) in to_sync {
+            crate::commands::sync_component_to_ast(
+                world,
+                entity,
+                "bevy_transform::components::transform::Transform",
+                &transform,
+            );
+        }
+    });
 }
 
 fn cancel_gizmo_drag(

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -980,22 +980,6 @@ pub(crate) fn spawn_component_display(
         ChildOf(toggle_area),
     ));
 
-    // Derived (= on the live entity, no authored document patch) gets a
-    // dashed-circle mark so required/runtime companions read differently
-    // from explicitly authored components.
-    if is_derived {
-        commands.spawn((
-            Text::new(String::from(Icon::CircleDashed.unicode())),
-            TextFont {
-                font: font.clone().into(),
-                font_size: tokens::TEXT_SIZE_SM,
-                ..Default::default()
-            },
-            TextColor(tokens::TEXT_MUTED_COLOR.into()),
-            ChildOf(toggle_area),
-        ));
-    }
-
     // Component name (orange if overridden; muted when derived).
     let name_color = if is_overridden {
         default_style::INSPECTOR_OVERRIDE

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -320,18 +320,14 @@ pub(crate) fn build_inspector_displays(
         })
         .collect();
 
-    // Sort: custom-category groups first, then alphabetical within
-    // each tier. `AvianCollider` is pinned to the top of its group
-    // because it carries the collider-type dropdown the user reaches
-    // for most when iterating on physics; ordering it alphabetically
-    // (where it'd sit under `RigidBody` in the Avian3d group) buries
-    // it under runtime-state components.
-    let group_pin_priority = |type_path: &str| -> u8 {
-        if type_path == "jackdaw_avian_integration::AvianCollider" {
-            0
-        } else {
-            1
-        }
+    // Sort: custom-category groups first, then by group name, then
+    // authored before derived within a group, then alphabetical.
+    let is_derived_path = |type_path: &str| -> bool {
+        !authored_type_paths.is_empty()
+            && !jackdaw_bsn::type_paths_include(
+                authored_type_paths.iter().map(String::as_str),
+                type_path,
+            )
     };
     comp_list.sort_by(|a, b| {
         let a_custom = custom_groups.contains(&a.1);
@@ -339,7 +335,7 @@ pub(crate) fn build_inspector_displays(
         b_custom
             .cmp(&a_custom)
             .then_with(|| a.1.cmp(&b.1))
-            .then_with(|| group_pin_priority(&a.3).cmp(&group_pin_priority(&b.3)))
+            .then_with(|| is_derived_path(&a.3).cmp(&is_derived_path(&b.3)))
             .then_with(|| a.0.to_lowercase().cmp(&b.0.to_lowercase()))
     });
 

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -156,31 +156,6 @@ fn hidden_by_namespace(full_path: &str) -> bool {
         && !SCENE_TYPES_WITH_INSPECTOR_CARDS.contains(&full_path)
 }
 
-/// Whether the scene document tracks `full_path` on the inspected entity.
-///
-/// A document node records an enum component under its authored VARIANT
-/// path (`bevy_camera::visibility::Visibility::Visible`), never the bare
-/// type path, so an exact set lookup misses every enum component the
-/// scene authors and the AST filter drops it from the inspector. Match a
-/// stored path that is `full_path` plus exactly one `::`-separated
-/// variant segment; requiring a single segment keeps `Foo` from claiming
-/// a nested `Foo::Bar::Baz`.
-///
-/// Same rule `SceneBsnAst::find_patch_by_type_path` applies when it looks
-/// a patch up by type -- this is the string-set twin of it, because
-/// `component_type_paths` hands back raw authored paths.
-fn ast_tracks(jsn_type_paths: &HashSet<String>, full_path: &str) -> bool {
-    if jsn_type_paths.contains(full_path) {
-        return true;
-    }
-    jsn_type_paths.iter().any(|stored| {
-        stored
-            .strip_prefix(full_path)
-            .and_then(|rest| rest.strip_prefix("::"))
-            .is_some_and(|variant| !variant.is_empty() && !variant.contains("::"))
-    })
-}
-
 #[expect(
     clippy::too_many_arguments,
     reason = "inspector rebuild needs the full system param set; bundling into a struct would just push the problem one frame down"
@@ -296,7 +271,10 @@ pub(crate) fn build_inspector_displays(
                         || full_path.starts_with("jackdaw_multiplayer"));
                 if !is_user_type
                     && !authored_type_paths.is_empty()
-                    && !ast_tracks(authored_type_paths, full_path)
+                    && !jackdaw_bsn::type_paths_include(
+                        authored_type_paths.iter().map(String::as_str),
+                        full_path,
+                    )
                 {
                     return None;
                 }
@@ -410,8 +388,11 @@ pub(crate) fn build_inspector_displays(
         });
 
         let is_overridden = is_overridden_baseline || is_overridden_prefab;
-        let is_derived =
-            !authored_type_paths.is_empty() && !authored_type_paths.contains(type_path.as_str());
+        let is_derived = !authored_type_paths.is_empty()
+            && !jackdaw_bsn::type_paths_include(
+                authored_type_paths.iter().map(String::as_str),
+                type_path.as_str(),
+            );
 
         // Forward the prefab context whenever the entity sits inside a
         // prefab instance so the right-click menu can offer Revert /
@@ -1274,41 +1255,7 @@ pub(crate) fn filter_inspector_components(
 
 #[cfg(test)]
 mod tests {
-    use super::{ast_tracks, hidden_by_namespace};
-    use std::collections::HashSet;
-
-    fn set(paths: &[&str]) -> HashSet<String> {
-        paths.iter().map(|s| (*s).to_string()).collect()
-    }
-
-    #[test]
-    fn an_enum_component_authored_as_a_variant_still_counts_as_tracked() {
-        // What a scene document actually stores for `Visibility`.
-        let tracked = set(&[
-            "bevy_transform::components::transform::Transform",
-            "bevy_camera::visibility::Visibility::Visible",
-        ]);
-        assert!(ast_tracks(&tracked, "bevy_camera::visibility::Visibility"));
-        assert!(ast_tracks(
-            &tracked,
-            "bevy_transform::components::transform::Transform"
-        ));
-    }
-
-    #[test]
-    fn a_type_the_document_never_authored_stays_untracked() {
-        let tracked = set(&["bevy_camera::visibility::Visibility::Visible"]);
-        // Computed siblings share a module, not an identity.
-        assert!(!ast_tracks(
-            &tracked,
-            "bevy_camera::visibility::InheritedVisibility"
-        ));
-        // A prefix that is not followed by `::` is not a variant.
-        assert!(!ast_tracks(&tracked, "bevy_camera::visibility::Visib"));
-        // One variant segment only: `Foo` must not claim `Foo::Bar::Baz`.
-        assert!(!ast_tracks(&set(&["a::B::C::D"]), "a::B"));
-        assert!(ast_tracks(&set(&["a::B::C"]), "a::B"));
-    }
+    use super::hidden_by_namespace;
 
     #[test]
     fn the_scene_data_components_with_their_own_cards_survive_the_namespace_cull() {

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -83,7 +83,7 @@ pub(crate) fn add_component_displays(
     let source_entity = entity_ref.entity();
     let sel_count = selection.entities.len();
 
-    let jsn_type_paths = inspector_type_paths_for(
+    let authored_type_paths = inspector_type_paths_for(
         &asts.bsn,
         &prefab_cache,
         source_entity,
@@ -109,7 +109,7 @@ pub(crate) fn add_component_displays(
             &editor_font,
             false,
             &materials,
-            &jsn_type_paths,
+            &authored_type_paths,
             Some(&asts.bsn),
             Some(&prefab_cache),
             &collapse_state,
@@ -199,7 +199,7 @@ pub(crate) fn build_inspector_displays(
     editor_font: &EditorFont,
     _read_only: bool,
     materials: &Assets<StandardMaterial>,
-    jsn_type_paths: &HashSet<String>,
+    authored_type_paths: &HashSet<String>,
     scene_ast: Option<&jackdaw_bsn::SceneBsnAst>,
     prefab_cache: Option<&PrefabAstCache>,
     collapse_state: &super::InspectorCollapseState,
@@ -295,8 +295,8 @@ pub(crate) fn build_inspector_displays(
                         || full_path.starts_with("jackdaw_avian_integration")
                         || full_path.starts_with("jackdaw_multiplayer"));
                 if !is_user_type
-                    && !jsn_type_paths.is_empty()
-                    && !ast_tracks(jsn_type_paths, full_path)
+                    && !authored_type_paths.is_empty()
+                    && !ast_tracks(authored_type_paths, full_path)
                 {
                     return None;
                 }
@@ -410,6 +410,8 @@ pub(crate) fn build_inspector_displays(
         });
 
         let is_overridden = is_overridden_baseline || is_overridden_prefab;
+        let is_derived =
+            !authored_type_paths.is_empty() && !authored_type_paths.contains(type_path.as_str());
 
         // Forward the prefab context whenever the entity sits inside a
         // prefab instance so the right-click menu can offer Revert /
@@ -472,6 +474,7 @@ pub(crate) fn build_inspector_displays(
                 entity: source_entity,
                 component: Some(component_id),
                 is_overridden,
+                is_derived,
                 prefab_ctx: spec_prefab_ctx,
                 revert_through_prefab,
                 icon_font: &icon_font.0,
@@ -610,6 +613,7 @@ pub(crate) fn build_inspector_displays(
                     entity: source_entity,
                     component: None,
                     is_overridden: false,
+                    is_derived: false,
                     prefab_ctx: None,
                     revert_through_prefab: false,
                     icon_font: &icon_font.0,
@@ -770,7 +774,7 @@ pub(crate) fn on_inspector_dirty(
         }
         let sel_count = selection.entities.len();
 
-        let jsn_type_paths = inspector_type_paths_for(
+        let authored_type_paths = inspector_type_paths_for(
             &asts.bsn,
             &prefab_cache,
             source_entity,
@@ -793,7 +797,7 @@ pub(crate) fn on_inspector_dirty(
             &editor_font,
             false,
             &materials,
-            &jsn_type_paths,
+            &authored_type_paths,
             Some(&asts.bsn),
             Some(&prefab_cache),
             &collapse_state,
@@ -867,6 +871,9 @@ pub(crate) struct ComponentDisplaySpec<'a> {
     pub entity: Entity,
     pub component: Option<ComponentId>,
     pub is_overridden: bool,
+    /// True when the component is on the live entity but has no authored
+    /// document patch (`#[require]` companions, runtime inserts, etc.).
+    pub is_derived: bool,
     /// When `Some`, the entity sits inside a prefab instance. Drives
     /// the right-click menu for every component on the entity.
     pub prefab_ctx: Option<PrefabInstanceCtx>,
@@ -893,6 +900,7 @@ pub(crate) fn spawn_component_display(
         entity,
         component,
         is_overridden,
+        is_derived,
         prefab_ctx,
         revert_through_prefab,
         icon_font,
@@ -991,9 +999,27 @@ pub(crate) fn spawn_component_display(
         ChildOf(toggle_area),
     ));
 
-    // Component name (orange if overridden).
+    // Derived (= on the live entity, no authored document patch) gets a
+    // dashed-circle mark so required/runtime companions read differently
+    // from explicitly authored components.
+    if is_derived {
+        commands.spawn((
+            Text::new(String::from(Icon::CircleDashed.unicode())),
+            TextFont {
+                font: font.clone().into(),
+                font_size: tokens::TEXT_SIZE_SM,
+                ..Default::default()
+            },
+            TextColor(tokens::TEXT_MUTED_COLOR.into()),
+            ChildOf(toggle_area),
+        ));
+    }
+
+    // Component name (orange if overridden; muted when derived).
     let name_color = if is_overridden {
         default_style::INSPECTOR_OVERRIDE
+    } else if is_derived {
+        tokens::TEXT_MUTED_COLOR.into()
     } else {
         tokens::TEXT_DISPLAY_COLOR.into()
     };
@@ -1094,30 +1120,33 @@ pub(crate) fn spawn_component_display(
         }
 
         // Remove component button (X icon). See revert button for the
-        // tooltip-data + manual-dispatch pattern.
-        let remove_path = type_path_owned.clone();
-        let remove_call = ButtonOperatorCall::new(super::ops::ComponentRemoveOp::ID)
-            .with_param("entity", entity_param)
-            .with_param("type_path", remove_path.clone());
-        commands.spawn((
-            Text::new(String::from(Icon::X.unicode())),
-            TextFont {
-                font: font.clone().into(),
-                font_size: tokens::TEXT_SIZE_SM,
-                ..Default::default()
-            },
-            TextColor(tokens::TEXT_SECONDARY),
-            Hovered::default(),
-            remove_call,
-            ChildOf(header),
-            bevy::ui_widgets::observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
-                commands
-                    .operator(super::ops::ComponentRemoveOp::ID)
-                    .param("entity", entity_param)
-                    .param("type_path", type_path_owned.clone())
-                    .call();
-            }),
-        ));
+        // tooltip-data + manual-dispatch pattern. Derived companions have
+        // no document patch to remove — hide the control.
+        if !is_derived {
+            let remove_path = type_path_owned.clone();
+            let remove_call = ButtonOperatorCall::new(super::ops::ComponentRemoveOp::ID)
+                .with_param("entity", entity_param)
+                .with_param("type_path", remove_path.clone());
+            commands.spawn((
+                Text::new(String::from(Icon::X.unicode())),
+                TextFont {
+                    font: font.clone().into(),
+                    font_size: tokens::TEXT_SIZE_SM,
+                    ..Default::default()
+                },
+                TextColor(tokens::TEXT_SECONDARY),
+                Hovered::default(),
+                remove_call,
+                ChildOf(header),
+                bevy::ui_widgets::observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+                    commands
+                        .operator(super::ops::ComponentRemoveOp::ID)
+                        .param("entity", entity_param)
+                        .param("type_path", type_path_owned.clone())
+                        .call();
+                }),
+            ));
+        }
     }
 
     // Right-click context menu on prefab-instance component headers.

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -1120,8 +1120,7 @@ pub(crate) fn spawn_component_display(
         }
 
         // Remove component button (X icon). See revert button for the
-        // tooltip-data + manual-dispatch pattern. Derived companions have
-        // no document patch to remove — hide the control.
+        // tooltip-data + manual-dispatch pattern.
         if !is_derived {
             let remove_path = type_path_owned.clone();
             let remove_call = ButtonOperatorCall::new(super::ops::ComponentRemoveOp::ID)

--- a/src/inspector/component_picker.rs
+++ b/src/inspector/component_picker.rs
@@ -330,7 +330,12 @@ pub(crate) fn on_add_component_button_click(
         .map(|node| doc.component_type_paths(node).into_iter().collect())
         .unwrap_or_default();
     for schema in project_types.components() {
-        if schema.hidden || authored.contains(&schema.type_path) {
+        if schema.hidden
+            || jackdaw_bsn::type_paths_include(
+                authored.iter().map(String::as_str),
+                &schema.type_path,
+            )
+        {
             continue;
         }
         let group = if !schema.category.is_empty() {

--- a/src/inspector/physics_display.rs
+++ b/src/inspector/physics_display.rs
@@ -13,19 +13,18 @@ use crate::commands::{AddComponent, CommandGroup, CommandHistory, EditorCommand}
 pub(crate) const RIGID_BODY_TYPE_PATH: &str = "avian3d::dynamics::rigid_body::RigidBody";
 pub(crate) const AVIAN_COLLIDER_TYPE_PATH: &str = "jackdaw_avian_integration::AvianCollider";
 
-/// Command that disables physics on an entity. Captures the full pre-disable
-/// state (`RigidBody`, `AvianCollider`, and all derived avian components in
-/// the document) so undo restores them.
+/// Command that disables physics on an entity. Captures authored physics
+/// patches (`RigidBody`, `AvianCollider`, and any other avian overrides the
+/// user pinned) so undo restores them. Runtime `#[require]` companions are
+/// never in the document and are rebuilt by avian on re-enable.
 pub(crate) struct DisablePhysics {
     entity: Entity,
     /// Document patches that were removed, cloned for restore on undo.
     removed_patches: Vec<jackdaw_bsn::BsnPatch>,
-    /// Derived components that were cleared on execute, for re-adding on undo.
-    removed_derived: std::collections::HashSet<String>,
 }
 
 /// Whether a type path names one of the physics components this command
-/// removes: the canonical pair plus every derived avian component.
+/// removes: the canonical pair plus any authored avian overrides.
 fn is_physics_type_path(type_path: &str) -> bool {
     type_path == RIGID_BODY_TYPE_PATH
         || type_path == AVIAN_COLLIDER_TYPE_PATH
@@ -46,30 +45,21 @@ fn patch_type_path(patch: &jackdaw_bsn::BsnPatch) -> Option<&str> {
 impl DisablePhysics {
     pub(crate) fn from_world(world: &World, entity: Entity) -> Self {
         let mut removed_patches = Vec::new();
-        let mut removed_derived = std::collections::HashSet::new();
         let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
-        if let Some(node) = ast.ast_for(entity) {
-            if let Some(patches) = ast.get_patches(node) {
-                for &pe in &patches.0 {
-                    if let Some(patch) = ast.get_patch(pe)
-                        && patch_type_path(patch).is_some_and(is_physics_type_path)
-                    {
-                        removed_patches.push(patch.clone());
-                    }
-                }
-            }
-            if let Some(derived) = ast.world.get::<jackdaw_bsn::DerivedComponents>(node) {
-                for type_path in derived.0.iter() {
-                    if is_physics_type_path(type_path) {
-                        removed_derived.insert(type_path.clone());
-                    }
+        if let Some(node) = ast.ast_for(entity)
+            && let Some(patches) = ast.get_patches(node)
+        {
+            for &pe in &patches.0 {
+                if let Some(patch) = ast.get_patch(pe)
+                    && patch_type_path(patch).is_some_and(is_physics_type_path)
+                {
+                    removed_patches.push(patch.clone());
                 }
             }
         }
         Self {
             entity,
             removed_patches,
-            removed_derived,
         }
     }
 }
@@ -82,7 +72,7 @@ impl EditorCommand for DisablePhysics {
             ec.remove::<AvianCollider>();
             ec.remove::<Collider>();
         }
-        // Clean up the document (matches previous behavior)
+        // Clean up authored physics patches from the document.
         let mut ast = world.resource_mut::<jackdaw_bsn::SceneBsnAst>();
         if let Some(node) = ast.ast_for(self.entity) {
             let physics_paths: Vec<String> = ast
@@ -92,9 +82,6 @@ impl EditorCommand for DisablePhysics {
                 .collect();
             for type_path in physics_paths {
                 ast.remove_component_patch(node, &type_path);
-            }
-            if let Some(mut derived) = ast.world.get_mut::<jackdaw_bsn::DerivedComponents>(node) {
-                derived.0.clear();
             }
         }
     }
@@ -108,18 +95,6 @@ impl EditorCommand for DisablePhysics {
                     let pe = ast.world.spawn(patch.clone()).id();
                     if let Some(patches) = ast.get_patches_mut(node) {
                         patches.0.push(pe);
-                    }
-                }
-                if !self.removed_derived.is_empty() {
-                    let set: bevy::platform::collections::HashSet<String> =
-                        self.removed_derived.iter().cloned().collect();
-                    match ast.world.get_mut::<jackdaw_bsn::DerivedComponents>(node) {
-                        Some(mut derived) => derived.0.extend(set),
-                        None => {
-                            ast.world
-                                .entity_mut(node)
-                                .insert(jackdaw_bsn::DerivedComponents(set));
-                        }
                     }
                 }
             }

--- a/src/inspector/reflect_fields.rs
+++ b/src/inspector/reflect_fields.rs
@@ -2440,7 +2440,7 @@ pub(crate) fn on_text_edit_commit(
 }
 
 /// Apply a drag-tick (non-final) numeric edit via [`crate::commands::field_edit_preview`].
-/// Live ECS only — no document write, no undo. In PIE Live mode it routes
+/// Live ECS only, no document write or minting of undo. In PIE Live mode it routes
 /// through the live-edit stream instead.
 fn apply_field_value_live(
     world: &mut World,
@@ -3184,7 +3184,7 @@ fn apply_enum_variant_with_undo(
         &new_json,
         "Set enum on multiple entities",
     );
-    // No need to flag anything — `refresh_enum_variants` detects the ECS
+    // No need to flag anything -- `refresh_enum_variants` detects the ECS
     // variant change and rebuilds the affected subtree automatically. Same
     // goes for undo/redo since the command framework mutates the ECS too.
 }

--- a/src/inspector/reflect_fields.rs
+++ b/src/inspector/reflect_fields.rs
@@ -1,4 +1,3 @@
-use crate::commands::{CommandGroup, CommandHistory, EditorCommand, SetBsnField};
 use crate::selection::Selection;
 
 use bevy::reflect::{NamedField, UnnamedField};
@@ -1775,9 +1774,6 @@ fn apply_color_with_undo(
         return;
     }
 
-    let selection = world.resource::<Selection>();
-    let targets: Vec<Entity> = selection.entities.clone();
-
     // The canonical reflect JSON (`{"Srgba": {..}}`) deserializes into any
     // `Color`-typed field; the picker's raw sRGBA array does not.
     let srgba = Srgba::new(new_rgba[0], new_rgba[1], new_rgba[2], new_rgba[3]);
@@ -1786,41 +1782,13 @@ fn apply_color_with_undo(
         color_to_canonical_json(Color::Srgba(srgba), &reg)
     };
 
-    let mut sub_commands: Vec<Box<dyn EditorCommand>> = Vec::new();
-
-    for &target in &targets {
-        let old_value = crate::commands::authored_bsn_field(world, target, type_path, field_path);
-        let Some(new_value) = crate::commands::json_field_edit_to_bsn_value(
-            world, target, type_path, field_path, &new_json,
-        ) else {
-            continue;
-        };
-
-        sub_commands.push(Box::new(SetBsnField {
-            entity: target,
-            type_path: type_path.to_string(),
-            field_path: field_path.to_string(),
-            old_value,
-            new_value,
-            was_derived: false,
-        }));
-    }
-
-    if sub_commands.is_empty() {
-        return;
-    }
-
-    let mut cmd: Box<dyn EditorCommand> = if sub_commands.len() == 1 {
-        sub_commands.pop().unwrap()
-    } else {
-        Box::new(CommandGroup {
-            label: "Set color on multiple entities".to_string(),
-            commands: sub_commands,
-        })
-    };
-    cmd.execute(world);
-    let mut history = world.resource_mut::<CommandHistory>();
-    history.push_executed(cmd);
+    crate::commands::field_edit_commit(
+        world,
+        type_path,
+        field_path,
+        &new_json,
+        "Set color on multiple entities",
+    );
 }
 
 fn spawn_numeric_field(
@@ -2043,59 +2011,27 @@ fn color_to_canonical_json(
     })
 }
 
-/// Apply a field value change with undo support -- snapshots old value, creates command.
-/// Propagates the edit to all selected entities that have the same component.
+/// Apply a field value change with undo support via the field-edit lifecycle
+/// ([`crate::commands::field_edit_commit`]). Propagates to the current selection.
 fn apply_field_value_with_undo(
     world: &mut World,
-    _entity: Entity,
+    entity: Entity,
     type_path: &str,
     field_path: &str,
     new_value_str: &str,
 ) {
     let new_json = parse_to_json_value(new_value_str);
-    if try_route_pie_live_field_edit(world, _entity, type_path, field_path, new_json.clone()) {
+    if try_route_pie_live_field_edit(world, entity, type_path, field_path, new_json.clone()) {
         return;
     }
 
-    // Collect all selected entities
-    let selection = world.resource::<Selection>();
-    let targets: Vec<Entity> = selection.entities.clone();
-
-    let mut sub_commands: Vec<Box<dyn EditorCommand>> = Vec::new();
-
-    for &target in &targets {
-        let old_value = crate::commands::authored_bsn_field(world, target, type_path, field_path);
-        let Some(new_value) = crate::commands::json_field_edit_to_bsn_value(
-            world, target, type_path, field_path, &new_json,
-        ) else {
-            continue;
-        };
-
-        sub_commands.push(Box::new(SetBsnField {
-            entity: target,
-            type_path: type_path.to_string(),
-            field_path: field_path.to_string(),
-            old_value,
-            new_value,
-            was_derived: false,
-        }));
-    }
-
-    if sub_commands.is_empty() {
-        return;
-    }
-
-    let mut cmd: Box<dyn EditorCommand> = if sub_commands.len() == 1 {
-        sub_commands.pop().unwrap()
-    } else {
-        Box::new(CommandGroup {
-            label: "Set field on multiple entities".to_string(),
-            commands: sub_commands,
-        })
-    };
-    cmd.execute(world);
-    let mut history = world.resource_mut::<CommandHistory>();
-    history.push_executed(cmd);
+    crate::commands::field_edit_commit(
+        world,
+        type_path,
+        field_path,
+        &new_json,
+        "Set field on multiple entities",
+    );
 }
 
 /// Parse a text field string to the most appropriate JSON value. Integer-looking
@@ -2503,12 +2439,9 @@ pub(crate) fn on_text_edit_commit(
     });
 }
 
-/// Apply a drag-tick (non-final) numeric edit. Writes only the live ECS
-/// components for the current selection so the viewport tracks the drag,
-/// without touching the scene document or minting an undo entry. The
-/// pre-drag value survives in the document for the single `SetBsnField`
-/// pushed on `is_final`. In PIE Live mode it routes through the live-edit
-/// stream instead.
+/// Apply a drag-tick (non-final) numeric edit via [`crate::commands::field_edit_preview`].
+/// Live ECS only — no document write, no undo. In PIE Live mode it routes
+/// through the live-edit stream instead.
 fn apply_field_value_live(
     world: &mut World,
     source_entity: Entity,
@@ -2526,10 +2459,7 @@ fn apply_field_value_live(
     ) {
         return;
     }
-    let targets: Vec<Entity> = world.resource::<Selection>().entities.clone();
-    for target in targets {
-        crate::commands::apply_json_field_to_ecs(world, target, type_path, field_path, &new_json);
-    }
+    crate::commands::field_edit_preview(world, type_path, field_path, &new_json);
 }
 
 /// Write path for float drag-scrub fields. The widget emits
@@ -3247,45 +3177,14 @@ fn apply_enum_variant_with_undo(
         return;
     }
 
-    let selection = world.resource::<Selection>();
-    let targets: Vec<Entity> = selection.entities.clone();
-
-    let mut sub_commands: Vec<Box<dyn EditorCommand>> = Vec::new();
-
-    for &target in &targets {
-        let old_value = crate::commands::authored_bsn_field(world, target, type_path, field_path);
-        let Some(new_value) = crate::commands::json_field_edit_to_bsn_value(
-            world, target, type_path, field_path, &new_json,
-        ) else {
-            continue;
-        };
-
-        sub_commands.push(Box::new(SetBsnField {
-            entity: target,
-            type_path: type_path.to_string(),
-            field_path: field_path.to_string(),
-            old_value,
-            new_value,
-            was_derived: false,
-        }));
-    }
-
-    if sub_commands.is_empty() {
-        return;
-    }
-
-    let mut cmd: Box<dyn EditorCommand> = if sub_commands.len() == 1 {
-        sub_commands.pop().unwrap()
-    } else {
-        Box::new(CommandGroup {
-            label: "Set enum on multiple entities".to_string(),
-            commands: sub_commands,
-        })
-    };
-    cmd.execute(world);
-    let mut history = world.resource_mut::<CommandHistory>();
-    history.push_executed(cmd);
-    // No need to flag anything  -- `refresh_enum_variants` detects the ECS
+    crate::commands::field_edit_commit(
+        world,
+        type_path,
+        field_path,
+        &new_json,
+        "Set enum on multiple entities",
+    );
+    // No need to flag anything — `refresh_enum_variants` detects the ECS
     // variant change and rebuilds the affected subtree automatically. Same
     // goes for undo/redo since the command framework mutates the ECS too.
 }

--- a/src/live_edits.rs
+++ b/src/live_edits.rs
@@ -1319,7 +1319,7 @@ mod tests {
     }
 
     #[test]
-    fn undo_of_a_newly_authored_component_removes_it() {
+    fn undo_demotes_authored_live_component() {
         let (mut world, preview, _node_id) = build_world();
 
         save_unauthored_health(&mut world, preview);
@@ -1337,8 +1337,8 @@ mod tests {
             "undo removes the component entry instead of writing null"
         );
         assert!(
-            world.get::<Health>(preview).is_none(),
-            "undo removes the ECS component too"
+            world.get::<Health>(preview).is_some(),
+            "demote keeps the live component that predated the author"
         );
     }
 

--- a/src/remote/remote_inspector.rs
+++ b/src/remote/remote_inspector.rs
@@ -368,6 +368,7 @@ pub(crate) fn spawn_fallback_section(
                 entity: source_entity,
                 component: None,
                 is_overridden: false,
+                is_derived: false,
                 prefab_ctx: None,
                 revert_through_prefab: false,
                 icon_font: &icon_font.0,

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -863,13 +863,13 @@ fn rederive_handle_patches(
 }
 
 /// Emit a subset of the live BSN document (the given document nodes with
-/// their subtrees) as self-contained BSN text for the clipboard.
+/// their subtrees) as BSN text for the clipboard.
 ///
-/// Referenced runtime inline assets embed as `#Name` roots so a cross-scene
-/// paste carries them along; only catalog `@Name` assets are assumed to
-/// resolve at the destination. Stable node ids are stripped from the emitted
-/// text, so a paste mints fresh ones. Works on a deep clone of the document,
-/// so emission never mutates the live state.
+/// Same-scene inline `#Name` refs are preserved via the live
+/// [`jackdaw_bsn::BsnSceneAssets`] seed (same as full-scene save). Pathless
+/// handles unknown to the live scene still embed as `#Name` roots. Stable
+/// node ids are stripped so paste can mint fresh ones. Works on a deep clone
+/// of the document, so emission never mutates the live state.
 pub(crate) fn emit_bsn_entities_with_inline_assets(
     world: &mut World,
     parent_path: &Path,
@@ -890,14 +890,21 @@ pub(crate) fn emit_bsn_entities_with_inline_assets(
 
     let registry = world.resource::<AppTypeRegistry>().clone();
 
-    // Seed only catalog names: scene-inline assets referenced by the copied
-    // components must embed into the clipboard text to survive a paste into
-    // another scene.
+    // Seed catalog and live scene-inline names so same-scene copy keeps the
+    // existing `#Name` refs. Cross-scene paste of unknown inline assets is
+    // not supported yet; those handles would need embedding + merge.
     let mut seed: bevy::platform::collections::HashMap<UntypedAssetId, String> =
         bevy::platform::collections::HashMap::default();
     if let Some(catalog) = world.get_resource::<crate::asset_catalog::AssetCatalog>() {
         for (id, name) in &catalog.id_to_name {
             seed.entry(*id).or_insert_with(|| name.clone());
+        }
+    }
+    if let Some(scene_assets) = world.get_resource::<jackdaw_bsn::BsnSceneAssets>() {
+        for (ref_name, handle) in &scene_assets.0 {
+            if ref_name.starts_with('#') {
+                seed.insert(handle.id(), ref_name.clone());
+            }
         }
     }
 
@@ -917,8 +924,8 @@ pub(crate) fn emit_bsn_entities_with_inline_assets(
         collect_bsn_inline_assets(world, &reg, &entities, seed)
     };
 
-    // Strip stable node ids from the copied subtrees; a paste mints fresh
-    // ones, so the clipboard must not carry the source ids.
+    // Strip stable node ids from the copied subtrees; paste mints fresh ones
+    // before grafting, so the clipboard must not carry the source ids.
     for &node in &subtree_nodes {
         let found = ast.get_patches(node).and_then(|patches| {
             patches.0.iter().copied().find(|&pe| {


### PR DESCRIPTION
Fixes for a number of issues I ran in to while working with bsn scenes.

- fix empty scene having invalid , at start
- fix gizmo transform not syncing to ast
- make bsn not pull in derived components (copy paste, duplicate, aviancollider stuff)
- more concrete drag field editing (especially for undo redo)
- proper enum checking
- darken text for derived components, order authored components above derived ones
- tuple struct handling
- also increased base freecam speed (happy to revert this on pushback, it was just annoying me how slow it was in testing) 