### PR TITLE
Add sparse region storage and texture control data to jackdaw_terrain

### DIFF
--- a/crates/jackdaw_terrain/src/brush.rs
+++ b/crates/jackdaw_terrain/src/brush.rs
@@ -228,10 +228,7 @@ mod tests {
         assert_eq!(touched.len(), 4, "got {touched:?}");
     }
 
-    /// I2 pinning test: a non-finite strength (parsed from a hand-typed
-    /// "nan" or "inf" in the strength field) must not poison the
-    /// heightmap. Before the guard, `amount = strength * f * dt` wrote
-    /// NaN directly into every cell the falloff touched.
+    /// A non-finite strength must not poison the heightmap.
     #[test]
     fn a_non_finite_strength_does_not_poison_the_heightmap() {
         let mut hm = Heightmap::new(5, Vec2::splat(4.0), 10.0);

--- a/crates/jackdaw_terrain/src/control.rs
+++ b/crates/jackdaw_terrain/src/control.rs
@@ -1,0 +1,205 @@
+//! Packed per-cell control value: which textures a splat cell paints with.
+//!
+//! `Terrain3D`'s proven encoding, adopted so the format scales past 16
+//! textures without one weight map per texture. The bit layout is a
+//! PERSISTED CONTRACT -- it is written verbatim into sidecar v3 region
+//! data, so changing it breaks every terrain saved with the old layout.
+//!
+//! ```text
+//! bit     width   field
+//! 0       5       base texture id, 0..=31
+//! 5       5       overlay texture id, 0..=31
+//! 10      6       blend, 0..=63 (0 = pure base, 63 = pure overlay)
+//! 16      16      reserved (future: holes, autoshader flags), must be 0
+//! ```
+//!
+//! Call sites never shift or mask a raw `u32` themselves; they go through
+//! the typed accessors below, which read and write only their own field
+//! and leave every other bit -- including the reserved range -- untouched.
+
+const BASE_SHIFT: u32 = 0;
+const BASE_MASK: u32 = 0x1F;
+const OVERLAY_SHIFT: u32 = 5;
+const OVERLAY_MASK: u32 = 0x1F;
+const BLEND_SHIFT: u32 = 10;
+const BLEND_MASK: u32 = 0x3F;
+const RESERVED_SHIFT: u32 = 16;
+const RESERVED_MASK: u32 = 0xFFFF;
+
+/// Largest value the base/overlay texture id field can hold.
+pub const MAX_TEXTURE_ID: u8 = BASE_MASK as u8;
+/// Largest value the blend field can hold.
+pub const MAX_BLEND: u8 = BLEND_MASK as u8;
+
+/// A packed per-cell control value: base texture, overlay texture, blend.
+///
+/// The raw `u32` is the on-disk representation exactly; [`Control::from_raw`]
+/// and [`Control::to_raw`] are lossless and the only way in or out of the
+/// packed form. Every other constructor and accessor goes through the typed
+/// field methods so a call site can never touch the wrong bits.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Control(u32);
+
+impl Control {
+    /// Wrap a raw packed value. Does not validate the reserved bits; a
+    /// decoder that must refuse unknown reserved bits checks
+    /// [`Control::reserved`] itself before trusting the rest.
+    pub const fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// The raw packed value, exactly as it would be written to a sidecar.
+    pub const fn to_raw(self) -> u32 {
+        self.0
+    }
+
+    /// Base texture id, `0..=31`.
+    pub fn base_id(self) -> u8 {
+        ((self.0 >> BASE_SHIFT) & BASE_MASK) as u8
+    }
+
+    /// Set the base texture id, clamping to `0..=31` rather than wrapping.
+    /// Every other field, including reserved bits, is left unchanged.
+    #[must_use]
+    pub fn with_base_id(self, id: u8) -> Self {
+        let id = id.min(MAX_TEXTURE_ID) as u32;
+        Self((self.0 & !(BASE_MASK << BASE_SHIFT)) | (id << BASE_SHIFT))
+    }
+
+    /// Overlay texture id, `0..=31`.
+    pub fn overlay_id(self) -> u8 {
+        ((self.0 >> OVERLAY_SHIFT) & OVERLAY_MASK) as u8
+    }
+
+    /// Set the overlay texture id, clamping to `0..=31` rather than
+    /// wrapping. Every other field, including reserved bits, is left
+    /// unchanged.
+    #[must_use]
+    pub fn with_overlay_id(self, id: u8) -> Self {
+        let id = id.min(MAX_TEXTURE_ID) as u32;
+        Self((self.0 & !(OVERLAY_MASK << OVERLAY_SHIFT)) | (id << OVERLAY_SHIFT))
+    }
+
+    /// Blend between base and overlay, `0..=63` (0 = pure base, 63 = pure
+    /// overlay).
+    pub fn blend(self) -> u8 {
+        ((self.0 >> BLEND_SHIFT) & BLEND_MASK) as u8
+    }
+
+    /// Set the blend value, clamping to `0..=63` rather than wrapping.
+    /// Every other field, including reserved bits, is left unchanged.
+    #[must_use]
+    pub fn with_blend(self, blend: u8) -> Self {
+        let blend = blend.min(MAX_BLEND) as u32;
+        Self((self.0 & !(BLEND_MASK << BLEND_SHIFT)) | (blend << BLEND_SHIFT))
+    }
+
+    /// The reserved 16 bits, unshifted. Zero on every control value this
+    /// build writes; a decoder rejects a file where this is nonzero,
+    /// because it means something a future build understands and this one
+    /// does not.
+    pub fn reserved(self) -> u16 {
+        ((self.0 >> RESERVED_SHIFT) & RESERVED_MASK) as u16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_all_zero() {
+        assert_eq!(Control::default().to_raw(), 0);
+        assert_eq!(Control::default().base_id(), 0);
+        assert_eq!(Control::default().overlay_id(), 0);
+        assert_eq!(Control::default().blend(), 0);
+        assert_eq!(Control::default().reserved(), 0);
+    }
+
+    #[test]
+    fn from_raw_to_raw_round_trips() {
+        for raw in [0u32, 1, 0xFFFF_FFFF, 0xDEAD_BEEF, 0x1234_5678] {
+            assert_eq!(Control::from_raw(raw).to_raw(), raw);
+        }
+    }
+
+    #[test]
+    fn base_id_round_trips_at_field_boundaries() {
+        for id in [0u8, 1, 30, 31] {
+            let c = Control::default().with_base_id(id);
+            assert_eq!(c.base_id(), id);
+            assert_eq!(c.overlay_id(), 0);
+            assert_eq!(c.blend(), 0);
+            assert_eq!(c.reserved(), 0);
+        }
+    }
+
+    #[test]
+    fn overlay_id_round_trips_at_field_boundaries() {
+        for id in [0u8, 1, 30, 31] {
+            let c = Control::default().with_overlay_id(id);
+            assert_eq!(c.overlay_id(), id);
+            assert_eq!(c.base_id(), 0);
+            assert_eq!(c.blend(), 0);
+            assert_eq!(c.reserved(), 0);
+        }
+    }
+
+    #[test]
+    fn blend_round_trips_at_field_boundaries() {
+        for blend in [0u8, 1, 62, 63] {
+            let c = Control::default().with_blend(blend);
+            assert_eq!(c.blend(), blend);
+            assert_eq!(c.base_id(), 0);
+            assert_eq!(c.overlay_id(), 0);
+            assert_eq!(c.reserved(), 0);
+        }
+    }
+
+    #[test]
+    fn out_of_range_ids_and_blend_clamp_rather_than_wrap() {
+        assert_eq!(Control::default().with_base_id(32).base_id(), 31);
+        assert_eq!(Control::default().with_base_id(255).base_id(), 31);
+        assert_eq!(Control::default().with_overlay_id(200).overlay_id(), 31);
+        assert_eq!(Control::default().with_blend(64).blend(), 63);
+        assert_eq!(Control::default().with_blend(255).blend(), 63);
+    }
+
+    #[test]
+    fn fields_do_not_overlap_at_max_values() {
+        let c = Control::default()
+            .with_base_id(31)
+            .with_overlay_id(31)
+            .with_blend(63);
+        assert_eq!(c.base_id(), 31);
+        assert_eq!(c.overlay_id(), 31);
+        assert_eq!(c.blend(), 63);
+        assert_eq!(c.reserved(), 0);
+        // Every occupied bit sits in 0..16; nothing has leaked upward.
+        assert_eq!(c.to_raw(), 0x0000_FFFF);
+    }
+
+    #[test]
+    fn setters_preserve_reserved_bits_already_present() {
+        let with_reserved = Control::from_raw(0xBEEF_0000);
+        assert_eq!(with_reserved.reserved(), 0xBEEF);
+
+        let edited = with_reserved
+            .with_base_id(5)
+            .with_overlay_id(9)
+            .with_blend(20);
+        assert_eq!(edited.reserved(), 0xBEEF);
+        assert_eq!(edited.base_id(), 5);
+        assert_eq!(edited.overlay_id(), 9);
+        assert_eq!(edited.blend(), 20);
+    }
+
+    #[test]
+    fn setters_only_touch_their_own_field() {
+        let c = Control::default().with_base_id(3).with_overlay_id(7);
+        let blended = c.with_blend(11);
+        assert_eq!(blended.base_id(), 3);
+        assert_eq!(blended.overlay_id(), 7);
+        assert_eq!(blended.blend(), 11);
+    }
+}

--- a/crates/jackdaw_terrain/src/control.rs
+++ b/crates/jackdaw_terrain/src/control.rs
@@ -1,29 +1,24 @@
-//! Packed per-cell control value: which textures a splat cell paints with.
+//! Packed per-cell control value: base texture id, overlay texture id, and
+//! the blend between them. Scales past 16 textures without one weight map
+//! per texture.
 //!
-//! Same field decomposition as `Terrain3D`'s control map (base texture,
-//! overlay texture, blend), different bit assignment; scales past 16
-//! textures without one weight map per texture. The bit layout is a
-//! PERSISTED CONTRACT -- it is written verbatim into sidecar v3 region
-//! data, so changing it breaks every terrain saved with the old layout.
-//! Blend is 8 bits from day one (T1 review ruling, 2026-08-12): the
-//! reserved bits sit directly above it, so widening later would break
-//! them.
+//! The bit layout is a persisted contract: written verbatim into sidecar
+//! format version 2 region data. Changing it breaks every terrain saved
+//! with the old layout.
 //!
 //! ```text
 //! bit     width   field
 //! 0       5       base texture id, 0..=31
 //! 5       5       overlay texture id, 0..=31
 //! 10      8       blend, 0..=255 (0 = pure base, 255 = pure overlay)
-//! 18      14      reserved (future: holes, autoshader flags), must be 0
+//! 18      14      reserved, must be 0
 //! ```
 //!
-//! Call sites never shift or mask a raw `u32` themselves; they go through
-//! the typed accessors below, which read and write only their own field
-//! and leave every other bit -- including the reserved range -- untouched.
-//! `Control` is `#[repr(transparent)]` over its packed `u32` so a region's
-//! control layer can be stored and sliced as `[Control]` directly, with no
-//! bare-integer escape hatch for call sites to accidentally compare or
-//! shift around the type.
+//! Call sites use the typed accessors below rather than shifting or
+//! masking a raw `u32`; each accessor touches only its own field, leaving
+//! every other bit -- including reserved -- unchanged. `Control` is
+//! `#[repr(transparent)]`, so a region's control layer stores `[Control]`
+//! directly rather than `[u32]`.
 
 const BASE_SHIFT: u32 = 0;
 const BASE_MASK: u32 = 0x1F;
@@ -50,14 +45,13 @@ pub const MAX_BLEND: u8 = BLEND_MASK as u8;
 pub struct Control(u32);
 
 impl Control {
-    /// Wrap a raw packed value. Does not validate the reserved bits; a
-    /// decoder that must refuse unknown reserved bits checks
-    /// [`Control::reserved`] itself before trusting the rest.
+    /// Wrap a raw packed value. Does not validate reserved bits; callers
+    /// that must reject unknown reserved bits check [`Control::reserved`].
     pub const fn from_raw(raw: u32) -> Self {
         Self(raw)
     }
 
-    /// The raw packed value, exactly as it would be written to a sidecar.
+    /// The raw packed value, as written to a sidecar.
     pub const fn to_raw(self) -> u32 {
         self.0
     }
@@ -95,19 +89,16 @@ impl Control {
         ((self.0 >> BLEND_SHIFT) & BLEND_MASK) as u8
     }
 
-    /// Set the blend value. The field is a full `u8` (`0..=255`), so every
-    /// possible input is in range -- nothing to clamp. Every other field,
-    /// including reserved bits, is left unchanged.
+    /// Set the blend value (no clamping needed; the field is a full `u8`).
+    /// Every other field, including reserved bits, is left unchanged.
     #[must_use]
     pub fn with_blend(self, blend: u8) -> Self {
         let blend = blend as u32;
         Self((self.0 & !(BLEND_MASK << BLEND_SHIFT)) | (blend << BLEND_SHIFT))
     }
 
-    /// The reserved 14 bits, unshifted. Zero on every control value this
-    /// build writes; a decoder rejects a file where this is nonzero,
-    /// because it means something a future build understands and this one
-    /// does not.
+    /// The reserved 14 bits, unshifted. Must be 0; decode rejects a
+    /// nonzero value.
     pub fn reserved(self) -> u16 {
         ((self.0 >> RESERVED_SHIFT) & RESERVED_MASK) as u16
     }
@@ -171,8 +162,7 @@ mod tests {
         assert_eq!(Control::default().with_base_id(32).base_id(), 31);
         assert_eq!(Control::default().with_base_id(255).base_id(), 31);
         assert_eq!(Control::default().with_overlay_id(200).overlay_id(), 31);
-        // blend already fills a full u8, so there is no out-of-range input
-        // for it to clamp; 255 is both MAX_BLEND and u8::MAX.
+        // blend fills a full u8; nothing to clamp.
         assert_eq!(MAX_BLEND, u8::MAX);
     }
 

--- a/crates/jackdaw_terrain/src/control.rs
+++ b/crates/jackdaw_terrain/src/control.rs
@@ -1,30 +1,38 @@
 //! Packed per-cell control value: which textures a splat cell paints with.
 //!
-//! `Terrain3D`'s proven encoding, adopted so the format scales past 16
+//! Same field decomposition as `Terrain3D`'s control map (base texture,
+//! overlay texture, blend), different bit assignment; scales past 16
 //! textures without one weight map per texture. The bit layout is a
 //! PERSISTED CONTRACT -- it is written verbatim into sidecar v3 region
 //! data, so changing it breaks every terrain saved with the old layout.
+//! Blend is 8 bits from day one (T1 review ruling, 2026-08-12): the
+//! reserved bits sit directly above it, so widening later would break
+//! them.
 //!
 //! ```text
 //! bit     width   field
 //! 0       5       base texture id, 0..=31
 //! 5       5       overlay texture id, 0..=31
-//! 10      6       blend, 0..=63 (0 = pure base, 63 = pure overlay)
-//! 16      16      reserved (future: holes, autoshader flags), must be 0
+//! 10      8       blend, 0..=255 (0 = pure base, 255 = pure overlay)
+//! 18      14      reserved (future: holes, autoshader flags), must be 0
 //! ```
 //!
 //! Call sites never shift or mask a raw `u32` themselves; they go through
 //! the typed accessors below, which read and write only their own field
 //! and leave every other bit -- including the reserved range -- untouched.
+//! `Control` is `#[repr(transparent)]` over its packed `u32` so a region's
+//! control layer can be stored and sliced as `[Control]` directly, with no
+//! bare-integer escape hatch for call sites to accidentally compare or
+//! shift around the type.
 
 const BASE_SHIFT: u32 = 0;
 const BASE_MASK: u32 = 0x1F;
 const OVERLAY_SHIFT: u32 = 5;
 const OVERLAY_MASK: u32 = 0x1F;
 const BLEND_SHIFT: u32 = 10;
-const BLEND_MASK: u32 = 0x3F;
-const RESERVED_SHIFT: u32 = 16;
-const RESERVED_MASK: u32 = 0xFFFF;
+const BLEND_MASK: u32 = 0xFF;
+const RESERVED_SHIFT: u32 = 18;
+const RESERVED_MASK: u32 = 0x3FFF;
 
 /// Largest value the base/overlay texture id field can hold.
 pub const MAX_TEXTURE_ID: u8 = BASE_MASK as u8;
@@ -37,6 +45,7 @@ pub const MAX_BLEND: u8 = BLEND_MASK as u8;
 /// and [`Control::to_raw`] are lossless and the only way in or out of the
 /// packed form. Every other constructor and accessor goes through the typed
 /// field methods so a call site can never touch the wrong bits.
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Control(u32);
 
@@ -80,21 +89,22 @@ impl Control {
         Self((self.0 & !(OVERLAY_MASK << OVERLAY_SHIFT)) | (id << OVERLAY_SHIFT))
     }
 
-    /// Blend between base and overlay, `0..=63` (0 = pure base, 63 = pure
+    /// Blend between base and overlay, `0..=255` (0 = pure base, 255 = pure
     /// overlay).
     pub fn blend(self) -> u8 {
         ((self.0 >> BLEND_SHIFT) & BLEND_MASK) as u8
     }
 
-    /// Set the blend value, clamping to `0..=63` rather than wrapping.
-    /// Every other field, including reserved bits, is left unchanged.
+    /// Set the blend value. The field is a full `u8` (`0..=255`), so every
+    /// possible input is in range -- nothing to clamp. Every other field,
+    /// including reserved bits, is left unchanged.
     #[must_use]
     pub fn with_blend(self, blend: u8) -> Self {
-        let blend = blend.min(MAX_BLEND) as u32;
+        let blend = blend as u32;
         Self((self.0 & !(BLEND_MASK << BLEND_SHIFT)) | (blend << BLEND_SHIFT))
     }
 
-    /// The reserved 16 bits, unshifted. Zero on every control value this
+    /// The reserved 14 bits, unshifted. Zero on every control value this
     /// build writes; a decoder rejects a file where this is nonzero,
     /// because it means something a future build understands and this one
     /// does not.
@@ -147,7 +157,7 @@ mod tests {
 
     #[test]
     fn blend_round_trips_at_field_boundaries() {
-        for blend in [0u8, 1, 62, 63] {
+        for blend in [0u8, 1, 254, 255] {
             let c = Control::default().with_blend(blend);
             assert_eq!(c.blend(), blend);
             assert_eq!(c.base_id(), 0);
@@ -161,8 +171,9 @@ mod tests {
         assert_eq!(Control::default().with_base_id(32).base_id(), 31);
         assert_eq!(Control::default().with_base_id(255).base_id(), 31);
         assert_eq!(Control::default().with_overlay_id(200).overlay_id(), 31);
-        assert_eq!(Control::default().with_blend(64).blend(), 63);
-        assert_eq!(Control::default().with_blend(255).blend(), 63);
+        // blend already fills a full u8, so there is no out-of-range input
+        // for it to clamp; 255 is both MAX_BLEND and u8::MAX.
+        assert_eq!(MAX_BLEND, u8::MAX);
     }
 
     #[test]
@@ -170,28 +181,28 @@ mod tests {
         let c = Control::default()
             .with_base_id(31)
             .with_overlay_id(31)
-            .with_blend(63);
+            .with_blend(255);
         assert_eq!(c.base_id(), 31);
         assert_eq!(c.overlay_id(), 31);
-        assert_eq!(c.blend(), 63);
+        assert_eq!(c.blend(), 255);
         assert_eq!(c.reserved(), 0);
-        // Every occupied bit sits in 0..16; nothing has leaked upward.
-        assert_eq!(c.to_raw(), 0x0000_FFFF);
+        // Every occupied bit sits in 0..18; nothing has leaked upward.
+        assert_eq!(c.to_raw(), 0x0003_FFFF);
     }
 
     #[test]
     fn setters_preserve_reserved_bits_already_present() {
-        let with_reserved = Control::from_raw(0xBEEF_0000);
-        assert_eq!(with_reserved.reserved(), 0xBEEF);
+        let with_reserved = Control::from_raw(0x2AAA << RESERVED_SHIFT);
+        assert_eq!(with_reserved.reserved(), 0x2AAA);
 
         let edited = with_reserved
             .with_base_id(5)
             .with_overlay_id(9)
-            .with_blend(20);
-        assert_eq!(edited.reserved(), 0xBEEF);
+            .with_blend(200);
+        assert_eq!(edited.reserved(), 0x2AAA);
         assert_eq!(edited.base_id(), 5);
         assert_eq!(edited.overlay_id(), 9);
-        assert_eq!(edited.blend(), 20);
+        assert_eq!(edited.blend(), 200);
     }
 
     #[test]
@@ -201,5 +212,14 @@ mod tests {
         assert_eq!(blended.base_id(), 3);
         assert_eq!(blended.overlay_id(), 7);
         assert_eq!(blended.blend(), 11);
+    }
+
+    #[test]
+    fn is_repr_transparent_over_u32() {
+        assert_eq!(core::mem::size_of::<Control>(), core::mem::size_of::<u32>());
+        assert_eq!(
+            core::mem::align_of::<Control>(),
+            core::mem::align_of::<u32>()
+        );
     }
 }

--- a/crates/jackdaw_terrain/src/erosion.rs
+++ b/crates/jackdaw_terrain/src/erosion.rs
@@ -29,15 +29,9 @@ pub struct ErosionParams {
     pub min_slope: f32,
 }
 
-/// Iterations above this are clamped down to it rather than run.
-///
-/// Each iteration costs up to `max_lifetime` steps, so an unbounded
-/// count -- typed into the UI, or passed by a script or a headless
-/// caller -- can hang the editor for an unbounded amount of time. This
-/// is well above the default (70,000) and any legitimate heavy use, and
-/// is enforced here regardless of which widget or caller set
-/// `iterations`, not just whatever limit an inspector field happens to
-/// impose.
+/// Iterations above this are clamped rather than run: each iteration costs
+/// up to `max_lifetime` steps, so an unbounded count can hang for an
+/// unbounded time.
 pub const MAX_ITERATIONS: u32 = 1_000_000;
 
 /// Clamp a requested iteration count to [`MAX_ITERATIONS`].
@@ -275,9 +269,7 @@ fn erode_at(
 mod tests {
     use super::*;
 
-    /// I11 pinning test: an iteration count typed into the UI (or set by
-    /// any other caller) is capped regardless of what requested it, since
-    /// each iteration costs real, unbounded wall-clock time.
+    /// An iteration count is capped regardless of what requested it.
     #[test]
     fn a_pathological_iteration_count_is_clamped() {
         assert_eq!(clamp_iterations(u32::MAX), MAX_ITERATIONS);

--- a/crates/jackdaw_terrain/src/lib.rs
+++ b/crates/jackdaw_terrain/src/lib.rs
@@ -1,19 +1,23 @@
 pub mod brush;
 pub mod channel;
+pub mod control;
 pub mod erosion;
 pub mod generate;
 pub mod heightmap;
 pub mod mesh;
 pub mod quantize;
+pub mod region;
 pub mod scatter;
 pub mod sidecar;
 
 pub use brush::{SculptTool, affected_chunks, affected_chunks_at, apply_brush};
 pub use channel::{ChannelData, ChannelElement, apply_channel_brush};
+pub use control::Control;
 pub use erosion::{ErosionParams, hydraulic_erosion};
 pub use generate::{GenerateSettings, NoiseType, generate_heightmap};
 pub use heightmap::Heightmap;
 pub use mesh::{ChunkMeshData, build_chunk_mesh_data, build_chunk_mesh_data_flat};
 pub use quantize::{quantize_height, quantize_heights, quantize_region};
+pub use region::{Region, RegionCoord, RegionSize, RegionSizeError, TerrainRegions};
 pub use scatter::{Placement, ScatterMask, ScatterParams, scatter};
 pub use sidecar::{SidecarError, TerrainData};

--- a/crates/jackdaw_terrain/src/lib.rs
+++ b/crates/jackdaw_terrain/src/lib.rs
@@ -20,4 +20,4 @@ pub use mesh::{ChunkMeshData, build_chunk_mesh_data, build_chunk_mesh_data_flat}
 pub use quantize::{quantize_height, quantize_heights, quantize_region};
 pub use region::{Region, RegionCoord, RegionSize, RegionSizeError, TerrainRegions};
 pub use scatter::{Placement, ScatterMask, ScatterParams, scatter};
-pub use sidecar::{SidecarError, TerrainData};
+pub use sidecar::{RegionTerrainData, SidecarError, TerrainData};

--- a/crates/jackdaw_terrain/src/region.rs
+++ b/crates/jackdaw_terrain/src/region.rs
@@ -2,18 +2,49 @@
 //!
 //! A terrain is a sparse grid of fixed-size square [`Region`]s, addressed by
 //! integer [`RegionCoord`]. A region springs into existence the first time
-//! an edit touches one of its cells and is dropped again once every cell in
-//! it goes back to the default value -- a terrain that has only ever been
-//! edited near the origin costs nothing for the rest of the world, however
-//! far it nominally extends. This mirrors `Terrain3D`'s region model.
+//! an edit writes a non-default value into one of its cells -- a terrain
+//! that has only ever been edited near the origin costs nothing for the
+//! rest of the world, however far it nominally extends. This mirrors
+//! `Terrain3D`'s region model.
+//!
+//! Existence, once granted, is an AUTHORED fact, not a derived one (T1
+//! review ruling, 2026-08-12): a region sculpted flat back to every default
+//! value is still a region a person chose to allocate, and it stays
+//! allocated, round-trips through a sidecar, and re-encodes exactly as it
+//! was. The only way a region goes away is [`TerrainRegions::remove_region`]
+//! -- an explicit, deliberate removal, not a side effect of ordinary
+//! editing. This also means no setter ever scans a whole region to decide
+//! whether to keep it: allocating is an O(1) "does this one write differ
+//! from default" check, not an O(side^2) region-wide scan.
 //!
 //! Heights and the control map (see [`crate::control`]) always exist per
-//! region; the color layer is optional and only allocated the first time a
-//! cell in that region is painted, per the design's "allocated on first
-//! paint" rule.
+//! region; the color layer is optional and, once allocated the first time a
+//! cell in that region is painted, stays allocated for the same
+//! authored-presence reason -- it does not collapse back to absent just
+//! because every pixel happens to read as [`DEFAULT_COLOR`] again.
 //!
 //! Cell coordinates are signed: a region's world position can be negative
 //! in either axis, since edits are not constrained to start at the origin.
+//!
+//! # Seam rule (T4 builds on this; documented here since this is where
+//! region addressing lives)
+//!
+//! Cells are single-owner: a cell belongs to exactly one region, and
+//! storage never duplicates an edge row into its neighbor. A mesher
+//! building seamless geometry across a region boundary reads the
+//! neighboring region directly (via [`TerrainRegions::region`]) for the
+//! extra vertex row/column it needs; if that neighbor is not allocated, the
+//! mesher clamps to the current region's own edge rather than treating the
+//! absent neighbor as an error or fabricating a duplicate row for it.
+//!
+//! # A note on `f32` equality
+//!
+//! [`Region`], [`TerrainRegions`] and [`crate::sidecar::RegionTerrainData`]
+//! all derive `PartialEq` down to raw `f32` heights. IEEE 754 `NaN` is not
+//! equal to itself, so a height array containing `NaN` makes its own struct
+//! not equal to a bit-for-bit copy of itself under `==`/`assert_eq!`; a test
+//! that needs to compare data that may contain `NaN` must compare
+//! `to_bits()` of the individual floats instead.
 
 use std::collections::HashMap;
 
@@ -41,13 +72,22 @@ impl RegionCoord {
     }
 }
 
-/// Why a region size could not be used for a newly created terrain.
+impl core::fmt::Display for RegionCoord {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "({}, {})", self.x, self.z)
+    }
+}
+
+/// Why a region size could not be used.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RegionSizeError {
     /// A region cannot have zero cells per side.
     Zero,
-    /// New terrains require a power-of-two region size, so the mesher and
-    /// LOD clipmap (later tasks) can assume clean subdivision.
+    /// Region size must be a power of two, so the mesher and LOD clipmap
+    /// (later tasks) can assume clean subdivision. This is a real,
+    /// always-enforced invariant, not just a rule for newly created
+    /// terrains: a sidecar that declares a non-power-of-two region size is
+    /// rejected the same as one that declares zero.
     NotPowerOfTwo,
 }
 
@@ -63,17 +103,24 @@ impl core::fmt::Display for RegionSizeError {
 impl core::error::Error for RegionSizeError {}
 
 /// Cells per edge of every region in a terrain. Immutable once a terrain
-/// exists: changing it would require re-bucketing every region.
+/// exists: changing it would require re-bucketing every region. Every
+/// `RegionSize` in existence, however it was built, is guaranteed a
+/// nonzero power of two -- there is no unchecked or "trusted caller"
+/// constructor. A v1 sidecar's resolution is not assumed to satisfy this,
+/// so migrating one is fallible; see
+/// [`crate::sidecar::RegionTerrainData::from_legacy_v1`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RegionSize(u32);
 
 impl RegionSize {
     /// Region side length new terrains use unless the author picks another
     /// power of two at creation time.
-    pub const DEFAULT: u32 = 256;
+    pub const DEFAULT: RegionSize = RegionSize(256);
 
-    /// Validated constructor for a terrain created going forward: `side`
-    /// must be a nonzero power of two.
+    /// Validated constructor: `side` must be a nonzero power of two. Used
+    /// for terrains created going forward and for every sidecar v3 decode
+    /// -- a declared region size is only ever trusted once it has passed
+    /// through here.
     pub fn new(side: u32) -> Result<Self, RegionSizeError> {
         if side == 0 {
             return Err(RegionSizeError::Zero);
@@ -82,20 +129,6 @@ impl RegionSize {
             return Err(RegionSizeError::NotPowerOfTwo);
         }
         Ok(Self(side))
-    }
-
-    /// Unchecked constructor for sizes that predate the power-of-two rule.
-    ///
-    /// A v1 sidecar's whole resolution becomes one implicit region of that
-    /// exact size on migration (see [`crate::sidecar`]), and that
-    /// resolution was never required to be a power of two. Sidecar v3
-    /// decode also uses this once it has confirmed the declared size is
-    /// backed by enough file bytes to be plausible.
-    ///
-    /// The caller must ensure `side > 0`; this is not re-checked.
-    pub(crate) fn new_unchecked(side: u32) -> Self {
-        debug_assert!(side > 0, "region size must be nonzero");
-        Self(side)
     }
 
     pub fn get(self) -> u32 {
@@ -110,7 +143,7 @@ impl RegionSize {
 pub struct Region {
     side: u32,
     heights: Vec<f32>,
-    control: Vec<u32>,
+    control: Vec<Control>,
     color: Option<Vec<[u8; 4]>>,
 }
 
@@ -120,7 +153,7 @@ impl Region {
         Self {
             side,
             heights: vec![0.0; n],
-            control: vec![0; n],
+            control: vec![Control::default(); n],
             color: None,
         }
     }
@@ -131,7 +164,7 @@ impl Region {
     pub(crate) fn from_parts(
         side: u32,
         heights: Vec<f32>,
-        control: Vec<u32>,
+        control: Vec<Control>,
         color: Option<Vec<[u8; 4]>>,
     ) -> Self {
         let n = (side as usize) * (side as usize);
@@ -157,8 +190,8 @@ impl Region {
         &self.heights
     }
 
-    /// Row-major packed control words, length `side * side`.
-    pub fn control_words(&self) -> &[u32] {
+    /// Row-major control words, length `side * side`.
+    pub fn control_words(&self) -> &[Control] {
         &self.control
     }
 
@@ -181,12 +214,12 @@ impl Region {
     }
 
     fn control(&self, lx: u32, lz: u32) -> Control {
-        Control::from_raw(self.control[self.idx(lx, lz)])
+        self.control[self.idx(lx, lz)]
     }
 
     fn set_control(&mut self, lx: u32, lz: u32, value: Control) {
         let i = self.idx(lx, lz);
-        self.control[i] = value.to_raw();
+        self.control[i] = value;
     }
 
     fn color_at(&self, lx: u32, lz: u32) -> [u8; 4] {
@@ -203,21 +236,16 @@ impl Region {
         let layer = self.color.get_or_insert_with(|| vec![DEFAULT_COLOR; n]);
         layer[i] = value;
     }
+}
 
-    /// Drop the color layer back to `None` if painting has undone every
-    /// cell back to [`DEFAULT_COLOR`], so an undo-to-nothing stroke does
-    /// not leave a permanently allocated (if uniform) color buffer behind.
-    fn prune_color_if_default(&mut self) {
-        if matches!(&self.color, Some(layer) if layer.iter().all(|c| *c == DEFAULT_COLOR)) {
-            self.color = None;
-        }
-    }
-
-    fn is_default(&self) -> bool {
-        self.color.is_none()
-            && self.heights.iter().all(|h| *h == 0.0)
-            && self.control.iter().all(|c| *c == 0)
-    }
+/// Collapse `-0.0` to `+0.0` so a height that reads as "the default value"
+/// always has the one canonical bit pattern, in memory and on disk. Without
+/// this, sculpting a cell to exactly `-0.0` would compare equal to a
+/// never-touched default cell (`-0.0 == 0.0` is `true`) while carrying a
+/// different bit pattern, which is exactly the kind of surprise a "bit-level
+/// round trip" sidecar format should not have.
+fn canonicalize_zero(value: f32) -> f32 {
+    if value == 0.0 { 0.0 } else { value }
 }
 
 /// A terrain's sparse height/control/color storage.
@@ -252,15 +280,25 @@ impl TerrainRegions {
         self.regions.get(&coord)
     }
 
-    /// Insert an already-built region, dropping it instead if it turns out
-    /// to be all-default. Used by sidecar decode and the v1 migration
-    /// bridge; edits during normal use go through [`Self::set_height`] and
-    /// friends instead.
+    /// Insert an already-built region as an authored, present region.
+    /// Unlike the per-cell setters this never checks the region's content:
+    /// a region a sidecar's region table lists, or that migration builds
+    /// from a legacy heightmap, is present because it says so, default
+    /// content and all. Used by sidecar decode and the v1 migration
+    /// bridge; both are responsible for rejecting a duplicate coordinate
+    /// themselves before calling this, since a second call for the same
+    /// coordinate silently overwrites the first.
     pub(crate) fn insert_region(&mut self, coord: RegionCoord, region: Region) {
         debug_assert_eq!(region.side(), self.region_size.get());
-        if !region.is_default() {
-            self.regions.insert(coord, region);
-        }
+        self.regions.insert(coord, region);
+    }
+
+    /// Explicitly deallocate a region regardless of its content. This is
+    /// the only way a region goes away once it exists -- ordinary editing,
+    /// even sculpting every cell back to default, never does this on its
+    /// own. Returns the removed region, if there was one.
+    pub fn remove_region(&mut self, coord: RegionCoord) -> Option<Region> {
+        self.regions.remove(&coord)
     }
 
     /// Allocated regions in a deterministic, coordinate-sorted order.
@@ -290,16 +328,22 @@ impl TerrainRegions {
     }
 
     /// Write a height, allocating the owning region if this is its first
-    /// non-default write, and dropping it again if the write brought every
-    /// cell in it back to default.
+    /// non-default write. Once allocated, a region never deallocates
+    /// itself as a side effect of a write -- see the module docs.
     pub fn set_height(&mut self, x: i32, z: i32, value: f32) {
+        let value = canonicalize_zero(value);
         let (coord, lx, lz) = self.locate(x, z);
-        let side = self.region_size;
-        self.regions
-            .entry(coord)
-            .or_insert_with(|| Region::empty(side.get()))
-            .set_height(lx, lz, value);
-        self.prune(coord);
+        match self.regions.get_mut(&coord) {
+            Some(region) => region.set_height(lx, lz, value),
+            None if value != 0.0 => {
+                let side = self.region_size.get();
+                self.regions
+                    .entry(coord)
+                    .or_insert_with(|| Region::empty(side))
+                    .set_height(lx, lz, value);
+            }
+            None => {}
+        }
     }
 
     pub fn control_at(&self, x: i32, z: i32) -> Control {
@@ -311,12 +355,17 @@ impl TerrainRegions {
 
     pub fn set_control(&mut self, x: i32, z: i32, value: Control) {
         let (coord, lx, lz) = self.locate(x, z);
-        let side = self.region_size;
-        self.regions
-            .entry(coord)
-            .or_insert_with(|| Region::empty(side.get()))
-            .set_control(lx, lz, value);
-        self.prune(coord);
+        match self.regions.get_mut(&coord) {
+            Some(region) => region.set_control(lx, lz, value),
+            None if value != Control::default() => {
+                let side = self.region_size.get();
+                self.regions
+                    .entry(coord)
+                    .or_insert_with(|| Region::empty(side))
+                    .set_control(lx, lz, value);
+            }
+            None => {}
+        }
     }
 
     pub fn color_at(&self, x: i32, z: i32) -> [u8; 4] {
@@ -329,20 +378,16 @@ impl TerrainRegions {
     /// Paint a color, allocating the region's color layer on first use.
     pub fn set_color(&mut self, x: i32, z: i32, value: [u8; 4]) {
         let (coord, lx, lz) = self.locate(x, z);
-        let side = self.region_size;
-        self.regions
-            .entry(coord)
-            .or_insert_with(|| Region::empty(side.get()))
-            .set_color(lx, lz, value);
-        self.prune(coord);
-    }
-
-    fn prune(&mut self, coord: RegionCoord) {
-        if let Some(region) = self.regions.get_mut(&coord) {
-            region.prune_color_if_default();
-            if region.is_default() {
-                self.regions.remove(&coord);
+        match self.regions.get_mut(&coord) {
+            Some(region) => region.set_color(lx, lz, value),
+            None if value != DEFAULT_COLOR => {
+                let side = self.region_size.get();
+                self.regions
+                    .entry(coord)
+                    .or_insert_with(|| Region::empty(side))
+                    .set_color(lx, lz, value);
             }
+            None => {}
         }
     }
 }
@@ -358,6 +403,7 @@ mod tests {
         assert_eq!(RegionSize::new(255), Err(RegionSizeError::NotPowerOfTwo));
         assert!(RegionSize::new(256).is_ok());
         assert!(RegionSize::new(1).is_ok());
+        assert_eq!(RegionSize::DEFAULT.get(), 256);
     }
 
     #[test]
@@ -386,33 +432,66 @@ mod tests {
         assert_eq!(t.region_count(), 0);
         t.set_control(1, 1, Control::default());
         assert_eq!(t.region_count(), 0);
+        t.set_color(1, 1, DEFAULT_COLOR);
+        assert_eq!(t.region_count(), 0);
     }
 
     #[test]
-    fn returning_every_cell_to_default_deallocates_the_region() {
+    fn writing_negative_zero_to_an_unallocated_cell_allocates_nothing() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(1, 1, -0.0);
+        assert_eq!(t.region_count(), 0);
+        assert_eq!(t.height_at(1, 1).to_bits(), 0.0f32.to_bits());
+    }
+
+    #[test]
+    fn negative_zero_is_canonicalized_to_positive_zero_bit_pattern() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        // Force an allocation first, then sculpt the same cell to -0.0.
+        t.set_height(1, 1, 5.0);
+        t.set_height(1, 1, -0.0);
+        assert_eq!(t.height_at(1, 1).to_bits(), 0.0f32.to_bits());
+    }
+
+    #[test]
+    fn a_nan_height_still_allocates_and_reads_back_as_nan() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(0, 0, f32::NAN);
+        assert_eq!(t.region_count(), 1);
+        assert!(t.height_at(0, 0).is_nan());
+    }
+
+    #[test]
+    fn sculpting_every_cell_back_to_default_does_not_deallocate_the_region() {
         let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
         t.set_height(0, 0, 3.0);
         t.set_height(1, 2, 4.0);
         assert_eq!(t.region_count(), 1);
         t.set_height(0, 0, 0.0);
-        assert_eq!(t.region_count(), 1, "region 1,2 is still non-default");
         t.set_height(1, 2, 0.0);
-        assert_eq!(t.region_count(), 0);
+        assert_eq!(
+            t.region_count(),
+            1,
+            "an authored region persists even when every cell reads as default"
+        );
+        assert_eq!(t.height_at(0, 0), 0.0);
+        assert_eq!(t.height_at(1, 2), 0.0);
     }
 
     #[test]
-    fn control_writes_allocate_and_deallocate_independently_of_height() {
+    fn control_writes_allocate_but_never_self_deallocate() {
         let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
         let painted = Control::default().with_base_id(2);
         t.set_control(0, 0, painted);
         assert_eq!(t.region_count(), 1);
         assert_eq!(t.control_at(0, 0), painted);
         t.set_control(0, 0, Control::default());
-        assert_eq!(t.region_count(), 0);
+        assert_eq!(t.region_count(), 1);
+        assert_eq!(t.control_at(0, 0), Control::default());
     }
 
     #[test]
-    fn color_layer_allocates_on_first_paint_and_frees_when_reverted() {
+    fn color_layer_allocates_on_first_paint_and_stays_allocated() {
         let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
         assert_eq!(t.color_at(2, 2), DEFAULT_COLOR);
         t.set_color(2, 2, [10, 20, 30, 255]);
@@ -424,21 +503,22 @@ mod tests {
 
         t.set_color(2, 2, DEFAULT_COLOR);
         assert!(
-            t.region(RegionCoord::ORIGIN).is_none(),
-            "region should fully deallocate once color, control and height are all default"
+            t.region(RegionCoord::ORIGIN).unwrap().color().is_some(),
+            "the color layer stays allocated even once every pixel is default again"
         );
+        assert_eq!(t.region_count(), 1);
     }
 
     #[test]
-    fn painting_color_does_not_by_itself_keep_an_otherwise_default_region_forever_once_undone() {
-        let mut t = TerrainRegions::new(RegionSize::new(2).unwrap());
-        t.set_color(0, 0, [1, 2, 3, 4]);
-        t.set_color(1, 1, [5, 6, 7, 8]);
-        assert_eq!(t.region_count(), 1);
-        t.set_color(0, 0, DEFAULT_COLOR);
-        assert_eq!(t.region_count(), 1, "cell (1,1) is still painted");
-        t.set_color(1, 1, DEFAULT_COLOR);
+    fn explicit_remove_is_the_only_way_a_region_disappears() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(0, 0, 1.0);
+        t.set_height(0, 0, 0.0);
+        assert_eq!(t.region_count(), 1, "still present after sculpting to 0");
+        let removed = t.remove_region(RegionCoord::ORIGIN);
+        assert!(removed.is_some());
         assert_eq!(t.region_count(), 0);
+        assert!(t.remove_region(RegionCoord::ORIGIN).is_none());
     }
 
     #[test]
@@ -516,17 +596,27 @@ mod tests {
     }
 
     #[test]
-    fn insert_region_drops_an_all_default_region_instead_of_storing_it() {
+    fn insert_region_keeps_an_all_default_region() {
         let mut t = TerrainRegions::new(RegionSize::new(2).unwrap());
-        let region = Region::from_parts(2, vec![0.0; 4], vec![0; 4], None);
+        let region = Region::from_parts(2, vec![0.0; 4], vec![Control::default(); 4], None);
         t.insert_region(RegionCoord::ORIGIN, region);
-        assert_eq!(t.region_count(), 0);
+        assert_eq!(
+            t.region_count(),
+            1,
+            "an explicitly authored all-default region is still present"
+        );
+        assert_eq!(t.height_at(0, 0), 0.0);
     }
 
     #[test]
     fn insert_region_keeps_a_non_default_region() {
         let mut t = TerrainRegions::new(RegionSize::new(2).unwrap());
-        let region = Region::from_parts(2, vec![1.0, 0.0, 0.0, 0.0], vec![0; 4], None);
+        let region = Region::from_parts(
+            2,
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![Control::default(); 4],
+            None,
+        );
         t.insert_region(RegionCoord::ORIGIN, region);
         assert_eq!(t.region_count(), 1);
         assert_eq!(t.height_at(0, 0), 1.0);

--- a/crates/jackdaw_terrain/src/region.rs
+++ b/crates/jackdaw_terrain/src/region.rs
@@ -1,58 +1,32 @@
 //! Sparse region storage for a terrain's heights, control map, and color.
 //!
 //! A terrain is a sparse grid of fixed-size square [`Region`]s, addressed by
-//! integer [`RegionCoord`]. A region springs into existence the first time
-//! an edit writes a non-default value into one of its cells -- a terrain
-//! that has only ever been edited near the origin costs nothing for the
-//! rest of the world, however far it nominally extends. This mirrors
-//! `Terrain3D`'s region model.
+//! integer [`RegionCoord`]. A region allocates the first time an edit
+//! writes a non-default value into one of its cells.
 //!
-//! Existence, once granted, is an AUTHORED fact, not a derived one (T1
-//! review ruling, 2026-08-12): a region sculpted flat back to every default
-//! value is still a region a person chose to allocate, and it stays
-//! allocated, round-trips through a sidecar, and re-encodes exactly as it
-//! was. The only way a region goes away is [`TerrainRegions::remove_region`]
-//! -- an explicit, deliberate removal, not a side effect of ordinary
-//! editing. This also means no setter ever scans a whole region to decide
-//! whether to keep it: allocating is an O(1) "does this one write differ
-//! from default" check, not an O(side^2) region-wide scan.
+//! Region presence is explicit, not derived from content: a region
+//! sculpted back to every default value stays allocated and round-trips
+//! through a sidecar unchanged. [`TerrainRegions::remove_region`] is the
+//! only way a region is removed. Allocating on write is an O(1) check
+//! against the value being written, not a scan of the region.
 //!
 //! Heights and the control map (see [`crate::control`]) always exist per
-//! region; the color layer is optional and, once allocated the first time a
-//! cell in that region is painted, stays allocated for the same
-//! authored-presence reason -- it does not collapse back to absent just
-//! because every pixel happens to read as [`DEFAULT_COLOR`] again.
+//! region. The color layer is optional, allocated on first paint, and then
+//! stays allocated: it does not collapse back to absent just because every
+//! pixel reads as [`DEFAULT_COLOR`] again.
 //!
-//! Cell coordinates are signed: a region's world position can be negative
-//! in either axis, since edits are not constrained to start at the origin.
+//! Cell coordinates are signed; a region's position can be negative in
+//! either axis.
 //!
-//! # Seam rule (T4 builds on this; documented here since this is where
-//! region addressing lives)
-//!
-//! Cells are single-owner: a cell belongs to exactly one region, and
-//! storage never duplicates an edge row into its neighbor. A mesher
-//! building seamless geometry across a region boundary reads the
-//! neighboring region directly (via [`TerrainRegions::region`]) for the
-//! extra vertex row/column it needs; if that neighbor is not allocated, the
-//! mesher clamps to the current region's own edge rather than treating the
-//! absent neighbor as an error or fabricating a duplicate row for it.
-//!
-//! # A note on `f32` equality
-//!
-//! [`Region`], [`TerrainRegions`] and [`crate::sidecar::RegionTerrainData`]
-//! all derive `PartialEq` down to raw `f32` heights. IEEE 754 `NaN` is not
-//! equal to itself, so a height array containing `NaN` makes its own struct
-//! not equal to a bit-for-bit copy of itself under `==`/`assert_eq!`; a test
-//! that needs to compare data that may contain `NaN` must compare
-//! `to_bits()` of the individual floats instead.
+//! Each cell has a single owning region; storage never duplicates an edge
+//! row into a neighbor. Edge vertices are read from the neighboring region
+//! (via [`TerrainRegions::region`]), and an absent neighbor clamps.
 
 use std::collections::HashMap;
 
 use crate::control::Control;
 
-/// A cell's tint when no color layer has been painted there. Opaque white:
-/// "no tint," matching the convention that an unpainted region looks
-/// exactly like the splat material alone would render it.
+/// Tint for a cell with no color layer: opaque white (no tint).
 pub const DEFAULT_COLOR: [u8; 4] = [255, 255, 255, 255];
 
 /// Integer coordinate of a region on the terrain's region grid. Not a cell
@@ -83,11 +57,8 @@ impl core::fmt::Display for RegionCoord {
 pub enum RegionSizeError {
     /// A region cannot have zero cells per side.
     Zero,
-    /// Region size must be a power of two, so the mesher and LOD clipmap
-    /// (later tasks) can assume clean subdivision. This is a real,
-    /// always-enforced invariant, not just a rule for newly created
-    /// terrains: a sidecar that declares a non-power-of-two region size is
-    /// rejected the same as one that declares zero.
+    /// Region size must be a power of two, so the mesher can assume clean
+    /// subdivision. Enforced on every `RegionSize`, not just new terrains.
     NotPowerOfTwo,
 }
 
@@ -103,12 +74,8 @@ impl core::fmt::Display for RegionSizeError {
 impl core::error::Error for RegionSizeError {}
 
 /// Cells per edge of every region in a terrain. Immutable once a terrain
-/// exists: changing it would require re-bucketing every region. Every
-/// `RegionSize` in existence, however it was built, is guaranteed a
-/// nonzero power of two -- there is no unchecked or "trusted caller"
-/// constructor. A v1 sidecar's resolution is not assumed to satisfy this,
-/// so migrating one is fallible; see
-/// [`crate::sidecar::RegionTerrainData::from_legacy_v1`].
+/// exists. Always a nonzero power of two; there is no unchecked
+/// constructor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RegionSize(u32);
 
@@ -117,10 +84,7 @@ impl RegionSize {
     /// power of two at creation time.
     pub const DEFAULT: RegionSize = RegionSize(256);
 
-    /// Validated constructor: `side` must be a nonzero power of two. Used
-    /// for terrains created going forward and for every sidecar v3 decode
-    /// -- a declared region size is only ever trusted once it has passed
-    /// through here.
+    /// `side` must be a nonzero power of two.
     pub fn new(side: u32) -> Result<Self, RegionSizeError> {
         if side == 0 {
             return Err(RegionSizeError::Zero);
@@ -158,9 +122,7 @@ impl Region {
         }
     }
 
-    /// Build a region directly from already-sized layers. Used by sidecar
-    /// decode and the v1 migration bridge, both of which validate lengths
-    /// against `side` themselves before calling this.
+    /// Build a region from already-sized layers. Lengths must match `side`.
     pub(crate) fn from_parts(
         side: u32,
         heights: Vec<f32>,
@@ -238,21 +200,16 @@ impl Region {
     }
 }
 
-/// Collapse `-0.0` to `+0.0` so a height that reads as "the default value"
-/// always has the one canonical bit pattern, in memory and on disk. Without
-/// this, sculpting a cell to exactly `-0.0` would compare equal to a
-/// never-touched default cell (`-0.0 == 0.0` is `true`) while carrying a
-/// different bit pattern, which is exactly the kind of surprise a "bit-level
-/// round trip" sidecar format should not have.
+/// Collapse `-0.0` to `+0.0`, so a default-valued cell has one canonical
+/// bit pattern whether it was touched or not.
 fn canonicalize_zero(value: f32) -> f32 {
     if value == 0.0 { 0.0 } else { value }
 }
 
 /// A terrain's sparse height/control/color storage.
 ///
-/// Existing paint channels (scatter masks) are not part of this: they stay
-/// dense, whole-terrain, and unrelated to regions, per the design's split
-/// between gameplay masks and visual splat data.
+/// Paint channels (scatter masks) are not part of this; they stay dense
+/// and whole-terrain.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TerrainRegions {
     region_size: RegionSize,
@@ -280,31 +237,22 @@ impl TerrainRegions {
         self.regions.get(&coord)
     }
 
-    /// Insert an already-built region as an authored, present region.
-    /// Unlike the per-cell setters this never checks the region's content:
-    /// a region a sidecar's region table lists, or that migration builds
-    /// from a legacy heightmap, is present because it says so, default
-    /// content and all. Used by sidecar decode and the v1 migration
-    /// bridge; both are responsible for rejecting a duplicate coordinate
-    /// themselves before calling this, since a second call for the same
-    /// coordinate silently overwrites the first.
+    /// Insert an already-built region as present, regardless of content.
+    /// Callers must reject a duplicate coordinate themselves; a second call
+    /// for the same coordinate overwrites the first.
     pub(crate) fn insert_region(&mut self, coord: RegionCoord, region: Region) {
         debug_assert_eq!(region.side(), self.region_size.get());
         self.regions.insert(coord, region);
     }
 
-    /// Explicitly deallocate a region regardless of its content. This is
-    /// the only way a region goes away once it exists -- ordinary editing,
-    /// even sculpting every cell back to default, never does this on its
-    /// own. Returns the removed region, if there was one.
+    /// Remove a region regardless of content. The only way a region is
+    /// deallocated. Returns the removed region, if any.
     pub fn remove_region(&mut self, coord: RegionCoord) -> Option<Region> {
         self.regions.remove(&coord)
     }
 
-    /// Allocated regions in a deterministic, coordinate-sorted order.
-    /// Serializing code depends on this: `HashMap` iteration order is not
-    /// stable, and encoding must be a pure function of the data regardless
-    /// of the order edits happened to allocate regions in.
+    /// Allocated regions in coordinate-sorted order, independent of
+    /// `HashMap` iteration order.
     pub fn iter_sorted(&self) -> impl Iterator<Item = (RegionCoord, &Region)> {
         let mut entries: Vec<_> = self.regions.iter().map(|(c, r)| (*c, r)).collect();
         entries.sort_by_key(|(coord, _)| *coord);
@@ -327,9 +275,8 @@ impl TerrainRegions {
             .map_or(0.0, |region| region.height(lx, lz))
     }
 
-    /// Write a height, allocating the owning region if this is its first
-    /// non-default write. Once allocated, a region never deallocates
-    /// itself as a side effect of a write -- see the module docs.
+    /// Write a height, allocating the region on first non-default write.
+    /// A region never deallocates itself as a side effect of a write.
     pub fn set_height(&mut self, x: i32, z: i32, value: f32) {
         let value = canonicalize_zero(value);
         let (coord, lx, lz) = self.locate(x, z);

--- a/crates/jackdaw_terrain/src/region.rs
+++ b/crates/jackdaw_terrain/src/region.rs
@@ -1,0 +1,534 @@
+//! Sparse region storage for a terrain's heights, control map, and color.
+//!
+//! A terrain is a sparse grid of fixed-size square [`Region`]s, addressed by
+//! integer [`RegionCoord`]. A region springs into existence the first time
+//! an edit touches one of its cells and is dropped again once every cell in
+//! it goes back to the default value -- a terrain that has only ever been
+//! edited near the origin costs nothing for the rest of the world, however
+//! far it nominally extends. This mirrors `Terrain3D`'s region model.
+//!
+//! Heights and the control map (see [`crate::control`]) always exist per
+//! region; the color layer is optional and only allocated the first time a
+//! cell in that region is painted, per the design's "allocated on first
+//! paint" rule.
+//!
+//! Cell coordinates are signed: a region's world position can be negative
+//! in either axis, since edits are not constrained to start at the origin.
+
+use std::collections::HashMap;
+
+use crate::control::Control;
+
+/// A cell's tint when no color layer has been painted there. Opaque white:
+/// "no tint," matching the convention that an unpainted region looks
+/// exactly like the splat material alone would render it.
+pub const DEFAULT_COLOR: [u8; 4] = [255, 255, 255, 255];
+
+/// Integer coordinate of a region on the terrain's region grid. Not a cell
+/// coordinate -- multiply by the terrain's region size to get the world
+/// cell of the region's minimum corner.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RegionCoord {
+    pub x: i32,
+    pub z: i32,
+}
+
+impl RegionCoord {
+    pub const ORIGIN: RegionCoord = RegionCoord { x: 0, z: 0 };
+
+    pub const fn new(x: i32, z: i32) -> Self {
+        Self { x, z }
+    }
+}
+
+/// Why a region size could not be used for a newly created terrain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RegionSizeError {
+    /// A region cannot have zero cells per side.
+    Zero,
+    /// New terrains require a power-of-two region size, so the mesher and
+    /// LOD clipmap (later tasks) can assume clean subdivision.
+    NotPowerOfTwo,
+}
+
+impl core::fmt::Display for RegionSizeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Zero => write!(f, "region size must be at least 1 cell per side"),
+            Self::NotPowerOfTwo => write!(f, "region size must be a power of two"),
+        }
+    }
+}
+
+impl core::error::Error for RegionSizeError {}
+
+/// Cells per edge of every region in a terrain. Immutable once a terrain
+/// exists: changing it would require re-bucketing every region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct RegionSize(u32);
+
+impl RegionSize {
+    /// Region side length new terrains use unless the author picks another
+    /// power of two at creation time.
+    pub const DEFAULT: u32 = 256;
+
+    /// Validated constructor for a terrain created going forward: `side`
+    /// must be a nonzero power of two.
+    pub fn new(side: u32) -> Result<Self, RegionSizeError> {
+        if side == 0 {
+            return Err(RegionSizeError::Zero);
+        }
+        if !side.is_power_of_two() {
+            return Err(RegionSizeError::NotPowerOfTwo);
+        }
+        Ok(Self(side))
+    }
+
+    /// Unchecked constructor for sizes that predate the power-of-two rule.
+    ///
+    /// A v1 sidecar's whole resolution becomes one implicit region of that
+    /// exact size on migration (see [`crate::sidecar`]), and that
+    /// resolution was never required to be a power of two. Sidecar v3
+    /// decode also uses this once it has confirmed the declared size is
+    /// backed by enough file bytes to be plausible.
+    ///
+    /// The caller must ensure `side > 0`; this is not re-checked.
+    pub(crate) fn new_unchecked(side: u32) -> Self {
+        debug_assert!(side > 0, "region size must be nonzero");
+        Self(side)
+    }
+
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// One region's heights, control map, and optional color layer, each
+/// `side * side` cells, row-major (z-major, matching this crate's other
+/// grid data).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Region {
+    side: u32,
+    heights: Vec<f32>,
+    control: Vec<u32>,
+    color: Option<Vec<[u8; 4]>>,
+}
+
+impl Region {
+    fn empty(side: u32) -> Self {
+        let n = (side as usize) * (side as usize);
+        Self {
+            side,
+            heights: vec![0.0; n],
+            control: vec![0; n],
+            color: None,
+        }
+    }
+
+    /// Build a region directly from already-sized layers. Used by sidecar
+    /// decode and the v1 migration bridge, both of which validate lengths
+    /// against `side` themselves before calling this.
+    pub(crate) fn from_parts(
+        side: u32,
+        heights: Vec<f32>,
+        control: Vec<u32>,
+        color: Option<Vec<[u8; 4]>>,
+    ) -> Self {
+        let n = (side as usize) * (side as usize);
+        debug_assert_eq!(heights.len(), n);
+        debug_assert_eq!(control.len(), n);
+        if let Some(c) = &color {
+            debug_assert_eq!(c.len(), n);
+        }
+        Self {
+            side,
+            heights,
+            control,
+            color,
+        }
+    }
+
+    pub fn side(&self) -> u32 {
+        self.side
+    }
+
+    /// Row-major heights, length `side * side`.
+    pub fn heights(&self) -> &[f32] {
+        &self.heights
+    }
+
+    /// Row-major packed control words, length `side * side`.
+    pub fn control_words(&self) -> &[u32] {
+        &self.control
+    }
+
+    /// Row-major color, if this region has ever been painted.
+    pub fn color(&self) -> Option<&[[u8; 4]]> {
+        self.color.as_deref()
+    }
+
+    fn idx(&self, lx: u32, lz: u32) -> usize {
+        (lz as usize) * (self.side as usize) + lx as usize
+    }
+
+    fn height(&self, lx: u32, lz: u32) -> f32 {
+        self.heights[self.idx(lx, lz)]
+    }
+
+    fn set_height(&mut self, lx: u32, lz: u32, value: f32) {
+        let i = self.idx(lx, lz);
+        self.heights[i] = value;
+    }
+
+    fn control(&self, lx: u32, lz: u32) -> Control {
+        Control::from_raw(self.control[self.idx(lx, lz)])
+    }
+
+    fn set_control(&mut self, lx: u32, lz: u32, value: Control) {
+        let i = self.idx(lx, lz);
+        self.control[i] = value.to_raw();
+    }
+
+    fn color_at(&self, lx: u32, lz: u32) -> [u8; 4] {
+        let i = self.idx(lx, lz);
+        match &self.color {
+            Some(layer) => layer[i],
+            None => DEFAULT_COLOR,
+        }
+    }
+
+    fn set_color(&mut self, lx: u32, lz: u32, value: [u8; 4]) {
+        let n = self.heights.len();
+        let i = self.idx(lx, lz);
+        let layer = self.color.get_or_insert_with(|| vec![DEFAULT_COLOR; n]);
+        layer[i] = value;
+    }
+
+    /// Drop the color layer back to `None` if painting has undone every
+    /// cell back to [`DEFAULT_COLOR`], so an undo-to-nothing stroke does
+    /// not leave a permanently allocated (if uniform) color buffer behind.
+    fn prune_color_if_default(&mut self) {
+        if matches!(&self.color, Some(layer) if layer.iter().all(|c| *c == DEFAULT_COLOR)) {
+            self.color = None;
+        }
+    }
+
+    fn is_default(&self) -> bool {
+        self.color.is_none()
+            && self.heights.iter().all(|h| *h == 0.0)
+            && self.control.iter().all(|c| *c == 0)
+    }
+}
+
+/// A terrain's sparse height/control/color storage.
+///
+/// Existing paint channels (scatter masks) are not part of this: they stay
+/// dense, whole-terrain, and unrelated to regions, per the design's split
+/// between gameplay masks and visual splat data.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TerrainRegions {
+    region_size: RegionSize,
+    regions: HashMap<RegionCoord, Region>,
+}
+
+impl TerrainRegions {
+    pub fn new(region_size: RegionSize) -> Self {
+        Self {
+            region_size,
+            regions: HashMap::new(),
+        }
+    }
+
+    pub fn region_size(&self) -> RegionSize {
+        self.region_size
+    }
+
+    /// Number of currently allocated regions.
+    pub fn region_count(&self) -> usize {
+        self.regions.len()
+    }
+
+    pub fn region(&self, coord: RegionCoord) -> Option<&Region> {
+        self.regions.get(&coord)
+    }
+
+    /// Insert an already-built region, dropping it instead if it turns out
+    /// to be all-default. Used by sidecar decode and the v1 migration
+    /// bridge; edits during normal use go through [`Self::set_height`] and
+    /// friends instead.
+    pub(crate) fn insert_region(&mut self, coord: RegionCoord, region: Region) {
+        debug_assert_eq!(region.side(), self.region_size.get());
+        if !region.is_default() {
+            self.regions.insert(coord, region);
+        }
+    }
+
+    /// Allocated regions in a deterministic, coordinate-sorted order.
+    /// Serializing code depends on this: `HashMap` iteration order is not
+    /// stable, and encoding must be a pure function of the data regardless
+    /// of the order edits happened to allocate regions in.
+    pub fn iter_sorted(&self) -> impl Iterator<Item = (RegionCoord, &Region)> {
+        let mut entries: Vec<_> = self.regions.iter().map(|(c, r)| (*c, r)).collect();
+        entries.sort_by_key(|(coord, _)| *coord);
+        entries.into_iter()
+    }
+
+    fn locate(&self, x: i32, z: i32) -> (RegionCoord, u32, u32) {
+        let side = self.region_size.get() as i32;
+        let rx = x.div_euclid(side);
+        let rz = z.div_euclid(side);
+        let lx = x.rem_euclid(side) as u32;
+        let lz = z.rem_euclid(side) as u32;
+        (RegionCoord::new(rx, rz), lx, lz)
+    }
+
+    pub fn height_at(&self, x: i32, z: i32) -> f32 {
+        let (coord, lx, lz) = self.locate(x, z);
+        self.regions
+            .get(&coord)
+            .map_or(0.0, |region| region.height(lx, lz))
+    }
+
+    /// Write a height, allocating the owning region if this is its first
+    /// non-default write, and dropping it again if the write brought every
+    /// cell in it back to default.
+    pub fn set_height(&mut self, x: i32, z: i32, value: f32) {
+        let (coord, lx, lz) = self.locate(x, z);
+        let side = self.region_size;
+        self.regions
+            .entry(coord)
+            .or_insert_with(|| Region::empty(side.get()))
+            .set_height(lx, lz, value);
+        self.prune(coord);
+    }
+
+    pub fn control_at(&self, x: i32, z: i32) -> Control {
+        let (coord, lx, lz) = self.locate(x, z);
+        self.regions
+            .get(&coord)
+            .map_or(Control::default(), |region| region.control(lx, lz))
+    }
+
+    pub fn set_control(&mut self, x: i32, z: i32, value: Control) {
+        let (coord, lx, lz) = self.locate(x, z);
+        let side = self.region_size;
+        self.regions
+            .entry(coord)
+            .or_insert_with(|| Region::empty(side.get()))
+            .set_control(lx, lz, value);
+        self.prune(coord);
+    }
+
+    pub fn color_at(&self, x: i32, z: i32) -> [u8; 4] {
+        let (coord, lx, lz) = self.locate(x, z);
+        self.regions
+            .get(&coord)
+            .map_or(DEFAULT_COLOR, |region| region.color_at(lx, lz))
+    }
+
+    /// Paint a color, allocating the region's color layer on first use.
+    pub fn set_color(&mut self, x: i32, z: i32, value: [u8; 4]) {
+        let (coord, lx, lz) = self.locate(x, z);
+        let side = self.region_size;
+        self.regions
+            .entry(coord)
+            .or_insert_with(|| Region::empty(side.get()))
+            .set_color(lx, lz, value);
+        self.prune(coord);
+    }
+
+    fn prune(&mut self, coord: RegionCoord) {
+        if let Some(region) = self.regions.get_mut(&coord) {
+            region.prune_color_if_default();
+            if region.is_default() {
+                self.regions.remove(&coord);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn region_size_rejects_zero_and_non_power_of_two() {
+        assert_eq!(RegionSize::new(0), Err(RegionSizeError::Zero));
+        assert_eq!(RegionSize::new(3), Err(RegionSizeError::NotPowerOfTwo));
+        assert_eq!(RegionSize::new(255), Err(RegionSizeError::NotPowerOfTwo));
+        assert!(RegionSize::new(256).is_ok());
+        assert!(RegionSize::new(1).is_ok());
+    }
+
+    #[test]
+    fn a_fresh_terrain_has_no_regions() {
+        let t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        assert_eq!(t.region_count(), 0);
+        assert_eq!(t.height_at(0, 0), 0.0);
+        assert_eq!(t.control_at(0, 0), Control::default());
+        assert_eq!(t.color_at(0, 0), DEFAULT_COLOR);
+    }
+
+    #[test]
+    fn writing_a_height_allocates_its_region() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        assert_eq!(t.region_count(), 0);
+        t.set_height(1, 1, 5.0);
+        assert_eq!(t.region_count(), 1);
+        assert_eq!(t.height_at(1, 1), 5.0);
+        assert!(t.region(RegionCoord::ORIGIN).is_some());
+    }
+
+    #[test]
+    fn writing_default_value_to_an_unallocated_cell_allocates_nothing() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(1, 1, 0.0);
+        assert_eq!(t.region_count(), 0);
+        t.set_control(1, 1, Control::default());
+        assert_eq!(t.region_count(), 0);
+    }
+
+    #[test]
+    fn returning_every_cell_to_default_deallocates_the_region() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(0, 0, 3.0);
+        t.set_height(1, 2, 4.0);
+        assert_eq!(t.region_count(), 1);
+        t.set_height(0, 0, 0.0);
+        assert_eq!(t.region_count(), 1, "region 1,2 is still non-default");
+        t.set_height(1, 2, 0.0);
+        assert_eq!(t.region_count(), 0);
+    }
+
+    #[test]
+    fn control_writes_allocate_and_deallocate_independently_of_height() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        let painted = Control::default().with_base_id(2);
+        t.set_control(0, 0, painted);
+        assert_eq!(t.region_count(), 1);
+        assert_eq!(t.control_at(0, 0), painted);
+        t.set_control(0, 0, Control::default());
+        assert_eq!(t.region_count(), 0);
+    }
+
+    #[test]
+    fn color_layer_allocates_on_first_paint_and_frees_when_reverted() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        assert_eq!(t.color_at(2, 2), DEFAULT_COLOR);
+        t.set_color(2, 2, [10, 20, 30, 255]);
+        assert!(t.region(RegionCoord::ORIGIN).unwrap().color().is_some());
+        assert_eq!(t.color_at(2, 2), [10, 20, 30, 255]);
+        // Other cells in the same region are still the default tint even
+        // though the color layer now physically exists.
+        assert_eq!(t.color_at(0, 0), DEFAULT_COLOR);
+
+        t.set_color(2, 2, DEFAULT_COLOR);
+        assert!(
+            t.region(RegionCoord::ORIGIN).is_none(),
+            "region should fully deallocate once color, control and height are all default"
+        );
+    }
+
+    #[test]
+    fn painting_color_does_not_by_itself_keep_an_otherwise_default_region_forever_once_undone() {
+        let mut t = TerrainRegions::new(RegionSize::new(2).unwrap());
+        t.set_color(0, 0, [1, 2, 3, 4]);
+        t.set_color(1, 1, [5, 6, 7, 8]);
+        assert_eq!(t.region_count(), 1);
+        t.set_color(0, 0, DEFAULT_COLOR);
+        assert_eq!(t.region_count(), 1, "cell (1,1) is still painted");
+        t.set_color(1, 1, DEFAULT_COLOR);
+        assert_eq!(t.region_count(), 0);
+    }
+
+    #[test]
+    fn cells_at_a_region_edge_and_the_next_regions_corner_are_distinct() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(3, 3, 1.0); // last cell of region (0,0)
+        t.set_height(4, 4, 2.0); // first cell of region (1,1)
+        assert_eq!(t.region_count(), 2);
+        assert_eq!(t.height_at(3, 3), 1.0);
+        assert_eq!(t.height_at(4, 4), 2.0);
+        assert_eq!(t.height_at(4, 3), 0.0);
+        assert_eq!(t.height_at(3, 4), 0.0);
+        assert!(t.region(RegionCoord::new(0, 0)).is_some());
+        assert!(t.region(RegionCoord::new(1, 1)).is_some());
+    }
+
+    #[test]
+    fn negative_cell_coordinates_address_negative_regions_correctly() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        t.set_height(-1, -1, 9.0); // last cell of region (-1,-1)
+        assert_eq!(t.height_at(-1, -1), 9.0);
+        assert!(t.region(RegionCoord::new(-1, -1)).is_some());
+        // The region boundary sits exactly at 0: cell 0 is region (0,0),
+        // not (-1,-1).
+        assert_eq!(t.height_at(0, 0), 0.0);
+        assert!(t.region(RegionCoord::new(0, 0)).is_none());
+
+        t.set_height(-4, -4, 7.0); // first cell of region (-1,-1)
+        assert_eq!(t.height_at(-4, -4), 7.0);
+        assert_eq!(t.height_at(-1, -1), 9.0, "still holds its earlier write");
+
+        t.set_height(-5, -5, 3.0); // last cell of region (-2,-2)
+        assert!(t.region(RegionCoord::new(-2, -2)).is_some());
+        assert_eq!(t.height_at(-5, -5), 3.0);
+    }
+
+    #[test]
+    fn region_boundary_math_matches_across_a_zero_crossing() {
+        let mut t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        for x in -8..8 {
+            for z in -8..8 {
+                t.set_height(x, z, ((x + z) as f32) + 0.5);
+            }
+        }
+        for x in -8..8 {
+            for z in -8..8 {
+                assert_eq!(t.height_at(x, z), ((x + z) as f32) + 0.5, "at ({x},{z})");
+            }
+        }
+    }
+
+    #[test]
+    fn iter_sorted_is_stable_regardless_of_insertion_order() {
+        let mut a = TerrainRegions::new(RegionSize::new(2).unwrap());
+        a.set_height(0, 0, 1.0);
+        a.set_height(10, 10, 2.0);
+        a.set_height(-10, 3, 3.0);
+
+        let mut b = TerrainRegions::new(RegionSize::new(2).unwrap());
+        b.set_height(-10, 3, 3.0);
+        b.set_height(0, 0, 1.0);
+        b.set_height(10, 10, 2.0);
+
+        let coords_a: Vec<_> = a.iter_sorted().map(|(c, _)| c).collect();
+        let coords_b: Vec<_> = b.iter_sorted().map(|(c, _)| c).collect();
+        assert_eq!(coords_a, coords_b);
+        assert_eq!(
+            coords_a,
+            vec![
+                RegionCoord::new(-5, 1),
+                RegionCoord::new(0, 0),
+                RegionCoord::new(5, 5),
+            ]
+        );
+    }
+
+    #[test]
+    fn insert_region_drops_an_all_default_region_instead_of_storing_it() {
+        let mut t = TerrainRegions::new(RegionSize::new(2).unwrap());
+        let region = Region::from_parts(2, vec![0.0; 4], vec![0; 4], None);
+        t.insert_region(RegionCoord::ORIGIN, region);
+        assert_eq!(t.region_count(), 0);
+    }
+
+    #[test]
+    fn insert_region_keeps_a_non_default_region() {
+        let mut t = TerrainRegions::new(RegionSize::new(2).unwrap());
+        let region = Region::from_parts(2, vec![1.0, 0.0, 0.0, 0.0], vec![0; 4], None);
+        t.insert_region(RegionCoord::ORIGIN, region);
+        assert_eq!(t.region_count(), 1);
+        assert_eq!(t.height_at(0, 0), 1.0);
+    }
+}

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -17,7 +17,7 @@
 //! 10      2             flags, u16 (reserved, must be 0)
 //! 12      4             resolution, u32
 //! 16      4             channel count, u32
-//! 20      4*res*res     heights, f32
+//! 20      4*res*res     heights, f32 (IEEE 754, little-endian)
 //! then, per channel:
 //!         4             name length in bytes, u32
 //!         n             name, UTF-8
@@ -39,6 +39,13 @@
 //! well-formed bytes. Accepted as a tradeoff for the format staying
 //! trivial to read from any language; revisit if this ever needs to
 //! survive untrusted or unreliable transport.
+//!
+//! Decode also requires the file to end exactly where the declared
+//! structure ends: trailing bytes, or a header that under-claims a count
+//! (leaving real data unconsumed), are both rejected as [`SidecarError::Truncated`]
+//! rather than silently ignored. Failing open here -- accepting a
+//! shorter-than-claimed read as success -- would discard the unconsumed
+//! tail the moment anything re-saves the file.
 //!
 //! # v3: regions
 //!
@@ -62,16 +69,23 @@
 //! 16      4             channel_count, u32
 //! 20      ...           channels, same per-channel layout as v1
 //! then
-//!         4             region_size, u32 (cells per region edge, > 0)
+//!         4             region_size, u32 (cells per region edge; a
+//!                        nonzero power of two, checked on decode)
 //!         4             region_count, u32
 //!         4             texture_set path length in bytes, u32 (0 = none)
 //!         n             texture_set path, UTF-8, project-relative
-//! then, per region (region_count times):
+//! then, per region (region_count times), each an AUTHORED, present
+//! region regardless of its content (see crate::region):
 //!         4             region coord x, i32
 //!         4             region coord z, i32
-//!         1             region flags, u8 (bit 0 = has color layer)
+//!         1             region flags, u8:
+//!                          bit 0 = has color layer
+//!                          bit 1 = present (always 1; a file with this
+//!                                  clear declares a state this build does
+//!                                  not understand)
+//!                          bits 2-7 = reserved, must be 0
 //!         3             padding, must be 0
-//!         4*size^2      heights, f32
+//!         4*size^2      heights, f32 (IEEE 754, little-endian)
 //!         4*size^2      control, u32 (packed, see crate::control)
 //!         4*size^2      color RGBA8 -- only present if flag bit 0 is set
 //! ```
@@ -79,18 +93,24 @@
 //! [`load`] and [`save`] are the entry points call sites should use going
 //! forward: `load` transparently upgrades a v1 file into a single implicit
 //! region at the origin sized to its old resolution, with no control or
-//! color data, and `save` always writes v3. A newer-than-this-build version
-//! is refused by both, the same as v1 -- a file this build cannot
-//! understand is never silently dropped or overwritten. The bare
-//! `encode`/`decode` (v1) and `encode_regions`/`decode_regions` (v3) pairs
-//! stay available for testing and for code that specifically needs one
-//! format or the other.
+//! color data (rejecting a legacy resolution that is not a power of two,
+//! since this crate does not resample on migration), and `save` always
+//! writes v3. A newer-than-this-build version is refused by both, the same
+//! as v1 -- a file this build cannot understand is never silently dropped
+//! or overwritten. `save`/[`encode_regions`] also refuse to write a
+//! malformed texture-set reference, so a bad reference can never reach disk
+//! in the first place; a file that somehow has one anyway (hand-edited, or
+//! written by something other than this crate) is still caught on the way
+//! back in by [`decode_regions`]. The bare `encode`/`decode` (v1) and
+//! `encode_regions`/`decode_regions` (v3) pairs stay available for testing
+//! and for code that specifically needs one format or the other.
 
+use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 
 use crate::channel::{ChannelData, ChannelElement};
 use crate::control::Control;
-use crate::region::{Region, RegionCoord, RegionSize, TerrainRegions};
+use crate::region::{Region, RegionCoord, RegionSize, RegionSizeError, TerrainRegions};
 
 /// Magic bytes at the head of every sidecar.
 pub const MAGIC: [u8; 8] = *b"JDTERRN\0";
@@ -108,6 +128,15 @@ pub const VERSION_V3: u16 = 2;
 
 /// Conventional file extension for a terrain sidecar.
 pub const EXTENSION: &str = "jdterrain";
+
+/// Region flags bit: this region has a color layer, written right after
+/// its control words.
+const REGION_FLAG_HAS_COLOR: u8 = 0b0000_0001;
+/// Region flags bit: this region is present. Always set by this build;
+/// see the module-level v3 byte table.
+const REGION_FLAG_PRESENT: u8 = 0b0000_0010;
+/// Every region flags bit this build understands.
+const REGION_FLAGS_KNOWN: u8 = REGION_FLAG_HAS_COLOR | REGION_FLAG_PRESENT;
 
 /// Why a terrain sidecar path could not be resolved beneath a scene.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -227,7 +256,8 @@ pub enum SidecarError {
     /// A reserved field was non-zero, so the file means something this
     /// build does not understand.
     ReservedFieldSet,
-    /// The file ended before the declared data did.
+    /// The file ended before the declared data did, or had bytes left
+    /// over once every declared field was read.
     Truncated,
     /// A channel declared an element tag this build does not know.
     UnknownElement(u8),
@@ -235,10 +265,19 @@ pub enum SidecarError {
     BadName,
     /// The declared dimensions do not fit in this platform's address space.
     TooLarge,
-    /// A v3 region table declared a region size of zero.
-    InvalidRegionSize,
+    /// A v3 region table declared an unusable region size.
+    InvalidRegionSize(RegionSizeError),
     /// The texture-set reference string is unsafe or malformed.
     InvalidTextureSetRef(SidecarPathError),
+    /// A v3 region table declared the same region coordinate twice.
+    DuplicateRegion(RegionCoord),
+    /// A v1 resolution is not a power of two, so it cannot become a v3
+    /// region without resampling -- which this crate does not do.
+    UnmigratableResolution(u32),
+    /// A write-back (see [`RegionTerrainData::try_apply_legacy`]) was
+    /// attempted on a document with region data a legacy [`TerrainData`]
+    /// cannot represent.
+    NotLegacyCompatible,
 }
 
 impl core::fmt::Display for SidecarError {
@@ -253,13 +292,26 @@ impl core::fmt::Display for SidecarError {
             Self::UnknownElement(t) => write!(f, "unknown channel element tag {t}"),
             Self::BadName => write!(f, "channel name is not valid UTF-8"),
             Self::TooLarge => write!(f, "terrain sidecar declares more data than fits in memory"),
-            Self::InvalidRegionSize => write!(f, "terrain sidecar declares a region size of zero"),
+            Self::InvalidRegionSize(reason) => {
+                write!(f, "terrain sidecar region size is invalid: {reason}")
+            }
             Self::InvalidTextureSetRef(reason) => {
                 write!(
                     f,
                     "terrain sidecar texture-set reference is invalid: {reason}"
                 )
             }
+            Self::DuplicateRegion(coord) => {
+                write!(f, "terrain sidecar declares region {coord} twice")
+            }
+            Self::UnmigratableResolution(res) => write!(
+                f,
+                "terrain resolution {res} is not a power of two and cannot become a v3 region without resampling"
+            ),
+            Self::NotLegacyCompatible => write!(
+                f,
+                "terrain document has region data a legacy TerrainData cannot represent"
+            ),
         }
     }
 }
@@ -301,43 +353,6 @@ impl TerrainData {
     }
 }
 
-/// Serialize a terrain's bulk data.
-///
-/// Arrays shorter than `resolution^2` are zero-padded and longer ones are
-/// truncated, so the output always matches its own header. Returns `None`
-/// only when the declared size overflows `usize`.
-pub fn encode(data: &TerrainData) -> Option<Vec<u8>> {
-    let cells = data.cell_count()?;
-    let mut out = Vec::with_capacity(data.encoded_len()?);
-
-    out.extend_from_slice(&MAGIC);
-    out.extend_from_slice(&VERSION.to_le_bytes());
-    out.extend_from_slice(&0u16.to_le_bytes());
-    out.extend_from_slice(&data.resolution.to_le_bytes());
-    out.extend_from_slice(&(data.channels.len() as u32).to_le_bytes());
-
-    for i in 0..cells {
-        let h = data.heights.get(i).copied().unwrap_or(0.0);
-        out.extend_from_slice(&h.to_le_bytes());
-    }
-
-    for channel in &data.channels {
-        out.extend_from_slice(&(channel.name.len() as u32).to_le_bytes());
-        out.extend_from_slice(channel.name.as_bytes());
-        out.push(channel.element.tag());
-        out.extend_from_slice(&[0u8; 3]);
-        for i in 0..cells {
-            let v = channel.values.get(i).copied().unwrap_or(0);
-            match channel.element {
-                ChannelElement::U8 => out.push(v.min(u16::from(u8::MAX)) as u8),
-                ChannelElement::U16 => out.extend_from_slice(&v.to_le_bytes()),
-            }
-        }
-    }
-
-    Some(out)
-}
-
 /// Cursor over a sidecar's bytes that refuses to read past the end.
 struct Reader<'a> {
     bytes: &'a [u8],
@@ -373,76 +388,6 @@ impl<'a> Reader<'a> {
         let b = self.take(4)?;
         Ok(i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
     }
-}
-
-/// Deserialize a terrain's bulk data.
-pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
-    let mut r = Reader { bytes, at: 0 };
-
-    if r.take(MAGIC.len())? != MAGIC {
-        return Err(SidecarError::BadMagic);
-    }
-    let version = r.u16()?;
-    // 0 has never been a version any build wrote (VERSION starts at 1);
-    // accepting it would let a file whose version bytes were zeroed out
-    // by corruption parse as if it were a real, if ancient, format.
-    if version == 0 || version > VERSION {
-        return Err(SidecarError::UnsupportedVersion(version));
-    }
-    if r.u16()? != 0 {
-        return Err(SidecarError::ReservedFieldSet);
-    }
-
-    let resolution = r.u32()?;
-    let channel_count = r.u32()?;
-    let cells = (resolution as usize)
-        .checked_mul(resolution as usize)
-        .ok_or(SidecarError::TooLarge)?;
-
-    // A truncated file must not make us allocate its claimed size, so the
-    // remaining length is checked before every reservation.
-    let heights_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
-    let mut heights = Vec::with_capacity(cells);
-    for chunk in heights_bytes.chunks_exact(4) {
-        heights.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
-    }
-
-    let mut channels = Vec::new();
-    for _ in 0..channel_count {
-        let name_len = r.u32()? as usize;
-        let name = core::str::from_utf8(r.take(name_len)?)
-            .map_err(|_| SidecarError::BadName)?
-            .to_string();
-        let tag = r.u8()?;
-        let element = ChannelElement::from_tag(tag).ok_or(SidecarError::UnknownElement(tag))?;
-        if r.take(3)? != [0u8; 3] {
-            return Err(SidecarError::ReservedFieldSet);
-        }
-
-        let value_bytes = r.take(
-            cells
-                .checked_mul(element.byte_width())
-                .ok_or(SidecarError::TooLarge)?,
-        )?;
-        let values = match element {
-            ChannelElement::U8 => value_bytes.iter().map(|b| u16::from(*b)).collect(),
-            ChannelElement::U16 => value_bytes
-                .chunks_exact(2)
-                .map(|c| u16::from_le_bytes([c[0], c[1]]))
-                .collect(),
-        };
-        channels.push(ChannelData {
-            name,
-            element,
-            values,
-        });
-    }
-
-    Ok(TerrainData {
-        resolution,
-        heights,
-        channels,
-    })
 }
 
 fn encode_channels(out: &mut Vec<u8>, channels: &[ChannelData], cells: usize) {
@@ -499,9 +444,84 @@ fn decode_channels(
     Ok(channels)
 }
 
+/// Serialize a terrain's bulk data.
+///
+/// Arrays shorter than `resolution^2` are zero-padded and longer ones are
+/// truncated, so the output always matches its own header. Returns `None`
+/// only when the declared size overflows `usize`.
+pub fn encode(data: &TerrainData) -> Option<Vec<u8>> {
+    let cells = data.cell_count()?;
+    let mut out = Vec::with_capacity(data.encoded_len()?);
+
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&VERSION.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&data.resolution.to_le_bytes());
+    out.extend_from_slice(&(data.channels.len() as u32).to_le_bytes());
+
+    for i in 0..cells {
+        let h = data.heights.get(i).copied().unwrap_or(0.0);
+        out.extend_from_slice(&h.to_le_bytes());
+    }
+
+    encode_channels(&mut out, &data.channels, cells);
+
+    Some(out)
+}
+
+/// Deserialize a terrain's bulk data. Requires the file to end exactly
+/// where the header's declared shape says it should -- see the module docs.
+pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
+    let mut r = Reader { bytes, at: 0 };
+
+    if r.take(MAGIC.len())? != MAGIC {
+        return Err(SidecarError::BadMagic);
+    }
+    let version = r.u16()?;
+    // 0 has never been a version any build wrote (VERSION starts at 1);
+    // accepting it would let a file whose version bytes were zeroed out
+    // by corruption parse as if it were a real, if ancient, format.
+    if version == 0 || version > VERSION {
+        return Err(SidecarError::UnsupportedVersion(version));
+    }
+    if r.u16()? != 0 {
+        return Err(SidecarError::ReservedFieldSet);
+    }
+
+    let resolution = r.u32()?;
+    let channel_count = r.u32()?;
+    let cells = (resolution as usize)
+        .checked_mul(resolution as usize)
+        .ok_or(SidecarError::TooLarge)?;
+
+    // A truncated file must not make us allocate its claimed size, so the
+    // remaining length is checked before every reservation.
+    let heights_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
+    let mut heights = Vec::with_capacity(cells);
+    for chunk in heights_bytes.chunks_exact(4) {
+        heights.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+
+    let channels = decode_channels(&mut r, channel_count, cells)?;
+
+    if r.at != bytes.len() {
+        return Err(SidecarError::Truncated);
+    }
+
+    Ok(TerrainData {
+        resolution,
+        heights,
+        channels,
+    })
+}
+
 /// A v3 terrain document: channels (unchanged from v1) plus sparse
 /// region-based heights/control/color, plus the texture set the splat
 /// material paints with.
+///
+/// Derives `PartialEq` down to raw `f32` heights; see the "a note on `f32`
+/// equality" section in [`crate::region`] before comparing a document that
+/// might contain `NaN`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RegionTerrainData {
     /// Sizes `channels` exactly as `resolution` sized them in v1. Unrelated
@@ -520,28 +540,50 @@ impl RegionTerrainData {
     /// Migrate a v1 [`TerrainData`] into a v3 document: one implicit region
     /// at [`RegionCoord::ORIGIN`], sized to the legacy resolution exactly
     /// -- no resampling. The migrated region carries no control or color
-    /// data (both stay at their all-default values). Channels are moved
-    /// across unchanged.
-    pub fn from_legacy_v1(data: &TerrainData) -> Self {
+    /// paint (both stay at their all-default values), and is present even
+    /// if every height in it happens to be flat/default: a v1 file
+    /// authored its whole extent, zero included, and that is a real region
+    /// now, not nothing (see [`crate::region`]'s authored-presence rule).
+    /// Channels are moved across unchanged.
+    ///
+    /// A region size must be a nonzero power of two ([`RegionSize::new`]),
+    /// and this crate does not resample on migration, so a legacy
+    /// resolution that is not a power of two is rejected with
+    /// [`SidecarError::UnmigratableResolution`] rather than silently
+    /// rounded or truncated. A resolution of exactly 0 (an empty legacy
+    /// terrain) is the one exception: there are no cells to place in a
+    /// region either way, so it migrates to zero regions under
+    /// [`RegionSize::DEFAULT`].
+    pub fn from_legacy_v1(data: &TerrainData) -> Result<Self, SidecarError> {
         let mut normalized = data.clone();
         normalized.normalize();
         let resolution = normalized.resolution;
 
-        let mut regions = TerrainRegions::new(RegionSize::new_unchecked(resolution.max(1)));
-        if resolution > 0 {
+        let regions = if resolution == 0 {
+            TerrainRegions::new(RegionSize::DEFAULT)
+        } else {
+            let size = RegionSize::new(resolution)
+                .map_err(|_| SidecarError::UnmigratableResolution(resolution))?;
             let cells = (resolution as usize) * (resolution as usize);
+            let mut regions = TerrainRegions::new(size);
             regions.insert_region(
                 RegionCoord::ORIGIN,
-                Region::from_parts(resolution, normalized.heights, vec![0u32; cells], None),
+                Region::from_parts(
+                    resolution,
+                    normalized.heights,
+                    vec![Control::default(); cells],
+                    None,
+                ),
             );
-        }
+            regions
+        };
 
-        Self {
+        Ok(Self {
             channel_resolution: resolution,
             channels: normalized.channels,
             regions,
             texture_set: None,
-        }
+        })
     }
 
     /// A [`TerrainData`] view of this document, for call sites that have
@@ -555,7 +597,9 @@ impl RegionTerrainData {
     /// to the region API for real.
     pub fn as_legacy(&self) -> Option<TerrainData> {
         let heights = match self.regions.region_count() {
-            0 => vec![0.0; (self.channel_resolution as usize) * (self.channel_resolution as usize)],
+            0 => {
+                vec![0.0; (self.channel_resolution as usize) * (self.channel_resolution as usize)]
+            }
             1 => {
                 let (coord, region) = self.regions.iter_sorted().next()?;
                 if coord != RegionCoord::ORIGIN {
@@ -567,7 +611,11 @@ impl RegionTerrainData {
                 if region.color().is_some() {
                     return None;
                 }
-                if region.control_words().iter().any(|c| *c != 0) {
+                if region
+                    .control_words()
+                    .iter()
+                    .any(|c| *c != Control::default())
+                {
                     return None;
                 }
                 region.heights().to_vec()
@@ -581,14 +629,87 @@ impl RegionTerrainData {
             channels: self.channels.clone(),
         })
     }
+
+    /// Write a [`TerrainData`]'s heights and channels back into this
+    /// document's single origin region -- the inverse of [`Self::as_legacy`].
+    ///
+    /// This is the write-back path for call sites that still edit through
+    /// the legacy dense API (every existing sculpt/paint operator, until a
+    /// later task moves them onto regions directly): load, `as_legacy` to
+    /// get a `TerrainData`, run the existing edit, `try_apply_legacy` the
+    /// result back, `save`. It refuses under exactly the conditions
+    /// [`Self::as_legacy`] would return `None` for -- multi-region, or
+    /// control/color paint already present -- rather than clobbering
+    /// region-only data a legacy edit cannot see. On success this replaces
+    /// `channel_resolution`, `channels` and `regions` wholesale (from a
+    /// fresh [`Self::from_legacy_v1`] of `data`) and leaves `texture_set`
+    /// untouched, since a legacy view never had an opinion about it.
+    pub fn try_apply_legacy(&mut self, data: &TerrainData) -> Result<(), SidecarError> {
+        if self.as_legacy().is_none() {
+            return Err(SidecarError::NotLegacyCompatible);
+        }
+        let migrated = Self::from_legacy_v1(data)?;
+        self.channel_resolution = migrated.channel_resolution;
+        self.channels = migrated.channels;
+        self.regions = migrated.regions;
+        Ok(())
+    }
+
+    /// Bring `channels` to exactly `channel_resolution^2` entries,
+    /// zero-filling. Regions are never out of sync with their own `side`
+    /// by construction, so this only ever needs to touch `channels`; kept
+    /// as its own step (called by [`load`]) for a document built or edited
+    /// by hand rather than through decode.
+    pub fn normalize(&mut self) {
+        let cells = (self.channel_resolution as usize) * (self.channel_resolution as usize);
+        for channel in &mut self.channels {
+            channel.values.resize(cells, 0);
+        }
+    }
+
+    /// Byte length [`encode_regions`] will produce, or `None` on overflow.
+    pub fn encoded_len(&self) -> Option<usize> {
+        let channel_cells =
+            (self.channel_resolution as usize).checked_mul(self.channel_resolution as usize)?;
+        let mut len = 12usize; // magic + version + flags
+        len = len.checked_add(4)?.checked_add(4)?; // channel_resolution + channel_count
+        for channel in &self.channels {
+            len = len
+                .checked_add(8)?
+                .checked_add(channel.name.len())?
+                .checked_add(channel_cells.checked_mul(channel.element.byte_width())?)?;
+        }
+        // region_size + region_count + texture_set_len
+        len = len.checked_add(4)?.checked_add(4)?.checked_add(4)?;
+        let texture_set_len = self.texture_set.as_deref().unwrap_or("").len();
+        len = len.checked_add(texture_set_len)?;
+
+        for (_, region) in self.regions.iter_sorted() {
+            let region_cells = (region.side() as usize).checked_mul(region.side() as usize)?;
+            len = len.checked_add(8)?.checked_add(4)?; // coord + flags/pad
+            len = len.checked_add(region_cells.checked_mul(4)?)?; // heights
+            len = len.checked_add(region_cells.checked_mul(4)?)?; // control
+            if region.color().is_some() {
+                len = len.checked_add(region_cells.checked_mul(4)?)?; // color
+            }
+        }
+        Some(len)
+    }
 }
 
-/// Serialize a v3 terrain document.
-pub fn encode_regions(data: &RegionTerrainData) -> Option<Vec<u8>> {
-    let channel_cells =
-        (data.channel_resolution as usize).checked_mul(data.channel_resolution as usize)?;
+/// Serialize a v3 terrain document. Refuses a malformed texture-set
+/// reference rather than writing it -- see the module docs -- and refuses
+/// a size that overflows `usize`, the same as [`encode`].
+pub fn encode_regions(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError> {
+    if let Some(texture_set) = data.texture_set.as_deref() {
+        validate_texture_set_ref(texture_set).map_err(SidecarError::InvalidTextureSetRef)?;
+    }
 
-    let mut out = Vec::new();
+    let channel_cells = (data.channel_resolution as usize)
+        .checked_mul(data.channel_resolution as usize)
+        .ok_or(SidecarError::TooLarge)?;
+    let mut out = Vec::with_capacity(data.encoded_len().ok_or(SidecarError::TooLarge)?);
+
     out.extend_from_slice(&MAGIC);
     out.extend_from_slice(&VERSION_V3.to_le_bytes());
     out.extend_from_slice(&0u16.to_le_bytes());
@@ -606,7 +727,10 @@ pub fn encode_regions(data: &RegionTerrainData) -> Option<Vec<u8>> {
     for (coord, region) in data.regions.iter_sorted() {
         out.extend_from_slice(&coord.x.to_le_bytes());
         out.extend_from_slice(&coord.z.to_le_bytes());
-        let flags: u8 = if region.color().is_some() { 0x1 } else { 0 };
+        let mut flags = REGION_FLAG_PRESENT;
+        if region.color().is_some() {
+            flags |= REGION_FLAG_HAS_COLOR;
+        }
         out.push(flags);
         out.extend_from_slice(&[0u8; 3]);
 
@@ -614,7 +738,7 @@ pub fn encode_regions(data: &RegionTerrainData) -> Option<Vec<u8>> {
             out.extend_from_slice(&h.to_le_bytes());
         }
         for c in region.control_words() {
-            out.extend_from_slice(&c.to_le_bytes());
+            out.extend_from_slice(&c.to_raw().to_le_bytes());
         }
         if let Some(color) = region.color() {
             for px in color {
@@ -623,10 +747,12 @@ pub fn encode_regions(data: &RegionTerrainData) -> Option<Vec<u8>> {
         }
     }
 
-    Some(out)
+    Ok(out)
 }
 
-/// Deserialize a v3 terrain document.
+/// Deserialize a v3 terrain document. Requires the file to end exactly
+/// where the header's declared shape says it should, and rejects a region
+/// table that declares the same coordinate twice -- see the module docs.
 pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     let mut r = Reader { bytes, at: 0 };
 
@@ -648,10 +774,8 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
         .ok_or(SidecarError::TooLarge)?;
     let channels = decode_channels(&mut r, channel_count, channel_cells)?;
 
-    let region_size = r.u32()?;
-    if region_size == 0 {
-        return Err(SidecarError::InvalidRegionSize);
-    }
+    let region_size_raw = r.u32()?;
+    let region_size = RegionSize::new(region_size_raw).map_err(SidecarError::InvalidRegionSize)?;
     let region_count = r.u32()?;
 
     let texture_set_len = r.u32()? as usize;
@@ -666,22 +790,29 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
         Some(path)
     };
 
-    let cells = (region_size as usize)
-        .checked_mul(region_size as usize)
+    let cells = (region_size_raw as usize)
+        .checked_mul(region_size_raw as usize)
         .ok_or(SidecarError::TooLarge)?;
 
-    let mut regions = TerrainRegions::new(RegionSize::new_unchecked(region_size));
+    let mut regions = TerrainRegions::new(region_size);
+    let mut seen = HashSet::with_capacity(region_count.min(1024) as usize);
     for _ in 0..region_count {
         let x = r.i32()?;
         let z = r.i32()?;
         let flags = r.u8()?;
-        if flags & !0x1 != 0 {
+        if flags & !REGION_FLAGS_KNOWN != 0 {
+            return Err(SidecarError::ReservedFieldSet);
+        }
+        if flags & REGION_FLAG_PRESENT == 0 {
+            // This build only ever writes present regions; a clear
+            // presence bit means a state (an authored-absent tombstone,
+            // perhaps) this build does not understand.
             return Err(SidecarError::ReservedFieldSet);
         }
         if r.take(3)? != [0u8; 3] {
             return Err(SidecarError::ReservedFieldSet);
         }
-        let has_color = flags & 0x1 != 0;
+        let has_color = flags & REGION_FLAG_HAS_COLOR != 0;
 
         let heights_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
         let heights: Vec<f32> = heights_bytes
@@ -693,10 +824,11 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
         let mut control = Vec::with_capacity(cells);
         for chunk in control_bytes.chunks_exact(4) {
             let raw = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            if Control::from_raw(raw).reserved() != 0 {
+            let word = Control::from_raw(raw);
+            if word.reserved() != 0 {
                 return Err(SidecarError::ReservedFieldSet);
             }
-            control.push(raw);
+            control.push(word);
         }
 
         let color = if has_color {
@@ -711,10 +843,18 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
             None
         };
 
+        let coord = RegionCoord::new(x, z);
+        if !seen.insert(coord) {
+            return Err(SidecarError::DuplicateRegion(coord));
+        }
         regions.insert_region(
-            RegionCoord::new(x, z),
-            Region::from_parts(region_size, heights, control, color),
+            coord,
+            Region::from_parts(region_size_raw, heights, control, color),
         );
+    }
+
+    if r.at != bytes.len() {
+        return Err(SidecarError::Truncated);
     }
 
     Ok(RegionTerrainData {
@@ -726,9 +866,12 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
 }
 
 /// Load a sidecar of either version, upgrading a v1 file into a v3
-/// document in memory. Refuses a file written by a newer build than this
-/// one understands, the same as [`decode`]/[`decode_regions`] each do for
-/// their own version.
+/// document in memory and normalizing it (see
+/// [`RegionTerrainData::normalize`]) before returning. Refuses a file
+/// written by a newer build than this one understands, the same as
+/// [`decode`]/[`decode_regions`] each do for their own version, and refuses
+/// a v1 file whose resolution cannot become a region (see
+/// [`RegionTerrainData::from_legacy_v1`]).
 pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     let mut r = Reader { bytes, at: 0 };
     if r.take(MAGIC.len())? != MAGIC {
@@ -736,17 +879,19 @@ pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     }
     let version = r.u16()?;
 
-    match version {
+    let mut data = match version {
         0 => Err(SidecarError::UnsupportedVersion(0)),
-        VERSION => decode(bytes).map(|data| RegionTerrainData::from_legacy_v1(&data)),
+        VERSION => decode(bytes).and_then(|legacy| RegionTerrainData::from_legacy_v1(&legacy)),
         VERSION_V3 => decode_regions(bytes),
         other => Err(SidecarError::UnsupportedVersion(other)),
-    }
+    }?;
+    data.normalize();
+    Ok(data)
 }
 
 /// Serialize a terrain document as the current version (v3). The inverse
 /// of [`load`] for any file [`load`] can produce.
-pub fn save(data: &RegionTerrainData) -> Option<Vec<u8>> {
+pub fn save(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError> {
     encode_regions(data)
 }
 
@@ -755,6 +900,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+    use crate::region::DEFAULT_COLOR;
 
     fn sample() -> TerrainData {
         let mut biome = ChannelData::new("biome", ChannelElement::U8, 4);
@@ -922,6 +1068,33 @@ mod tests {
         assert_eq!(decode(&bytes), Err(SidecarError::Truncated));
     }
 
+    /// C2: a file with real bytes left over after every declared field is
+    /// read must not be silently accepted -- that tail would be lost the
+    /// next time something re-saves what it decoded.
+    #[test]
+    fn rejects_trailing_bytes_after_a_complete_v1_document() {
+        let mut bytes = encode(&sample()).expect("encodes");
+        bytes.push(0);
+        assert_eq!(decode(&bytes), Err(SidecarError::Truncated));
+    }
+
+    /// C2: an under-claimed channel count leaves the second channel's real
+    /// bytes unconsumed; that must fail the same as trailing garbage.
+    #[test]
+    fn rejects_an_under_claimed_channel_count_that_leaves_bytes_unconsumed() {
+        let data = TerrainData {
+            resolution: 2,
+            heights: vec![0.0; 4],
+            channels: vec![
+                ChannelData::new("a", ChannelElement::U8, 2),
+                ChannelData::new("b", ChannelElement::U8, 2),
+            ],
+        };
+        let mut bytes = encode(&data).expect("encodes");
+        bytes[16..20].copy_from_slice(&1u32.to_le_bytes()); // claim only 1 of 2
+        assert_eq!(decode(&bytes), Err(SidecarError::Truncated));
+    }
+
     #[test]
     fn normalize_squares_every_array_to_the_resolution() {
         let mut data = TerrainData {
@@ -1060,9 +1233,64 @@ mod tests {
         assert_eq!(back, data);
     }
 
+    /// C3: a region a person sculpted back to every default value is still
+    /// a region they chose to allocate. It must survive a full
+    /// bytes-round-trip, and re-encoding what was just decoded must
+    /// produce the identical bytes again.
+    #[test]
+    fn v3_round_trip_preserves_an_explicitly_declared_all_default_region() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        regions.set_height(0, 0, 0.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        assert_eq!(data.regions.region_count(), 1);
+
+        let bytes = encode_regions(&data).expect("encodes");
+        let decoded = decode_regions(&bytes).expect("decodes");
+        assert_eq!(
+            decoded.regions.region_count(),
+            1,
+            "the authored, now-default region survives the round trip"
+        );
+        assert_eq!(decoded, data);
+
+        let bytes_again = encode_regions(&decoded).expect("encodes");
+        assert_eq!(bytes, bytes_again);
+    }
+
+    #[test]
+    fn v3_round_trips_nan_and_negative_zero_heights_bit_exact() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, f32::NAN);
+        regions.set_height(1, 0, -0.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+        let back = decode_regions(&bytes).expect("decodes");
+
+        let original = data.regions.region(RegionCoord::ORIGIN).unwrap();
+        let round_tripped = back.regions.region(RegionCoord::ORIGIN).unwrap();
+        for (a, b) in original.heights().iter().zip(round_tripped.heights()) {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "NaN/-0.0 must round-trip bit exact"
+            );
+        }
+    }
+
     #[test]
     fn migrating_a_real_v1_file_produces_a_single_origin_region() {
-        let migrated = RegionTerrainData::from_legacy_v1(&sample());
+        let migrated = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
         assert_eq!(migrated.channel_resolution, 4);
         assert_eq!(migrated.channels, sample().channels);
         assert_eq!(migrated.regions.region_count(), 1);
@@ -1070,15 +1298,50 @@ mod tests {
         let region = migrated.regions.region(RegionCoord::ORIGIN).unwrap();
         assert_eq!(region.side(), 4);
         assert_eq!(region.heights(), sample().heights.as_slice());
-        assert!(region.control_words().iter().all(|c| *c == 0));
+        assert!(
+            region
+                .control_words()
+                .iter()
+                .all(|c| *c == Control::default())
+        );
         assert!(region.color().is_none());
     }
 
     #[test]
     fn migrating_an_empty_v1_terrain_allocates_no_regions() {
-        let migrated = RegionTerrainData::from_legacy_v1(&TerrainData::default());
+        let migrated = RegionTerrainData::from_legacy_v1(&TerrainData::default()).unwrap();
         assert_eq!(migrated.regions.region_count(), 0);
         assert_eq!(migrated.channel_resolution, 0);
+    }
+
+    /// C3: a v1 file authored its whole extent, flat or not -- migrating a
+    /// flat but nonzero-resolution legacy terrain must still produce a
+    /// present region, not nothing.
+    #[test]
+    fn migrating_a_flat_nonzero_resolution_v1_terrain_still_produces_a_present_region() {
+        let data = TerrainData {
+            resolution: 4,
+            heights: vec![0.0; 16],
+            channels: vec![],
+        };
+        let migrated = RegionTerrainData::from_legacy_v1(&data).unwrap();
+        assert_eq!(migrated.regions.region_count(), 1);
+    }
+
+    /// I1: a legacy resolution that is not a power of two cannot become a
+    /// region without resampling, which this crate does not do -- pinned
+    /// as a clear, explicit rejection rather than silent truncation.
+    #[test]
+    fn migrating_a_non_power_of_two_legacy_resolution_is_rejected_with_a_clear_error() {
+        let data = TerrainData {
+            resolution: 3,
+            heights: vec![0.0; 9],
+            channels: vec![],
+        };
+        assert_eq!(
+            RegionTerrainData::from_legacy_v1(&data),
+            Err(SidecarError::UnmigratableResolution(3))
+        );
     }
 
     #[test]
@@ -1089,7 +1352,10 @@ mod tests {
 
         // Load it: auto-upgrades to a v3 document, single implicit region.
         let migrated = load(&v1_bytes).expect("loads v1");
-        assert_eq!(migrated, RegionTerrainData::from_legacy_v1(&original));
+        assert_eq!(
+            migrated,
+            RegionTerrainData::from_legacy_v1(&original).unwrap()
+        );
         assert_eq!(migrated.as_legacy(), Some(original.clone()));
 
         // Save it: always writes v3.
@@ -1104,7 +1370,7 @@ mod tests {
 
     #[test]
     fn as_legacy_refuses_once_control_has_been_painted() {
-        let mut migrated = RegionTerrainData::from_legacy_v1(&sample());
+        let mut migrated = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
         migrated
             .regions
             .set_control(0, 0, Control::default().with_base_id(1));
@@ -1113,16 +1379,42 @@ mod tests {
 
     #[test]
     fn as_legacy_refuses_once_color_has_been_painted() {
-        let mut migrated = RegionTerrainData::from_legacy_v1(&sample());
+        let mut migrated = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
         migrated.regions.set_color(0, 0, [1, 2, 3, 4]);
         assert_eq!(migrated.as_legacy(), None);
     }
 
     #[test]
     fn as_legacy_refuses_once_a_terrain_goes_multi_region() {
-        let mut migrated = RegionTerrainData::from_legacy_v1(&sample());
+        let mut migrated = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
         migrated.regions.set_height(100, 100, 1.0);
         assert_eq!(migrated.as_legacy(), None);
+    }
+
+    #[test]
+    fn as_legacy_refuses_a_single_region_not_at_the_origin() {
+        let mut regions = TerrainRegions::new(RegionSize::new(4).unwrap());
+        regions.set_height(100, 100, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 4,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        assert_eq!(data.as_legacy(), None);
+    }
+
+    #[test]
+    fn as_legacy_refuses_when_the_single_regions_size_does_not_match_channel_resolution() {
+        let mut regions = TerrainRegions::new(RegionSize::new(4).unwrap());
+        regions.set_height(0, 0, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 8,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        assert_eq!(data.as_legacy(), None);
     }
 
     #[test]
@@ -1140,6 +1432,41 @@ mod tests {
                 heights: vec![0.0; 9],
                 channels: vec![],
             })
+        );
+    }
+
+    #[test]
+    fn try_apply_legacy_writes_back_into_a_legacy_shaped_document() {
+        let mut doc = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
+        let mut edited = sample();
+        edited.heights[0] = 99.0;
+        doc.try_apply_legacy(&edited)
+            .expect("a legacy-shaped document accepts a legacy write-back");
+        assert_eq!(doc.as_legacy(), Some(edited));
+    }
+
+    #[test]
+    fn try_apply_legacy_refuses_once_the_document_is_not_legacy_shaped() {
+        let mut doc = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
+        doc.regions
+            .set_control(0, 0, Control::default().with_base_id(1));
+        assert_eq!(
+            doc.try_apply_legacy(&sample()),
+            Err(SidecarError::NotLegacyCompatible)
+        );
+    }
+
+    #[test]
+    fn try_apply_legacy_propagates_a_non_power_of_two_target_resolution() {
+        let mut doc = RegionTerrainData::from_legacy_v1(&sample()).unwrap();
+        let bad = TerrainData {
+            resolution: 3,
+            heights: vec![0.0; 9],
+            channels: vec![],
+        };
+        assert_eq!(
+            doc.try_apply_legacy(&bad),
+            Err(SidecarError::UnmigratableResolution(3))
         );
     }
 
@@ -1202,7 +1529,30 @@ mod tests {
         // header(12) + channel_resolution(4) + channel_count(4) = offset 20
         // is region_size (no channels in this fixture).
         bytes[20..24].copy_from_slice(&0u32.to_le_bytes());
-        assert_eq!(decode_regions(&bytes), Err(SidecarError::InvalidRegionSize));
+        assert_eq!(
+            decode_regions(&bytes),
+            Err(SidecarError::InvalidRegionSize(RegionSizeError::Zero))
+        );
+    }
+
+    /// I1: region size must be a real, always-enforced power-of-two
+    /// invariant, not just a rule for newly created terrains.
+    #[test]
+    fn v3_rejects_a_non_power_of_two_region_size() {
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: TerrainRegions::new(RegionSize::new(4).unwrap()),
+            texture_set: None,
+        };
+        let mut bytes = encode_regions(&data).expect("encodes");
+        bytes[20..24].copy_from_slice(&300u32.to_le_bytes());
+        assert_eq!(
+            decode_regions(&bytes),
+            Err(SidecarError::InvalidRegionSize(
+                RegionSizeError::NotPowerOfTwo
+            ))
+        );
     }
 
     #[test]
@@ -1229,7 +1579,7 @@ mod tests {
             poisoned[control_offset + 2],
             poisoned[control_offset + 3],
         ]);
-        let with_reserved = word | (1 << 16);
+        let with_reserved = word | (1 << 18);
         poisoned[control_offset..control_offset + 4].copy_from_slice(&with_reserved.to_le_bytes());
 
         assert_eq!(
@@ -1261,6 +1611,30 @@ mod tests {
         );
     }
 
+    /// C3/decode counterpart: the presence bit being clear declares a
+    /// state this build does not understand, so it must be rejected the
+    /// same as any other unknown reserved bit.
+    #[test]
+    fn v3_rejects_a_region_whose_presence_bit_is_clear() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+        let flags_offset = 40;
+        let mut poisoned = bytes.clone();
+        assert_eq!(poisoned[flags_offset], REGION_FLAG_PRESENT);
+        poisoned[flags_offset] = 0;
+        assert_eq!(
+            decode_regions(&poisoned),
+            Err(SidecarError::ReservedFieldSet)
+        );
+    }
+
     #[test]
     fn v3_rejects_nonzero_region_padding() {
         let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
@@ -1281,15 +1655,42 @@ mod tests {
         );
     }
 
+    /// C1: a bad reference must never reach disk in the first place --
+    /// encode is where this is caught, not decode.
     #[test]
-    fn v3_rejects_an_invalid_texture_set_reference() {
+    fn encode_regions_refuses_an_invalid_texture_set_reference() {
         let data = RegionTerrainData {
             channel_resolution: 0,
             channels: vec![],
             regions: TerrainRegions::new(RegionSize::new(4).unwrap()),
             texture_set: Some("../escape.jdtextureset".to_string()),
         };
-        let bytes = encode_regions(&data).expect("encodes");
+        assert!(matches!(
+            encode_regions(&data),
+            Err(SidecarError::InvalidTextureSetRef(_))
+        ));
+        assert!(matches!(
+            save(&data),
+            Err(SidecarError::InvalidTextureSetRef(_))
+        ));
+    }
+
+    /// C1: since encode can no longer produce such a file, hand-craft the
+    /// bytes to prove decode is still hostile-safe on its own, in case
+    /// bytes ever reach it from something other than this crate's encoder.
+    #[test]
+    fn decode_regions_also_refuses_a_hand_crafted_invalid_texture_set_reference() {
+        let bad_ref = b"../escape";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC);
+        bytes.extend_from_slice(&VERSION_V3.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_resolution
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_count
+        bytes.extend_from_slice(&4u32.to_le_bytes()); // region_size
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // region_count
+        bytes.extend_from_slice(&(bad_ref.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(bad_ref);
         assert!(matches!(
             decode_regions(&bytes),
             Err(SidecarError::InvalidTextureSetRef(_))
@@ -1307,14 +1708,67 @@ mod tests {
         }
     }
 
+    /// C2: fixed to test truncation at every real structural boundary
+    /// (rather than arbitrary offsets), one byte short of each field's own
+    /// end. The fixture's layout is asserted against the real encoder's
+    /// output length first, so a wrong hand computation fails loudly
+    /// instead of silently testing the wrong offsets.
     #[test]
-    fn v3_a_truncated_file_is_rejected_at_every_boundary() {
-        let bytes = encode_regions(&sample_regions()).expect("encodes");
-        for cut in [0, 8, 10, 12, 20, 40, 60, bytes.len() - 1] {
+    fn v3_every_structural_boundary_is_rejected_one_byte_short() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        regions.set_color(0, 0, [9, 9, 9, 9]);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: Some("t".to_string()),
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+
+        let magic_end = 8;
+        let version_end = magic_end + 2;
+        let flags_end = version_end + 2;
+        let chan_res_end = flags_end + 4;
+        let chan_count_end = chan_res_end + 4;
+        let region_size_end = chan_count_end + 4;
+        let region_count_end = region_size_end + 4;
+        let tex_len_end = region_count_end + 4;
+        let tex_bytes_end = tex_len_end + 1; // "t"
+        let coord_end = tex_bytes_end + 8;
+        let region_flags_end = coord_end + 1;
+        let pad_end = region_flags_end + 3;
+        let heights_end = pad_end + 4 * 4; // 4 cells * 4 bytes per f32
+        let control_end = heights_end + 4 * 4; // 4 cells * 4 bytes per u32
+        let color_end = control_end + 4 * 4; // 4 cells * 4 bytes per rgba8
+
+        assert_eq!(
+            color_end,
+            bytes.len(),
+            "fixture layout math must match the real encoder"
+        );
+
+        for end in [
+            magic_end,
+            version_end,
+            flags_end,
+            chan_res_end,
+            chan_count_end,
+            region_size_end,
+            region_count_end,
+            tex_len_end,
+            tex_bytes_end,
+            coord_end,
+            region_flags_end,
+            pad_end,
+            heights_end,
+            control_end,
+            color_end,
+        ] {
             assert_eq!(
-                decode_regions(&bytes[..cut]),
+                decode_regions(&bytes[..end - 1]),
                 Err(SidecarError::Truncated),
-                "cut at {cut} should be truncated"
+                "truncating 1 byte before offset {end} must be rejected",
             );
         }
     }
@@ -1329,10 +1783,38 @@ mod tests {
         };
         let mut bytes = encode_regions(&data).expect("encodes");
         // No regions were written, so forging a region_count of 1 against
-        // an enormous region_size must not allocate that claim.
-        bytes[20..24].copy_from_slice(&1_000_000u32.to_le_bytes()); // region_size
+        // an enormous (but power-of-two, and non-overflowing) region_size
+        // must not allocate that claim -- distinct from the TooLarge case
+        // below, where the claim overflows arithmetic before any read.
+        bytes[20..24].copy_from_slice(&(1u32 << 20).to_le_bytes()); // region_size
         bytes[24..28].copy_from_slice(&1u32.to_le_bytes()); // region_count
         assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
+    }
+
+    /// I6/C2 boundary: a region size whose cell-count-in-bytes overflows
+    /// `usize` must be reported as `TooLarge`, not `Truncated` -- the
+    /// failure happens in arithmetic before any byte is read, so it must
+    /// not be conflated with merely running out of file.
+    #[test]
+    fn v3_a_genuinely_overflowing_size_claim_is_too_large_not_truncated() {
+        // 2^31 is a valid power-of-two region size; its cell count squared
+        // times the 4 bytes per f32 overflows u64 (2^62 * 4 == 2^64).
+        let region_size: u32 = 1 << 31;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC);
+        bytes.extend_from_slice(&VERSION_V3.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_resolution
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_count
+        bytes.extend_from_slice(&region_size.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // region_count
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // texture_set_len
+        bytes.extend_from_slice(&0i32.to_le_bytes()); // coord x
+        bytes.extend_from_slice(&0i32.to_le_bytes()); // coord z
+        bytes.push(REGION_FLAG_PRESENT);
+        bytes.extend_from_slice(&[0u8; 3]);
+
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::TooLarge));
     }
 
     #[test]
@@ -1346,5 +1828,66 @@ mod tests {
         let mut bytes = encode_regions(&data).expect("encodes");
         bytes[12..16].copy_from_slice(&1_000_000u32.to_le_bytes());
         assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
+    }
+
+    /// C2: trailing bytes after a fully-decoded v3 document must be
+    /// rejected, the same as v1.
+    #[test]
+    fn v3_rejects_trailing_bytes_after_a_complete_document() {
+        let mut bytes = encode_regions(&sample_regions()).expect("encodes");
+        bytes.push(0);
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
+    }
+
+    /// C2: an under-claimed `region_count` leaves a real region's bytes
+    /// unconsumed.
+    #[test]
+    fn v3_rejects_an_under_claimed_region_count_that_leaves_bytes_unconsumed() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        regions.set_height(10, 10, 2.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let mut bytes = encode_regions(&data).expect("encodes");
+        // header(12)+chan_res(4)+chan_count(4)=20 is region_size, +4=24 is
+        // region_count.
+        bytes[24..28].copy_from_slice(&1u32.to_le_bytes()); // claim only 1 of 2
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
+    }
+
+    /// I2: decode must be canonical -- a file cannot declare the same
+    /// region coordinate twice.
+    #[test]
+    fn v3_rejects_a_duplicate_region_coordinate() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+        // No channels, no texture set: the region table starts at 32 for
+        // this fixture. Duplicate that one region entry and bump the
+        // count to match.
+        let region_entry = bytes[32..].to_vec();
+        let mut poisoned = bytes.clone();
+        poisoned[24..28].copy_from_slice(&2u32.to_le_bytes());
+        poisoned.extend_from_slice(&region_entry);
+        assert_eq!(
+            decode_regions(&poisoned),
+            Err(SidecarError::DuplicateRegion(RegionCoord::ORIGIN))
+        );
+    }
+
+    #[test]
+    fn default_color_constant_is_reexported_and_used_by_a_fresh_terrain() {
+        let t = TerrainRegions::new(RegionSize::new(4).unwrap());
+        assert_eq!(t.color_at(0, 0), DEFAULT_COLOR);
     }
 }

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -30,59 +30,43 @@
 //! the data, so the same terrain always produces the same bytes and a
 //! sidecar can be committed and diffed.
 //!
-//! There is no checksum. A file can be truncated or bit-flipped by
-//! something outside the atomic-write path this format's own writer uses
-//! (a bad disk, a naive sync tool) and still pass magic/version/length
-//! checks while carrying wrong values -- decode only catches structural
-//! corruption (bad magic, an unreadable version, a length that does not
-//! fit the claimed shape), not silent bit rot within otherwise
-//! well-formed bytes. Accepted as a tradeoff for the format staying
-//! trivial to read from any language; revisit if this ever needs to
-//! survive untrusted or unreliable transport.
+//! There is no checksum. Decode catches structural corruption (bad magic,
+//! an unreadable version, a length that does not fit the claimed shape),
+//! not silent bit rot within otherwise well-formed bytes.
 //!
-//! Decode also requires the file to end exactly where the declared
-//! structure ends: trailing bytes, or a header that under-claims a count
-//! (leaving real data unconsumed), are both rejected as [`SidecarError::Truncated`]
-//! rather than silently ignored. Failing open here -- accepting a
-//! shorter-than-claimed read as success -- would discard the unconsumed
-//! tail the moment anything re-saves the file.
+//! Decode requires the file to end exactly where the declared structure
+//! ends: trailing bytes, and a header that under-claims a count, are both
+//! rejected as [`SidecarError::Truncated`].
 //!
-//! # v3: regions
+//! # Format version 2
 //!
-//! [`VERSION`] (1) is the layout above: one dense heightmap plus channels,
-//! everything sized to a single `resolution`. It is what the terrain
-//! track's design doc calls "v2" -- there has only ever been one shipped
-//! format before this one, and the doc's v2/v3 numbering counts generations
-//! of the design, not this field's literal value. [`VERSION_V3`] (2) is
-//! what the doc calls "v3": heights, the control map and an optional color
-//! layer move into sparse regions (see [`crate::region`]), addressed by
-//! [`RegionCoord`]. Channels are unaffected -- they are gameplay masks, not
-//! visual splat, and stay dense at `channel_resolution` exactly as they
-//! were at `resolution` before.
+//! Format version 1 is the layout above: one dense heightmap plus channels,
+//! sized to a single `resolution`. Format version 2 moves heights, the
+//! control map, and an optional color layer into sparse regions (see
+//! [`crate::region`]), addressed by [`RegionCoord`]. Channels stay dense at
+//! `channel_resolution`, unchanged from version 1.
 //!
 //! ```text
 //! offset  size          field
 //! 0       8             magic, b"JDTERRN\0"             (shared header)
-//! 8       2             format version, u16 == VERSION_V3
+//! 8       2             format version, u16 == 2
 //! 10      2             flags, u16 (reserved, must be 0)
 //! 12      4             channel_resolution, u32
 //! 16      4             channel_count, u32
-//! 20      ...           channels, same per-channel layout as v1
+//! 20      ...           channels, same per-channel layout as version 1
 //! then
 //!         4             region_size, u32 (cells per region edge; a
-//!                        nonzero power of two, checked on decode)
+//!                        nonzero power of two)
 //!         4             region_count, u32
 //!         4             texture_set path length in bytes, u32 (0 = none)
 //!         n             texture_set path, UTF-8, project-relative
-//! then, per region (region_count times), each an AUTHORED, present
-//! region regardless of its content (see crate::region):
+//! then, per region (region_count times), each present regardless of
+//! content:
 //!         4             region coord x, i32
 //!         4             region coord z, i32
 //!         1             region flags, u8:
 //!                          bit 0 = has color layer
-//!                          bit 1 = present (always 1; a file with this
-//!                                  clear declares a state this build does
-//!                                  not understand)
+//!                          bit 1 = present (always 1)
 //!                          bits 2-7 = reserved, must be 0
 //!         3             padding, must be 0
 //!         4*size^2      heights, f32 (IEEE 754, little-endian)
@@ -90,20 +74,14 @@
 //!         4*size^2      color RGBA8 -- only present if flag bit 0 is set
 //! ```
 //!
-//! [`load`] and [`save`] are the entry points call sites should use going
-//! forward: `load` transparently upgrades a v1 file into a single implicit
-//! region at the origin sized to its old resolution, with no control or
-//! color data (rejecting a legacy resolution that is not a power of two,
-//! since this crate does not resample on migration), and `save` always
-//! writes v3. A newer-than-this-build version is refused by both, the same
-//! as v1 -- a file this build cannot understand is never silently dropped
-//! or overwritten. `save`/[`encode_regions`] also refuse to write a
-//! malformed texture-set reference, so a bad reference can never reach disk
-//! in the first place; a file that somehow has one anyway (hand-edited, or
-//! written by something other than this crate) is still caught on the way
-//! back in by [`decode_regions`]. The bare `encode`/`decode` (v1) and
-//! `encode_regions`/`decode_regions` (v3) pairs stay available for testing
-//! and for code that specifically needs one format or the other.
+//! [`load`] and [`save`] are the entry points to use: `load` upgrades a
+//! version-1 file into a single region at the origin sized to its old
+//! resolution, and `save` always writes version 2. A newer-than-this-build
+//! version is refused by both. `save`/[`encode_regions`] refuse to write a
+//! malformed texture-set reference; [`decode_regions`] rejects one too, for
+//! bytes from elsewhere. The bare `encode`/`decode` and
+//! `encode_regions`/`decode_regions` pairs stay available for one format
+//! or the other directly.
 
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
@@ -121,10 +99,8 @@ pub const VERSION: u16 = 1;
 
 /// Format version [`encode_regions`]/[`decode_regions`] read and write, and
 /// what [`save`] always writes: regions replace the dense heightmap. See
-/// the module-level "v3: regions" section for the full layout and how the
-/// version numbers here map onto the terrain track design doc's v2/v3
-/// naming.
-pub const VERSION_V3: u16 = 2;
+/// the module-level "Format version 2" section for the full layout.
+pub const VERSION_2: u16 = 2;
 
 /// Conventional file extension for a terrain sidecar.
 pub const EXTENSION: &str = "jdterrain";
@@ -132,8 +108,7 @@ pub const EXTENSION: &str = "jdterrain";
 /// Region flags bit: this region has a color layer, written right after
 /// its control words.
 const REGION_FLAG_HAS_COLOR: u8 = 0b0000_0001;
-/// Region flags bit: this region is present. Always set by this build;
-/// see the module-level v3 byte table.
+/// Region flags bit: this region is present. Always set by this build.
 const REGION_FLAG_PRESENT: u8 = 0b0000_0010;
 /// Every region flags bit this build understands.
 const REGION_FLAGS_KNOWN: u8 = REGION_FLAG_HAS_COLOR | REGION_FLAG_PRESENT;
@@ -171,14 +146,11 @@ impl core::fmt::Display for SidecarPathError {
 impl core::error::Error for SidecarPathError {}
 
 /// Traversal guard shared by every project-relative path string this crate
-/// accepts from a file: sidecar `data_path` (resolved beneath a scene) and
-/// texture-set references (resolved beneath the project) both go through
-/// this before any format-specific check, so both stay equally hostile to
-/// the same escape tricks.
+/// accepts from a file: sidecar `data_path` and texture-set references both
+/// go through this before any format-specific check.
 ///
-/// Deliberately stricter than the host platform: backslashes and Windows
-/// drive prefixes are rejected on every platform, as are empty, `.` and
-/// `..` components.
+/// Stricter than the host platform: backslashes and Windows drive prefixes
+/// are rejected on every platform, as are empty, `.` and `..` components.
 fn reject_path_traversal(data_path: &str) -> Result<(), SidecarPathError> {
     if data_path.is_empty() {
         return Err(SidecarPathError::Empty);
@@ -227,10 +199,8 @@ pub fn resolve_path(scene_dir: &Path, data_path: &str) -> Result<PathBuf, Sideca
 }
 
 /// Validate a texture-set asset reference: a project-relative path string,
-/// stored on a v3 sidecar and resolved beneath the project root by whatever
-/// asset system loads it (T2/T3, not this crate). Same traversal guard as
-/// [`resolve_path`], minus the sidecar-specific extension check -- the
-/// texture-set asset's extension is not this crate's concern.
+/// resolved beneath the project root by the asset system that loads it.
+/// Same traversal guard as [`resolve_path`], minus the extension check.
 pub fn validate_texture_set_ref(path: &str) -> Result<(), SidecarPathError> {
     reject_path_traversal(path)
 }
@@ -265,18 +235,17 @@ pub enum SidecarError {
     BadName,
     /// The declared dimensions do not fit in this platform's address space.
     TooLarge,
-    /// A v3 region table declared an unusable region size.
+    /// A region table declared an unusable region size.
     InvalidRegionSize(RegionSizeError),
     /// The texture-set reference string is unsafe or malformed.
     InvalidTextureSetRef(SidecarPathError),
-    /// A v3 region table declared the same region coordinate twice.
+    /// A region table declared the same region coordinate twice.
     DuplicateRegion(RegionCoord),
-    /// A v1 resolution is not a power of two, so it cannot become a v3
-    /// region without resampling -- which this crate does not do.
+    /// A resolution is not a power of two, so it cannot become a region
+    /// without resampling.
     UnmigratableResolution(u32),
-    /// A write-back (see [`RegionTerrainData::try_apply_legacy`]) was
-    /// attempted on a document with region data a legacy [`TerrainData`]
-    /// cannot represent.
+    /// [`RegionTerrainData::try_apply_legacy`] was attempted on a document
+    /// with region data a [`TerrainData`] cannot represent.
     NotLegacyCompatible,
 }
 
@@ -306,7 +275,7 @@ impl core::fmt::Display for SidecarError {
             }
             Self::UnmigratableResolution(res) => write!(
                 f,
-                "terrain resolution {res} is not a power of two and cannot become a v3 region without resampling"
+                "terrain resolution {res} is not a power of two and cannot become a region without resampling"
             ),
             Self::NotLegacyCompatible => write!(
                 f,
@@ -470,7 +439,7 @@ pub fn encode(data: &TerrainData) -> Option<Vec<u8>> {
 }
 
 /// Deserialize a terrain's bulk data. Requires the file to end exactly
-/// where the header's declared shape says it should -- see the module docs.
+/// where the declared shape says it should.
 pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
     let mut r = Reader { bytes, at: 0 };
 
@@ -478,9 +447,8 @@ pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
         return Err(SidecarError::BadMagic);
     }
     let version = r.u16()?;
-    // 0 has never been a version any build wrote (VERSION starts at 1);
-    // accepting it would let a file whose version bytes were zeroed out
-    // by corruption parse as if it were a real, if ancient, format.
+    // Version 0 is never valid: it would accept a file whose version
+    // bytes were zeroed out by corruption.
     if version == 0 || version > VERSION {
         return Err(SidecarError::UnsupportedVersion(version));
     }
@@ -515,17 +483,12 @@ pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
     })
 }
 
-/// A v3 terrain document: channels (unchanged from v1) plus sparse
-/// region-based heights/control/color, plus the texture set the splat
-/// material paints with.
-///
-/// Derives `PartialEq` down to raw `f32` heights; see the "a note on `f32`
-/// equality" section in [`crate::region`] before comparing a document that
-/// might contain `NaN`.
+/// A terrain document: channels plus sparse region-based heights/control/
+/// color, plus the texture set the splat material paints with.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RegionTerrainData {
-    /// Sizes `channels` exactly as `resolution` sized them in v1. Unrelated
-    /// to region addressing -- channels are not part of the region model.
+    /// Sizes `channels`. Unrelated to region addressing -- channels are
+    /// not part of the region model.
     pub channel_resolution: u32,
     /// Named integer layers, in the order the project declared them.
     pub channels: Vec<ChannelData>,
@@ -537,22 +500,15 @@ pub struct RegionTerrainData {
 }
 
 impl RegionTerrainData {
-    /// Migrate a v1 [`TerrainData`] into a v3 document: one implicit region
-    /// at [`RegionCoord::ORIGIN`], sized to the legacy resolution exactly
-    /// -- no resampling. The migrated region carries no control or color
-    /// paint (both stay at their all-default values), and is present even
-    /// if every height in it happens to be flat/default: a v1 file
-    /// authored its whole extent, zero included, and that is a real region
-    /// now, not nothing (see [`crate::region`]'s authored-presence rule).
-    /// Channels are moved across unchanged.
+    /// Migrate a [`TerrainData`] into a region document: one region at
+    /// [`RegionCoord::ORIGIN`], sized to the legacy resolution, with no
+    /// control or color paint. Present even if every height is default.
+    /// Channels move across unchanged.
     ///
-    /// A region size must be a nonzero power of two ([`RegionSize::new`]),
-    /// and this crate does not resample on migration, so a legacy
-    /// resolution that is not a power of two is rejected with
-    /// [`SidecarError::UnmigratableResolution`] rather than silently
-    /// rounded or truncated. A resolution of exactly 0 (an empty legacy
-    /// terrain) is the one exception: there are no cells to place in a
-    /// region either way, so it migrates to zero regions under
+    /// Region size must be a nonzero power of two; a legacy resolution
+    /// that isn't one is rejected with
+    /// [`SidecarError::UnmigratableResolution`] rather than resampled. A
+    /// resolution of 0 migrates to zero regions under
     /// [`RegionSize::DEFAULT`].
     pub fn from_legacy_v1(data: &TerrainData) -> Result<Self, SidecarError> {
         let mut normalized = data.clone();
@@ -586,15 +542,10 @@ impl RegionTerrainData {
         })
     }
 
-    /// A [`TerrainData`] view of this document, for call sites that have
-    /// not migrated to the region API yet -- the "compat view" that lets
-    /// existing single-blob call sites keep working unmodified as long as
-    /// a terrain is still, in every sense, v1-shaped: at most one region,
-    /// at the origin, sized to `channel_resolution`, with no control or
-    /// color paint. Returns `None` once any of that stops holding, rather
-    /// than lossily flattening real region/control/color data into a shape
-    /// that cannot represent it -- at that point the call site has to move
-    /// to the region API for real.
+    /// A [`TerrainData`] view of this document: at most one region, at the
+    /// origin, sized to `channel_resolution`, with no control or color
+    /// paint. Returns `None` once any of that stops holding, rather than
+    /// flattening data it cannot represent.
     pub fn as_legacy(&self) -> Option<TerrainData> {
         let heights = match self.regions.region_count() {
             0 => {
@@ -631,19 +582,11 @@ impl RegionTerrainData {
     }
 
     /// Write a [`TerrainData`]'s heights and channels back into this
-    /// document's single origin region -- the inverse of [`Self::as_legacy`].
-    ///
-    /// This is the write-back path for call sites that still edit through
-    /// the legacy dense API (every existing sculpt/paint operator, until a
-    /// later task moves them onto regions directly): load, `as_legacy` to
-    /// get a `TerrainData`, run the existing edit, `try_apply_legacy` the
-    /// result back, `save`. It refuses under exactly the conditions
-    /// [`Self::as_legacy`] would return `None` for -- multi-region, or
-    /// control/color paint already present -- rather than clobbering
-    /// region-only data a legacy edit cannot see. On success this replaces
-    /// `channel_resolution`, `channels` and `regions` wholesale (from a
-    /// fresh [`Self::from_legacy_v1`] of `data`) and leaves `texture_set`
-    /// untouched, since a legacy view never had an opinion about it.
+    /// document's single origin region -- the inverse of
+    /// [`Self::as_legacy`]. Refuses under the same conditions
+    /// [`Self::as_legacy`] returns `None` for. On success replaces
+    /// `channel_resolution`, `channels` and `regions` wholesale; leaves
+    /// `texture_set` untouched.
     pub fn try_apply_legacy(&mut self, data: &TerrainData) -> Result<(), SidecarError> {
         if self.as_legacy().is_none() {
             return Err(SidecarError::NotLegacyCompatible);
@@ -656,10 +599,7 @@ impl RegionTerrainData {
     }
 
     /// Bring `channels` to exactly `channel_resolution^2` entries,
-    /// zero-filling. Regions are never out of sync with their own `side`
-    /// by construction, so this only ever needs to touch `channels`; kept
-    /// as its own step (called by [`load`]) for a document built or edited
-    /// by hand rather than through decode.
+    /// zero-filling.
     pub fn normalize(&mut self) {
         let cells = (self.channel_resolution as usize) * (self.channel_resolution as usize);
         for channel in &mut self.channels {
@@ -697,9 +637,8 @@ impl RegionTerrainData {
     }
 }
 
-/// Serialize a v3 terrain document. Refuses a malformed texture-set
-/// reference rather than writing it -- see the module docs -- and refuses
-/// a size that overflows `usize`, the same as [`encode`].
+/// Serialize a terrain document. Refuses a malformed texture-set reference,
+/// and a size that overflows `usize`.
 pub fn encode_regions(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError> {
     if let Some(texture_set) = data.texture_set.as_deref() {
         validate_texture_set_ref(texture_set).map_err(SidecarError::InvalidTextureSetRef)?;
@@ -711,7 +650,7 @@ pub fn encode_regions(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError>
     let mut out = Vec::with_capacity(data.encoded_len().ok_or(SidecarError::TooLarge)?);
 
     out.extend_from_slice(&MAGIC);
-    out.extend_from_slice(&VERSION_V3.to_le_bytes());
+    out.extend_from_slice(&VERSION_2.to_le_bytes());
     out.extend_from_slice(&0u16.to_le_bytes());
     out.extend_from_slice(&data.channel_resolution.to_le_bytes());
     out.extend_from_slice(&(data.channels.len() as u32).to_le_bytes());
@@ -750,9 +689,9 @@ pub fn encode_regions(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError>
     Ok(out)
 }
 
-/// Deserialize a v3 terrain document. Requires the file to end exactly
-/// where the header's declared shape says it should, and rejects a region
-/// table that declares the same coordinate twice -- see the module docs.
+/// Deserialize a terrain document. Requires the file to end exactly where
+/// the declared shape says it should, and rejects a region table that
+/// declares the same coordinate twice.
 pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     let mut r = Reader { bytes, at: 0 };
 
@@ -760,7 +699,7 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
         return Err(SidecarError::BadMagic);
     }
     let version = r.u16()?;
-    if version != VERSION_V3 {
+    if version != VERSION_2 {
         return Err(SidecarError::UnsupportedVersion(version));
     }
     if r.u16()? != 0 {
@@ -804,9 +743,6 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
             return Err(SidecarError::ReservedFieldSet);
         }
         if flags & REGION_FLAG_PRESENT == 0 {
-            // This build only ever writes present regions; a clear
-            // presence bit means a state (an authored-absent tombstone,
-            // perhaps) this build does not understand.
             return Err(SidecarError::ReservedFieldSet);
         }
         if r.take(3)? != [0u8; 3] {
@@ -865,13 +801,10 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     })
 }
 
-/// Load a sidecar of either version, upgrading a v1 file into a v3
-/// document in memory and normalizing it (see
-/// [`RegionTerrainData::normalize`]) before returning. Refuses a file
-/// written by a newer build than this one understands, the same as
-/// [`decode`]/[`decode_regions`] each do for their own version, and refuses
-/// a v1 file whose resolution cannot become a region (see
-/// [`RegionTerrainData::from_legacy_v1`]).
+/// Load a sidecar of either format version, upgrading version 1 to a
+/// region document and normalizing it before returning. Refuses a file
+/// written by a newer build, and a version-1 file whose resolution cannot
+/// become a region.
 pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     let mut r = Reader { bytes, at: 0 };
     if r.take(MAGIC.len())? != MAGIC {
@@ -882,14 +815,14 @@ pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     let mut data = match version {
         0 => Err(SidecarError::UnsupportedVersion(0)),
         VERSION => decode(bytes).and_then(|legacy| RegionTerrainData::from_legacy_v1(&legacy)),
-        VERSION_V3 => decode_regions(bytes),
+        VERSION_2 => decode_regions(bytes),
         other => Err(SidecarError::UnsupportedVersion(other)),
     }?;
     data.normalize();
     Ok(data)
 }
 
-/// Serialize a terrain document as the current version (v3). The inverse
+/// Serialize a terrain document as the current format version. The inverse
 /// of [`load`] for any file [`load`] can produce.
 pub fn save(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError> {
     encode_regions(data)
@@ -1023,9 +956,6 @@ mod tests {
         );
     }
 
-    /// M5: version 0 has never been written by any build and must not be
-    /// accepted as if it were a real, if ancient, format -- most likely
-    /// to show up from version bytes zeroed out by corruption.
     #[test]
     fn rejects_version_zero() {
         let mut bytes = encode(&sample()).expect("encodes");
@@ -1068,9 +998,6 @@ mod tests {
         assert_eq!(decode(&bytes), Err(SidecarError::Truncated));
     }
 
-    /// C2: a file with real bytes left over after every declared field is
-    /// read must not be silently accepted -- that tail would be lost the
-    /// next time something re-saves what it decoded.
     #[test]
     fn rejects_trailing_bytes_after_a_complete_v1_document() {
         let mut bytes = encode(&sample()).expect("encodes");
@@ -1078,8 +1005,6 @@ mod tests {
         assert_eq!(decode(&bytes), Err(SidecarError::Truncated));
     }
 
-    /// C2: an under-claimed channel count leaves the second channel's real
-    /// bytes unconsumed; that must fail the same as trailing garbage.
     #[test]
     fn rejects_an_under_claimed_channel_count_that_leaves_bytes_unconsumed() {
         let data = TerrainData {
@@ -1233,10 +1158,6 @@ mod tests {
         assert_eq!(back, data);
     }
 
-    /// C3: a region a person sculpted back to every default value is still
-    /// a region they chose to allocate. It must survive a full
-    /// bytes-round-trip, and re-encoding what was just decoded must
-    /// produce the identical bytes again.
     #[test]
     fn v3_round_trip_preserves_an_explicitly_declared_all_default_region() {
         let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
@@ -1279,6 +1200,7 @@ mod tests {
 
         let original = data.regions.region(RegionCoord::ORIGIN).unwrap();
         let round_tripped = back.regions.region(RegionCoord::ORIGIN).unwrap();
+        // NaN != NaN; compare bits.
         for (a, b) in original.heights().iter().zip(round_tripped.heights()) {
             assert_eq!(
                 a.to_bits(),
@@ -1314,9 +1236,6 @@ mod tests {
         assert_eq!(migrated.channel_resolution, 0);
     }
 
-    /// C3: a v1 file authored its whole extent, flat or not -- migrating a
-    /// flat but nonzero-resolution legacy terrain must still produce a
-    /// present region, not nothing.
     #[test]
     fn migrating_a_flat_nonzero_resolution_v1_terrain_still_produces_a_present_region() {
         let data = TerrainData {
@@ -1328,9 +1247,6 @@ mod tests {
         assert_eq!(migrated.regions.region_count(), 1);
     }
 
-    /// I1: a legacy resolution that is not a power of two cannot become a
-    /// region without resampling, which this crate does not do -- pinned
-    /// as a clear, explicit rejection rather than silent truncation.
     #[test]
     fn migrating_a_non_power_of_two_legacy_resolution_is_rejected_with_a_clear_error() {
         let data = TerrainData {
@@ -1346,11 +1262,9 @@ mod tests {
 
     #[test]
     fn v1_to_v3_migration_round_trips_through_load_and_save() {
-        // Build a real v1 file with the existing encoder.
         let original = sample();
         let v1_bytes = encode(&original).expect("v1 encodes");
 
-        // Load it: auto-upgrades to a v3 document, single implicit region.
         let migrated = load(&v1_bytes).expect("loads v1");
         assert_eq!(
             migrated,
@@ -1358,13 +1272,11 @@ mod tests {
         );
         assert_eq!(migrated.as_legacy(), Some(original.clone()));
 
-        // Save it: always writes v3.
-        let v3_bytes = save(&migrated).expect("v3 encodes");
-        assert_eq!(u16::from_le_bytes([v3_bytes[8], v3_bytes[9]]), VERSION_V3);
+        let v3_bytes = save(&migrated).expect("encodes");
+        assert_eq!(u16::from_le_bytes([v3_bytes[8], v3_bytes[9]]), VERSION_2);
         assert_ne!(v3_bytes[8..10], v1_bytes[8..10]);
 
-        // Reload the v3 bytes: matches what was saved exactly.
-        let reloaded = load(&v3_bytes).expect("loads v3");
+        let reloaded = load(&v3_bytes).expect("loads");
         assert_eq!(reloaded, migrated);
     }
 
@@ -1474,28 +1386,28 @@ mod tests {
     fn rejects_a_v3_file_written_by_a_newer_build() {
         let bytes = encode_regions(&sample_regions()).expect("encodes");
         let mut newer = bytes.clone();
-        newer[8..10].copy_from_slice(&(VERSION_V3 + 1).to_le_bytes());
+        newer[8..10].copy_from_slice(&(VERSION_2 + 1).to_le_bytes());
         assert_eq!(
             decode_regions(&newer),
-            Err(SidecarError::UnsupportedVersion(VERSION_V3 + 1))
+            Err(SidecarError::UnsupportedVersion(VERSION_2 + 1))
         );
         assert_eq!(
             load(&newer),
-            Err(SidecarError::UnsupportedVersion(VERSION_V3 + 1))
+            Err(SidecarError::UnsupportedVersion(VERSION_2 + 1))
         );
     }
 
     #[test]
     fn load_never_misparses_one_version_as_the_other() {
         let v1 = encode(&sample()).expect("encodes");
-        let v3 = encode_regions(&sample_regions()).expect("encodes");
+        let regions_bytes = encode_regions(&sample_regions()).expect("encodes");
         assert_eq!(
             decode_regions(&v1),
             Err(SidecarError::UnsupportedVersion(VERSION))
         );
         assert_eq!(
-            decode(&v3),
-            Err(SidecarError::UnsupportedVersion(VERSION_V3))
+            decode(&regions_bytes),
+            Err(SidecarError::UnsupportedVersion(VERSION_2))
         );
     }
 
@@ -1535,8 +1447,6 @@ mod tests {
         );
     }
 
-    /// I1: region size must be a real, always-enforced power-of-two
-    /// invariant, not just a rule for newly created terrains.
     #[test]
     fn v3_rejects_a_non_power_of_two_region_size() {
         let data = RegionTerrainData {
@@ -1655,8 +1565,6 @@ mod tests {
         );
     }
 
-    /// C1: a bad reference must never reach disk in the first place --
-    /// encode is where this is caught, not decode.
     #[test]
     fn encode_regions_refuses_an_invalid_texture_set_reference() {
         let data = RegionTerrainData {
@@ -1675,15 +1583,12 @@ mod tests {
         ));
     }
 
-    /// C1: since encode can no longer produce such a file, hand-craft the
-    /// bytes to prove decode is still hostile-safe on its own, in case
-    /// bytes ever reach it from something other than this crate's encoder.
     #[test]
     fn decode_regions_also_refuses_a_hand_crafted_invalid_texture_set_reference() {
         let bad_ref = b"../escape";
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&MAGIC);
-        bytes.extend_from_slice(&VERSION_V3.to_le_bytes());
+        bytes.extend_from_slice(&VERSION_2.to_le_bytes());
         bytes.extend_from_slice(&0u16.to_le_bytes());
         bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_resolution
         bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_count
@@ -1708,11 +1613,9 @@ mod tests {
         }
     }
 
-    /// C2: fixed to test truncation at every real structural boundary
-    /// (rather than arbitrary offsets), one byte short of each field's own
-    /// end. The fixture's layout is asserted against the real encoder's
-    /// output length first, so a wrong hand computation fails loudly
-    /// instead of silently testing the wrong offsets.
+    /// Truncates one byte short of each field's own end. The fixture's
+    /// layout is asserted against the real encoder's output length first,
+    /// so a wrong hand computation fails loudly.
     #[test]
     fn v3_every_structural_boundary_is_rejected_one_byte_short() {
         let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
@@ -1782,19 +1685,16 @@ mod tests {
             texture_set: None,
         };
         let mut bytes = encode_regions(&data).expect("encodes");
-        // No regions were written, so forging a region_count of 1 against
-        // an enormous (but power-of-two, and non-overflowing) region_size
-        // must not allocate that claim -- distinct from the TooLarge case
-        // below, where the claim overflows arithmetic before any read.
+        // Forges an allocation the tiny file cannot back; distinct from the
+        // TooLarge case below, which overflows arithmetic before any read.
         bytes[20..24].copy_from_slice(&(1u32 << 20).to_le_bytes()); // region_size
         bytes[24..28].copy_from_slice(&1u32.to_le_bytes()); // region_count
         assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
     }
 
-    /// I6/C2 boundary: a region size whose cell-count-in-bytes overflows
-    /// `usize` must be reported as `TooLarge`, not `Truncated` -- the
-    /// failure happens in arithmetic before any byte is read, so it must
-    /// not be conflated with merely running out of file.
+    /// A region size whose cell-count-in-bytes overflows `usize` reports
+    /// `TooLarge`, not `Truncated`: the failure is arithmetic, before any
+    /// byte is read.
     #[test]
     fn v3_a_genuinely_overflowing_size_claim_is_too_large_not_truncated() {
         // 2^31 is a valid power-of-two region size; its cell count squared
@@ -1802,7 +1702,7 @@ mod tests {
         let region_size: u32 = 1 << 31;
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&MAGIC);
-        bytes.extend_from_slice(&VERSION_V3.to_le_bytes());
+        bytes.extend_from_slice(&VERSION_2.to_le_bytes());
         bytes.extend_from_slice(&0u16.to_le_bytes());
         bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_resolution
         bytes.extend_from_slice(&0u32.to_le_bytes()); // channel_count
@@ -1830,8 +1730,6 @@ mod tests {
         assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
     }
 
-    /// C2: trailing bytes after a fully-decoded v3 document must be
-    /// rejected, the same as v1.
     #[test]
     fn v3_rejects_trailing_bytes_after_a_complete_document() {
         let mut bytes = encode_regions(&sample_regions()).expect("encodes");
@@ -1839,8 +1737,6 @@ mod tests {
         assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
     }
 
-    /// C2: an under-claimed `region_count` leaves a real region's bytes
-    /// unconsumed.
     #[test]
     fn v3_rejects_an_under_claimed_region_count_that_leaves_bytes_unconsumed() {
         let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
@@ -1859,8 +1755,6 @@ mod tests {
         assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
     }
 
-    /// I2: decode must be canonical -- a file cannot declare the same
-    /// region coordinate twice.
     #[test]
     fn v3_rejects_a_duplicate_region_coordinate() {
         let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -39,16 +39,72 @@
 //! well-formed bytes. Accepted as a tradeoff for the format staying
 //! trivial to read from any language; revisit if this ever needs to
 //! survive untrusted or unreliable transport.
+//!
+//! # v3: regions
+//!
+//! [`VERSION`] (1) is the layout above: one dense heightmap plus channels,
+//! everything sized to a single `resolution`. It is what the terrain
+//! track's design doc calls "v2" -- there has only ever been one shipped
+//! format before this one, and the doc's v2/v3 numbering counts generations
+//! of the design, not this field's literal value. [`VERSION_V3`] (2) is
+//! what the doc calls "v3": heights, the control map and an optional color
+//! layer move into sparse regions (see [`crate::region`]), addressed by
+//! [`RegionCoord`]. Channels are unaffected -- they are gameplay masks, not
+//! visual splat, and stay dense at `channel_resolution` exactly as they
+//! were at `resolution` before.
+//!
+//! ```text
+//! offset  size          field
+//! 0       8             magic, b"JDTERRN\0"             (shared header)
+//! 8       2             format version, u16 == VERSION_V3
+//! 10      2             flags, u16 (reserved, must be 0)
+//! 12      4             channel_resolution, u32
+//! 16      4             channel_count, u32
+//! 20      ...           channels, same per-channel layout as v1
+//! then
+//!         4             region_size, u32 (cells per region edge, > 0)
+//!         4             region_count, u32
+//!         4             texture_set path length in bytes, u32 (0 = none)
+//!         n             texture_set path, UTF-8, project-relative
+//! then, per region (region_count times):
+//!         4             region coord x, i32
+//!         4             region coord z, i32
+//!         1             region flags, u8 (bit 0 = has color layer)
+//!         3             padding, must be 0
+//!         4*size^2      heights, f32
+//!         4*size^2      control, u32 (packed, see crate::control)
+//!         4*size^2      color RGBA8 -- only present if flag bit 0 is set
+//! ```
+//!
+//! [`load`] and [`save`] are the entry points call sites should use going
+//! forward: `load` transparently upgrades a v1 file into a single implicit
+//! region at the origin sized to its old resolution, with no control or
+//! color data, and `save` always writes v3. A newer-than-this-build version
+//! is refused by both, the same as v1 -- a file this build cannot
+//! understand is never silently dropped or overwritten. The bare
+//! `encode`/`decode` (v1) and `encode_regions`/`decode_regions` (v3) pairs
+//! stay available for testing and for code that specifically needs one
+//! format or the other.
 
 use std::path::{Component, Path, PathBuf};
 
 use crate::channel::{ChannelData, ChannelElement};
+use crate::control::Control;
+use crate::region::{Region, RegionCoord, RegionSize, TerrainRegions};
 
 /// Magic bytes at the head of every sidecar.
 pub const MAGIC: [u8; 8] = *b"JDTERRN\0";
 
-/// Format version this build writes.
+/// Format version [`encode`]/[`decode`] read and write: the original
+/// single dense heightmap layout, with no regions.
 pub const VERSION: u16 = 1;
+
+/// Format version [`encode_regions`]/[`decode_regions`] read and write, and
+/// what [`save`] always writes: regions replace the dense heightmap. See
+/// the module-level "v3: regions" section for the full layout and how the
+/// version numbers here map onto the terrain track design doc's v2/v3
+/// naming.
+pub const VERSION_V3: u16 = 2;
 
 /// Conventional file extension for a terrain sidecar.
 pub const EXTENSION: &str = "jdterrain";
@@ -85,12 +141,16 @@ impl core::fmt::Display for SidecarPathError {
 
 impl core::error::Error for SidecarPathError {}
 
-/// Validate `data_path` and resolve it beneath `scene_dir`.
+/// Traversal guard shared by every project-relative path string this crate
+/// accepts from a file: sidecar `data_path` (resolved beneath a scene) and
+/// texture-set references (resolved beneath the project) both go through
+/// this before any format-specific check, so both stay equally hostile to
+/// the same escape tricks.
 ///
-/// Scene metadata is portable, so validation is deliberately stricter than
-/// the host platform: backslashes and Windows drive prefixes are rejected on
-/// every platform, as are empty, `.` and `..` components.
-pub fn resolve_path(scene_dir: &Path, data_path: &str) -> Result<PathBuf, SidecarPathError> {
+/// Deliberately stricter than the host platform: backslashes and Windows
+/// drive prefixes are rejected on every platform, as are empty, `.` and
+/// `..` components.
+fn reject_path_traversal(data_path: &str) -> Result<(), SidecarPathError> {
     if data_path.is_empty() {
         return Err(SidecarPathError::Empty);
     }
@@ -122,11 +182,28 @@ pub fn resolve_path(scene_dir: &Path, data_path: &str) -> Result<PathBuf, Sideca
         }
     }
 
+    Ok(())
+}
+
+/// Validate `data_path` and resolve it beneath `scene_dir`.
+pub fn resolve_path(scene_dir: &Path, data_path: &str) -> Result<PathBuf, SidecarPathError> {
+    reject_path_traversal(data_path)?;
+    let path = Path::new(data_path);
+
     if path.extension().and_then(|extension| extension.to_str()) != Some(EXTENSION) {
         return Err(SidecarPathError::WrongExtension);
     }
 
     Ok(scene_dir.join(path))
+}
+
+/// Validate a texture-set asset reference: a project-relative path string,
+/// stored on a v3 sidecar and resolved beneath the project root by whatever
+/// asset system loads it (T2/T3, not this crate). Same traversal guard as
+/// [`resolve_path`], minus the sidecar-specific extension check -- the
+/// texture-set asset's extension is not this crate's concern.
+pub fn validate_texture_set_ref(path: &str) -> Result<(), SidecarPathError> {
+    reject_path_traversal(path)
 }
 
 /// A terrain's bulk per-cell data: the heightmap plus every paint channel.
@@ -158,6 +235,10 @@ pub enum SidecarError {
     BadName,
     /// The declared dimensions do not fit in this platform's address space.
     TooLarge,
+    /// A v3 region table declared a region size of zero.
+    InvalidRegionSize,
+    /// The texture-set reference string is unsafe or malformed.
+    InvalidTextureSetRef(SidecarPathError),
 }
 
 impl core::fmt::Display for SidecarError {
@@ -172,6 +253,13 @@ impl core::fmt::Display for SidecarError {
             Self::UnknownElement(t) => write!(f, "unknown channel element tag {t}"),
             Self::BadName => write!(f, "channel name is not valid UTF-8"),
             Self::TooLarge => write!(f, "terrain sidecar declares more data than fits in memory"),
+            Self::InvalidRegionSize => write!(f, "terrain sidecar declares a region size of zero"),
+            Self::InvalidTextureSetRef(reason) => {
+                write!(
+                    f,
+                    "terrain sidecar texture-set reference is invalid: {reason}"
+                )
+            }
         }
     }
 }
@@ -280,6 +368,11 @@ impl<'a> Reader<'a> {
         let b = self.take(4)?;
         Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
     }
+
+    fn i32(&mut self) -> Result<i32, SidecarError> {
+        let b = self.take(4)?;
+        Ok(i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
 }
 
 /// Deserialize a terrain's bulk data.
@@ -350,6 +443,311 @@ pub fn decode(bytes: &[u8]) -> Result<TerrainData, SidecarError> {
         heights,
         channels,
     })
+}
+
+fn encode_channels(out: &mut Vec<u8>, channels: &[ChannelData], cells: usize) {
+    for channel in channels {
+        out.extend_from_slice(&(channel.name.len() as u32).to_le_bytes());
+        out.extend_from_slice(channel.name.as_bytes());
+        out.push(channel.element.tag());
+        out.extend_from_slice(&[0u8; 3]);
+        for i in 0..cells {
+            let v = channel.values.get(i).copied().unwrap_or(0);
+            match channel.element {
+                ChannelElement::U8 => out.push(v.min(u16::from(u8::MAX)) as u8),
+                ChannelElement::U16 => out.extend_from_slice(&v.to_le_bytes()),
+            }
+        }
+    }
+}
+
+fn decode_channels(
+    r: &mut Reader<'_>,
+    channel_count: u32,
+    cells: usize,
+) -> Result<Vec<ChannelData>, SidecarError> {
+    let mut channels = Vec::new();
+    for _ in 0..channel_count {
+        let name_len = r.u32()? as usize;
+        let name = core::str::from_utf8(r.take(name_len)?)
+            .map_err(|_| SidecarError::BadName)?
+            .to_string();
+        let tag = r.u8()?;
+        let element = ChannelElement::from_tag(tag).ok_or(SidecarError::UnknownElement(tag))?;
+        if r.take(3)? != [0u8; 3] {
+            return Err(SidecarError::ReservedFieldSet);
+        }
+
+        let value_bytes = r.take(
+            cells
+                .checked_mul(element.byte_width())
+                .ok_or(SidecarError::TooLarge)?,
+        )?;
+        let values = match element {
+            ChannelElement::U8 => value_bytes.iter().map(|b| u16::from(*b)).collect(),
+            ChannelElement::U16 => value_bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect(),
+        };
+        channels.push(ChannelData {
+            name,
+            element,
+            values,
+        });
+    }
+    Ok(channels)
+}
+
+/// A v3 terrain document: channels (unchanged from v1) plus sparse
+/// region-based heights/control/color, plus the texture set the splat
+/// material paints with.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RegionTerrainData {
+    /// Sizes `channels` exactly as `resolution` sized them in v1. Unrelated
+    /// to region addressing -- channels are not part of the region model.
+    pub channel_resolution: u32,
+    /// Named integer layers, in the order the project declared them.
+    pub channels: Vec<ChannelData>,
+    /// Sparse heights, control map and color.
+    pub regions: TerrainRegions,
+    /// Project-relative path to the texture set this terrain paints with,
+    /// or `None` if it has not been assigned one yet.
+    pub texture_set: Option<String>,
+}
+
+impl RegionTerrainData {
+    /// Migrate a v1 [`TerrainData`] into a v3 document: one implicit region
+    /// at [`RegionCoord::ORIGIN`], sized to the legacy resolution exactly
+    /// -- no resampling. The migrated region carries no control or color
+    /// data (both stay at their all-default values). Channels are moved
+    /// across unchanged.
+    pub fn from_legacy_v1(data: &TerrainData) -> Self {
+        let mut normalized = data.clone();
+        normalized.normalize();
+        let resolution = normalized.resolution;
+
+        let mut regions = TerrainRegions::new(RegionSize::new_unchecked(resolution.max(1)));
+        if resolution > 0 {
+            let cells = (resolution as usize) * (resolution as usize);
+            regions.insert_region(
+                RegionCoord::ORIGIN,
+                Region::from_parts(resolution, normalized.heights, vec![0u32; cells], None),
+            );
+        }
+
+        Self {
+            channel_resolution: resolution,
+            channels: normalized.channels,
+            regions,
+            texture_set: None,
+        }
+    }
+
+    /// A [`TerrainData`] view of this document, for call sites that have
+    /// not migrated to the region API yet -- the "compat view" that lets
+    /// existing single-blob call sites keep working unmodified as long as
+    /// a terrain is still, in every sense, v1-shaped: at most one region,
+    /// at the origin, sized to `channel_resolution`, with no control or
+    /// color paint. Returns `None` once any of that stops holding, rather
+    /// than lossily flattening real region/control/color data into a shape
+    /// that cannot represent it -- at that point the call site has to move
+    /// to the region API for real.
+    pub fn as_legacy(&self) -> Option<TerrainData> {
+        let heights = match self.regions.region_count() {
+            0 => vec![0.0; (self.channel_resolution as usize) * (self.channel_resolution as usize)],
+            1 => {
+                let (coord, region) = self.regions.iter_sorted().next()?;
+                if coord != RegionCoord::ORIGIN {
+                    return None;
+                }
+                if region.side() != self.channel_resolution {
+                    return None;
+                }
+                if region.color().is_some() {
+                    return None;
+                }
+                if region.control_words().iter().any(|c| *c != 0) {
+                    return None;
+                }
+                region.heights().to_vec()
+            }
+            _ => return None,
+        };
+
+        Some(TerrainData {
+            resolution: self.channel_resolution,
+            heights,
+            channels: self.channels.clone(),
+        })
+    }
+}
+
+/// Serialize a v3 terrain document.
+pub fn encode_regions(data: &RegionTerrainData) -> Option<Vec<u8>> {
+    let channel_cells =
+        (data.channel_resolution as usize).checked_mul(data.channel_resolution as usize)?;
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&VERSION_V3.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&data.channel_resolution.to_le_bytes());
+    out.extend_from_slice(&(data.channels.len() as u32).to_le_bytes());
+    encode_channels(&mut out, &data.channels, channel_cells);
+
+    out.extend_from_slice(&data.regions.region_size().get().to_le_bytes());
+    out.extend_from_slice(&(data.regions.region_count() as u32).to_le_bytes());
+
+    let texture_set = data.texture_set.as_deref().unwrap_or("");
+    out.extend_from_slice(&(texture_set.len() as u32).to_le_bytes());
+    out.extend_from_slice(texture_set.as_bytes());
+
+    for (coord, region) in data.regions.iter_sorted() {
+        out.extend_from_slice(&coord.x.to_le_bytes());
+        out.extend_from_slice(&coord.z.to_le_bytes());
+        let flags: u8 = if region.color().is_some() { 0x1 } else { 0 };
+        out.push(flags);
+        out.extend_from_slice(&[0u8; 3]);
+
+        for h in region.heights() {
+            out.extend_from_slice(&h.to_le_bytes());
+        }
+        for c in region.control_words() {
+            out.extend_from_slice(&c.to_le_bytes());
+        }
+        if let Some(color) = region.color() {
+            for px in color {
+                out.extend_from_slice(px);
+            }
+        }
+    }
+
+    Some(out)
+}
+
+/// Deserialize a v3 terrain document.
+pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
+    let mut r = Reader { bytes, at: 0 };
+
+    if r.take(MAGIC.len())? != MAGIC {
+        return Err(SidecarError::BadMagic);
+    }
+    let version = r.u16()?;
+    if version != VERSION_V3 {
+        return Err(SidecarError::UnsupportedVersion(version));
+    }
+    if r.u16()? != 0 {
+        return Err(SidecarError::ReservedFieldSet);
+    }
+
+    let channel_resolution = r.u32()?;
+    let channel_count = r.u32()?;
+    let channel_cells = (channel_resolution as usize)
+        .checked_mul(channel_resolution as usize)
+        .ok_or(SidecarError::TooLarge)?;
+    let channels = decode_channels(&mut r, channel_count, channel_cells)?;
+
+    let region_size = r.u32()?;
+    if region_size == 0 {
+        return Err(SidecarError::InvalidRegionSize);
+    }
+    let region_count = r.u32()?;
+
+    let texture_set_len = r.u32()? as usize;
+    let texture_set_bytes = r.take(texture_set_len)?;
+    let texture_set = if texture_set_bytes.is_empty() {
+        None
+    } else {
+        let path = core::str::from_utf8(texture_set_bytes)
+            .map_err(|_| SidecarError::BadName)?
+            .to_string();
+        validate_texture_set_ref(&path).map_err(SidecarError::InvalidTextureSetRef)?;
+        Some(path)
+    };
+
+    let cells = (region_size as usize)
+        .checked_mul(region_size as usize)
+        .ok_or(SidecarError::TooLarge)?;
+
+    let mut regions = TerrainRegions::new(RegionSize::new_unchecked(region_size));
+    for _ in 0..region_count {
+        let x = r.i32()?;
+        let z = r.i32()?;
+        let flags = r.u8()?;
+        if flags & !0x1 != 0 {
+            return Err(SidecarError::ReservedFieldSet);
+        }
+        if r.take(3)? != [0u8; 3] {
+            return Err(SidecarError::ReservedFieldSet);
+        }
+        let has_color = flags & 0x1 != 0;
+
+        let heights_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
+        let heights: Vec<f32> = heights_bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+
+        let control_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
+        let mut control = Vec::with_capacity(cells);
+        for chunk in control_bytes.chunks_exact(4) {
+            let raw = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            if Control::from_raw(raw).reserved() != 0 {
+                return Err(SidecarError::ReservedFieldSet);
+            }
+            control.push(raw);
+        }
+
+        let color = if has_color {
+            let color_bytes = r.take(cells.checked_mul(4).ok_or(SidecarError::TooLarge)?)?;
+            Some(
+                color_bytes
+                    .chunks_exact(4)
+                    .map(|c| [c[0], c[1], c[2], c[3]])
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        regions.insert_region(
+            RegionCoord::new(x, z),
+            Region::from_parts(region_size, heights, control, color),
+        );
+    }
+
+    Ok(RegionTerrainData {
+        channel_resolution,
+        channels,
+        regions,
+        texture_set,
+    })
+}
+
+/// Load a sidecar of either version, upgrading a v1 file into a v3
+/// document in memory. Refuses a file written by a newer build than this
+/// one understands, the same as [`decode`]/[`decode_regions`] each do for
+/// their own version.
+pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
+    let mut r = Reader { bytes, at: 0 };
+    if r.take(MAGIC.len())? != MAGIC {
+        return Err(SidecarError::BadMagic);
+    }
+    let version = r.u16()?;
+
+    match version {
+        0 => Err(SidecarError::UnsupportedVersion(0)),
+        VERSION => decode(bytes).map(|data| RegionTerrainData::from_legacy_v1(&data)),
+        VERSION_V3 => decode_regions(bytes),
+        other => Err(SidecarError::UnsupportedVersion(other)),
+    }
+}
+
+/// Serialize a terrain document as the current version (v3). The inverse
+/// of [`load`] for any file [`load`] can produce.
+pub fn save(data: &RegionTerrainData) -> Option<Vec<u8>> {
+    encode_regions(data)
 }
 
 #[cfg(test)]
@@ -578,5 +976,375 @@ mod tests {
                 "{data_path:?} must not resolve",
             );
         }
+    }
+
+    fn sample_regions() -> RegionTerrainData {
+        let mut regions = TerrainRegions::new(RegionSize::new(4).unwrap());
+        regions.set_height(0, 0, 1.5);
+        regions.set_height(3, 3, -2.25);
+        regions.set_control(1, 1, Control::default().with_base_id(3).with_blend(40));
+        regions.set_color(2, 2, [10, 20, 30, 255]);
+        // A second, negatively-coordinate region, to exercise multi-region
+        // and negative-coord encode/decode together.
+        regions.set_height(-1, -4, 9.0);
+
+        RegionTerrainData {
+            channel_resolution: 4,
+            channels: vec![{
+                let mut c = ChannelData::new("biome", ChannelElement::U8, 4);
+                c.values[0] = 7;
+                c
+            }],
+            regions,
+            texture_set: Some("textures/zone1.jdtextureset".to_string()),
+        }
+    }
+
+    #[test]
+    fn v3_round_trips_regions_channels_and_texture_set() {
+        let data = sample_regions();
+        let bytes = encode_regions(&data).expect("encodes");
+        let back = decode_regions(&bytes).expect("decodes");
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn v3_encoding_is_deterministic_regardless_of_edit_order() {
+        let mut a = TerrainRegions::new(RegionSize::new(4).unwrap());
+        a.set_height(0, 0, 1.0);
+        a.set_height(20, 20, 2.0);
+        a.set_height(-9, 4, 3.0);
+        let mut b = TerrainRegions::new(RegionSize::new(4).unwrap());
+        b.set_height(-9, 4, 3.0);
+        b.set_height(20, 20, 2.0);
+        b.set_height(0, 0, 1.0);
+
+        let da = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: a,
+            texture_set: None,
+        };
+        let db = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: b,
+            texture_set: None,
+        };
+        assert_eq!(encode_regions(&da), encode_regions(&db));
+    }
+
+    #[test]
+    fn v3_with_no_texture_set_round_trips_to_none() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let back = decode_regions(&encode_regions(&data).expect("encodes")).expect("decodes");
+        assert_eq!(back.texture_set, None);
+    }
+
+    #[test]
+    fn v3_with_an_empty_region_set_round_trips() {
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: TerrainRegions::new(RegionSize::new(64).unwrap()),
+            texture_set: None,
+        };
+        let back = decode_regions(&encode_regions(&data).expect("encodes")).expect("decodes");
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn migrating_a_real_v1_file_produces_a_single_origin_region() {
+        let migrated = RegionTerrainData::from_legacy_v1(&sample());
+        assert_eq!(migrated.channel_resolution, 4);
+        assert_eq!(migrated.channels, sample().channels);
+        assert_eq!(migrated.regions.region_count(), 1);
+        assert_eq!(migrated.texture_set, None);
+        let region = migrated.regions.region(RegionCoord::ORIGIN).unwrap();
+        assert_eq!(region.side(), 4);
+        assert_eq!(region.heights(), sample().heights.as_slice());
+        assert!(region.control_words().iter().all(|c| *c == 0));
+        assert!(region.color().is_none());
+    }
+
+    #[test]
+    fn migrating_an_empty_v1_terrain_allocates_no_regions() {
+        let migrated = RegionTerrainData::from_legacy_v1(&TerrainData::default());
+        assert_eq!(migrated.regions.region_count(), 0);
+        assert_eq!(migrated.channel_resolution, 0);
+    }
+
+    #[test]
+    fn v1_to_v3_migration_round_trips_through_load_and_save() {
+        // Build a real v1 file with the existing encoder.
+        let original = sample();
+        let v1_bytes = encode(&original).expect("v1 encodes");
+
+        // Load it: auto-upgrades to a v3 document, single implicit region.
+        let migrated = load(&v1_bytes).expect("loads v1");
+        assert_eq!(migrated, RegionTerrainData::from_legacy_v1(&original));
+        assert_eq!(migrated.as_legacy(), Some(original.clone()));
+
+        // Save it: always writes v3.
+        let v3_bytes = save(&migrated).expect("v3 encodes");
+        assert_eq!(u16::from_le_bytes([v3_bytes[8], v3_bytes[9]]), VERSION_V3);
+        assert_ne!(v3_bytes[8..10], v1_bytes[8..10]);
+
+        // Reload the v3 bytes: matches what was saved exactly.
+        let reloaded = load(&v3_bytes).expect("loads v3");
+        assert_eq!(reloaded, migrated);
+    }
+
+    #[test]
+    fn as_legacy_refuses_once_control_has_been_painted() {
+        let mut migrated = RegionTerrainData::from_legacy_v1(&sample());
+        migrated
+            .regions
+            .set_control(0, 0, Control::default().with_base_id(1));
+        assert_eq!(migrated.as_legacy(), None);
+    }
+
+    #[test]
+    fn as_legacy_refuses_once_color_has_been_painted() {
+        let mut migrated = RegionTerrainData::from_legacy_v1(&sample());
+        migrated.regions.set_color(0, 0, [1, 2, 3, 4]);
+        assert_eq!(migrated.as_legacy(), None);
+    }
+
+    #[test]
+    fn as_legacy_refuses_once_a_terrain_goes_multi_region() {
+        let mut migrated = RegionTerrainData::from_legacy_v1(&sample());
+        migrated.regions.set_height(100, 100, 1.0);
+        assert_eq!(migrated.as_legacy(), None);
+    }
+
+    #[test]
+    fn as_legacy_succeeds_for_a_never_edited_v3_native_terrain() {
+        let data = RegionTerrainData {
+            channel_resolution: 3,
+            channels: vec![],
+            regions: TerrainRegions::new(RegionSize::new(256).unwrap()),
+            texture_set: None,
+        };
+        assert_eq!(
+            data.as_legacy(),
+            Some(TerrainData {
+                resolution: 3,
+                heights: vec![0.0; 9],
+                channels: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_a_v3_file_written_by_a_newer_build() {
+        let bytes = encode_regions(&sample_regions()).expect("encodes");
+        let mut newer = bytes.clone();
+        newer[8..10].copy_from_slice(&(VERSION_V3 + 1).to_le_bytes());
+        assert_eq!(
+            decode_regions(&newer),
+            Err(SidecarError::UnsupportedVersion(VERSION_V3 + 1))
+        );
+        assert_eq!(
+            load(&newer),
+            Err(SidecarError::UnsupportedVersion(VERSION_V3 + 1))
+        );
+    }
+
+    #[test]
+    fn load_never_misparses_one_version_as_the_other() {
+        let v1 = encode(&sample()).expect("encodes");
+        let v3 = encode_regions(&sample_regions()).expect("encodes");
+        assert_eq!(
+            decode_regions(&v1),
+            Err(SidecarError::UnsupportedVersion(VERSION))
+        );
+        assert_eq!(
+            decode(&v3),
+            Err(SidecarError::UnsupportedVersion(VERSION_V3))
+        );
+    }
+
+    #[test]
+    fn v3_rejects_version_zero() {
+        let mut bytes = encode_regions(&sample_regions()).expect("encodes");
+        bytes[8..10].copy_from_slice(&0u16.to_le_bytes());
+        assert_eq!(
+            decode_regions(&bytes),
+            Err(SidecarError::UnsupportedVersion(0))
+        );
+        assert_eq!(load(&bytes), Err(SidecarError::UnsupportedVersion(0)));
+    }
+
+    #[test]
+    fn v3_rejects_a_set_header_reserved_flag() {
+        let mut bytes = encode_regions(&sample_regions()).expect("encodes");
+        bytes[10..12].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::ReservedFieldSet));
+    }
+
+    #[test]
+    fn v3_rejects_a_region_size_of_zero() {
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: TerrainRegions::new(RegionSize::new(4).unwrap()),
+            texture_set: None,
+        };
+        let mut bytes = encode_regions(&data).expect("encodes");
+        // header(12) + channel_resolution(4) + channel_count(4) = offset 20
+        // is region_size (no channels in this fixture).
+        bytes[20..24].copy_from_slice(&0u32.to_le_bytes());
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::InvalidRegionSize));
+    }
+
+    #[test]
+    fn v3_rejects_reserved_bits_set_in_a_control_word() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_control(0, 0, Control::default().with_base_id(1));
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+
+        // Locate the control block: header(12) + channel_resolution(4) +
+        // channel_count(4) + region_size(4) + region_count(4) +
+        // texture_set_len(4) + coord(8) + flags+pad(4) + heights(4*4) = 60
+        // is where the control words start for this 2x2 region.
+        let control_offset = 60;
+        let mut poisoned = bytes.clone();
+        let word = u32::from_le_bytes([
+            poisoned[control_offset],
+            poisoned[control_offset + 1],
+            poisoned[control_offset + 2],
+            poisoned[control_offset + 3],
+        ]);
+        let with_reserved = word | (1 << 16);
+        poisoned[control_offset..control_offset + 4].copy_from_slice(&with_reserved.to_le_bytes());
+
+        assert_eq!(
+            decode_regions(&poisoned),
+            Err(SidecarError::ReservedFieldSet)
+        );
+    }
+
+    #[test]
+    fn v3_rejects_reserved_bits_set_in_region_flags() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+        // header(12) + channel_resolution(4) + channel_count(4) +
+        // region_size(4) + region_count(4) + texture_set_len(4) +
+        // coord(8) = offset 40 is the region flags byte.
+        let flags_offset = 40;
+        let mut poisoned = bytes.clone();
+        poisoned[flags_offset] |= 0b1000_0000;
+        assert_eq!(
+            decode_regions(&poisoned),
+            Err(SidecarError::ReservedFieldSet)
+        );
+    }
+
+    #[test]
+    fn v3_rejects_nonzero_region_padding() {
+        let mut regions = TerrainRegions::new(RegionSize::new(2).unwrap());
+        regions.set_height(0, 0, 1.0);
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions,
+            texture_set: None,
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+        let pad_offset = 41; // one byte after the flags byte at 40
+        let mut poisoned = bytes.clone();
+        poisoned[pad_offset] = 1;
+        assert_eq!(
+            decode_regions(&poisoned),
+            Err(SidecarError::ReservedFieldSet)
+        );
+    }
+
+    #[test]
+    fn v3_rejects_an_invalid_texture_set_reference() {
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: TerrainRegions::new(RegionSize::new(4).unwrap()),
+            texture_set: Some("../escape.jdtextureset".to_string()),
+        };
+        let bytes = encode_regions(&data).expect("encodes");
+        assert!(matches!(
+            decode_regions(&bytes),
+            Err(SidecarError::InvalidTextureSetRef(_))
+        ));
+    }
+
+    #[test]
+    fn validate_texture_set_ref_accepts_a_plain_relative_path_and_rejects_traversal() {
+        assert!(validate_texture_set_ref("textures/zone1.jdtextureset").is_ok());
+        for bad in ["", "../x", "/abs/x", "a/../b", r"a\b", "C:/x"] {
+            assert!(
+                validate_texture_set_ref(bad).is_err(),
+                "{bad:?} must not validate"
+            );
+        }
+    }
+
+    #[test]
+    fn v3_a_truncated_file_is_rejected_at_every_boundary() {
+        let bytes = encode_regions(&sample_regions()).expect("encodes");
+        for cut in [0, 8, 10, 12, 20, 40, 60, bytes.len() - 1] {
+            assert_eq!(
+                decode_regions(&bytes[..cut]),
+                Err(SidecarError::Truncated),
+                "cut at {cut} should be truncated"
+            );
+        }
+    }
+
+    #[test]
+    fn v3_an_oversized_region_size_claim_over_a_tiny_file_is_rejected() {
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![],
+            regions: TerrainRegions::new(RegionSize::new(4).unwrap()),
+            texture_set: None,
+        };
+        let mut bytes = encode_regions(&data).expect("encodes");
+        // No regions were written, so forging a region_count of 1 against
+        // an enormous region_size must not allocate that claim.
+        bytes[20..24].copy_from_slice(&1_000_000u32.to_le_bytes()); // region_size
+        bytes[24..28].copy_from_slice(&1u32.to_le_bytes()); // region_count
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
+    }
+
+    #[test]
+    fn v3_an_oversized_channel_resolution_claim_is_rejected() {
+        let data = RegionTerrainData {
+            channel_resolution: 0,
+            channels: vec![ChannelData::new("c", ChannelElement::U8, 0)],
+            regions: TerrainRegions::new(RegionSize::new(4).unwrap()),
+            texture_set: None,
+        };
+        let mut bytes = encode_regions(&data).expect("encodes");
+        bytes[12..16].copy_from_slice(&1_000_000u32.to_le_bytes());
+        assert_eq!(decode_regions(&bytes), Err(SidecarError::Truncated));
     }
 }


### PR DESCRIPTION
- Terrain data is stored in fixed-size square regions, allocated only where the terrain has content
- Each cell carries a packed control word (base texture, overlay texture, blend) for texture painting
- The sidecar format gains a region table, control and color layers, and a texture-set reference; existing files migrate automatically on load
- Decoding is stricter: the whole file must parse, duplicate regions and malformed references are rejected before anything touches disk