### PR TITLE
Fix opening of assets/scene.bsn not opening tab properly

### DIFF
--- a/src/project_select.rs
+++ b/src/project_select.rs
@@ -1249,7 +1249,7 @@ fn transition_to_editor(world: &mut World, root: PathBuf) {
             None
         };
         if let Some(scene_path) = scene_path {
-            crate::scene_io::load_scene_from_file(world, &scene_path);
+            crate::scenes::operators::scene_open_system(world, &scene_path);
         } else {
             crate::scenes::operators::scene_new_system(world);
         }


### PR DESCRIPTION
When the editor opens a project and doesn't have any tabs to load, it'll load assets/scene.bsn as a fallback. All well and good, but this was using crate::scene_io::load_scene_from_file instead of crate::scenes::operators::scene_open_system, meaning it didn't open a proper tab or anything, which kind of bugged the editor out.

![Uploading image.png…]()
